### PR TITLE
Allow phstore in style files even when --hstore is not specified

### DIFF
--- a/output-pgsql.c
+++ b/output-pgsql.c
@@ -156,13 +156,6 @@ void read_style_file( const char *filename )
       if( i == NUM_FLAGS )
         fprintf( stderr, "Unknown flag '%s' line %d, ignored\n", str, lineno );
     }
-    if (temp.flags==FLAG_PHSTORE) {
-        if (HSTORE_NONE==(Options->enable_hstore)) {
-            fprintf( stderr, "Error reading style file line %d (fields=%d)\n", lineno, fields );
-            fprintf( stderr, "flag 'phstore' is invalid in non-hstore mode\n");
-            exit_nicely();
-        }
-    }
     if ((temp.flags!=FLAG_DELETE) && ((strchr(temp.name,'?') != NULL) || (strchr(temp.name,'*') != NULL))) {
         fprintf( stderr, "wildcard '%s' in non-delete style entry\n",temp.name);
         exit_nicely();


### PR DESCRIPTION
This allows a style file to be designed for both with and without hstore,
important for general-use style files.

I was unable to run integration tests on this branch. It obviously shouldn't impact output with --hstore, nor **should** it change output with a .style file with no phstore items.
