### PR TITLE
Expand default.style documentation

### DIFF
--- a/default.style
+++ b/default.style
@@ -1,44 +1,94 @@
-# This is the style file that matches the old version of osm2pgsql, which
-# did not make distinctions between tags for nodes and for ways. There are a
-# number of optimisations that can be applied here. Firstly, certain tags
-# only apply to only nodes or only ways. By fixing this we reduce the amount
-# of useless data loaded into the DB, which is a good thing. Possible
-# optimisations for the future:
-
-# 1. Generate this file directly from the mapnik XML config, so it's always
-# optimal
-
-# 2. Extend it so it can understand that highway=tertiary is for ways and
-# highway=bus_stop is for nodes
-
-# Flags field isn't used much yet, expect if it contains the text "polygon"
-# it indicates the shape is candidate for the polygon table. In the future I
-# would like to be able to add directives like "nocache" which tells
-# osm2pgsql that it is unlikely this node will be used by a way and so it
-# doesn't need to be stored (eg coastline nodes). While in essence an
-# optimisation hack, for --slim mode it doesn't matter if you're wrong, but
-# in non-slim you might break something!
-
-# Also possibly an ignore flag, for things like "note" and "source" which
-# can simply be deleted. (In slim mode this is, does not apply to non-slim
-# obviously)
+# This is the default osm2pgsql .style file that comes with osm2pgsql.
+#
+# A .style file has 4 columns that define how OSM objects end up in tables in
+# the database and what columns are created. It interacts with the command-line
+# hstore options.
+#
+# Columns
+# =======
+#
+# OsmType: This is either "node", "way" or "node,way" and indicates if this tag
+# applies to nodes, ways, or both.
+#
+# Tag: The tag
+#
+# DataType: The type of the column to be created. Normally "text"
+#
+# Flags: Flags that indicate what table the OSM object is moved into.
+#
+# There are 5 possible flags. These flags are used both to indicate if a column
+# should be created, and if ways with the tag are assumed to be areas. The area
+# assumptions can be overridden with an area=yes/no tag
+#
+# polygon - Create a column for this tag, and objects the tag with are areas
+#
+# linear - Create a column for this tag
+#
+# phstore - Don't create a column for this tag, but objects with the tag are areas
+#
+# delete - Drop this tag completely and don't create a column for it. This also
+# prevents the tag from being added to hstore columns
+#
+# nocache - Deprecated and does nothing
+#
+# If an object has a tag that indicates it is an area or has area=yes/1,
+# osm2pgsql will try to turn it into an area. If it succeeds, it places it in
+# the polygon table. If it fails (e.g. not a closed way) it places it in the
+# line table.
+#
+# Nodes are never placed into the polygon or line table and are always placed in
+# the point table.
+#
+# Hstore
+# ======
+#
+# The options --hstore, --hstore-match-only, and --hstore-all interact with
+# the .style file.
+#
+# With --hstore any tags without a column will be added to the hstore column.
+# This will also cause all objects to be kept.
+#
+# With --hstore-match-only the behavior for tags is the same, but objects are 
+# only kept if they have a non-NULL value in one of the columns.
+#
+# With --hstore-all all tags are added to the hstore column unless they appear
+# in the style file with a delete flag, causing duplication between the normal 
+# columns and the hstore column.
+#
+# Special database columns
+# ========================
+#
+# There are some special database columns that if present in the .style file
+# will be populated by osm2pgsql.
+#
+# These are
+#
+# z_order - datatype int4
+#
+# way_area - datatype real. The area of the way, in the units of the projection
+# (e.g. square mercator meters). Only applies to areas
+#
+# osm_user, osm_uid, osm_version, osm_timestamp - datatype text. Used with the
+# --extra-attributes option to include metadata in the database. If importing
+# with both --hstore and --extra-attributes the meta-data will end up in the
+# tags hstore column regardless of the style file.
 
 # OsmType  Tag          DataType     Flags
 node,way   note         text         delete   # These tags can be long but are useless for rendering
-node,way   source       text         delete   # This indicates that we shouldn't store them
+node,way   source       text         delete
 node,way   created_by   text         delete
 
 node,way   access       text         linear
 node,way   addr:housename      text  linear
 node,way   addr:housenumber    text  linear
-node,way   addr:interpolation  text  linear 
+node,way   addr:interpolation  text  linear
 node,way   admin_level  text         linear
 node,way   aerialway    text         linear
 node,way   aeroway      text         polygon
-node,way   amenity      text         nocache,polygon
+node,way   amenity      text         polygon
 node,way   area         text         # hard coded support for area=1/yes => polygon is in osm2pgsql
 node,way   barrier      text         linear
-node,way   bicycle      text         nocache
+node,way   bicycle      text         
 node,way   brand        text         linear
 node,way   bridge       text         linear
 node,way   boundary     text         linear
@@ -98,27 +148,3 @@ node,way   width        text         linear
 node,way   wood         text         linear
 node,way   z_order      int4         linear # This is calculated during import
 way        way_area     real                # This is calculated during import
-
-# If you're interested in bicycle routes, you may want the following fields
-# To make these work you need slim mode or the necessary data won't be remembered.
-#way       lcn_ref      text     linear
-#way       rcn_ref      text     linear
-#way       ncn_ref      text     linear
-#way       lcn          text     linear
-#way       rcn          text     linear
-#way       ncn          text     linear
-#way       lwn_ref      text     linear
-#way       rwn_ref      text     linear
-#way       nwn_ref          text     linear
-#way       lwn              text     linear
-#way       rwn              text     linear
-#way       nwn              text     linear
-#way       route_pref_color text     linear
-#way       route_name       text     linear
-
-# The following entries can be used with the --extra-attributes option
-# to include the username, userid, version & timstamp in the DB
-#node,way  osm_user       text
-#node,way  osm_uid        text
-#node,way  osm_version    text
-#node,way  osm_timestamp  text


### PR DESCRIPTION
These changes are purely in comments and the unused nocache flag

Fixes #66

Comments from earlier feedback, which I've hopefully integrated.

**hstore needs a general explanation of how it interacts with the `default.style`**

```
08:19 < apmon> pnorman: I had a look at the default.style docu
08:19 < apmon> looks like a good improvement
08:19 < apmon> a couple of comments though:
08:19 < apmon> I think the phstore flag needs some additional explanation of how it works
08:20 < apmon> The delete flag explanation should probably mention that it also
    deletes it from --hstore-all
08:22 < apmon> I wonder if the section on osm_user, osm_uid also should have a
    mention, that if you import with hstore, then those will be in the tags 
    column independent of if they are listed here
08:23 < apmon> coming to think of it, perhaps hstore needs a general 
    explanation of how it interacts with the default.style
08:23 < apmon> i.e. how --hstore-all --hstore and --hstore-match-only are 
    effected by default.style
```

I must admit I don't fully understand the interaction between `--hstore`, `--hstore-match-only`, `--hstore-all`, `--extra-attributes` and `default.style` and I doubt the average user does.
