### PR TITLE
Use wildcards for deleting import and note tags in empty style

### DIFF
--- a/empty.style
+++ b/empty.style
@@ -40,16 +40,10 @@ way         way_area                real            # This is calculated during 
 # These tags are used by mappers to keep track of data.
 # They aren't very useful for rendering.
 node,way    note                    text    delete
-node,way    note:ja                 text    delete
-node,way    note:en                 text    delete
-node,way    note:es                 text    delete
+node,way    note:*                  text    delete
 node,way    source                  text    delete
 node,way    source_ref              text    delete
-node,way    source:addr             text    delete
-node,way    source:date             text    delete
-node,way    source:loc              text    delete
-node,way    source:name             text    delete
-node,way    source:file             text    delete
+node,way    source:*                text    delete
 node,way    attribution             text    delete
 node,way    comment                 text    delete
 node,way    fixme                   text    delete
@@ -62,54 +56,18 @@ node,way    SK53_bulk:load          text    delete
 
 # Lots of import tags
 # TIGER (US)
-node,way    tiger:cfcc              text    delete
-node,way    tiger:county            text    delete
-node,way    tiger:name_base         text    delete
-node,way    tiger:name_base_1       text    delete
-node,way    tiger:name_type         text    delete
-node,way    tiger:name_type_1       text    delete
-node,way    tiger:name_direction_prefix text    delete
-node,way    tiger:name_direction_prefix_1 text    delete
-node,way    tiger:name_direction_suffix text    delete
-node,way    tiger:name_direction_suffix_1 text    delete
-node,way    tiger:reviewed          text    delete
-node,way    tiger:separated         text    delete
-node,way    tiger:source            text    delete
-node,way    tiger:tlid              text    delete
-node,way    tiger:upload_uuid       text    delete
-node,way    tiger:zip_left          text    delete
-node,way    tiger:zip_left_1        text    delete
-node,way    tiger:zip_right         text    delete
-node,way    tiger:zip_right_1         text    delete
+node,way    tiger:*                 text    delete
 
 # NHD (US)
 # NHD has been converted every way imaginable
-node,way    NHD:ComID               text    delete
-node,way    NHD:FCode               text    delete
-node,way    NHD:FDate               text    delete
-node,way    NHD:FTYPE               text    delete
-node,way    NHD:Permanent_          text    delete
-node,way    NHD:RESOLUTION          text    delete
-node,way    NHD:ReachCode           text    delete
-node,way    NHD:Resolution          text    delete
-node,way    NHD:way_id              text    delete
-node,way    nhd:com_id              text    delete
-node,way    nhd:fcode               text    delete
-node,way    nhd:fdate               text    delete
-node,way    nhd:ftype               text    delete
-node,way    nhd:reach_code          text    delete
+node,way    NHD:*                   text    delete
+node,way    nhd:*                   text    delete
+
 # GNIS (US)
-node,way    gnis:county_id          text    delete
-node,way    gnis:created            text    delete
-node,way    gnis:fcode              text    delete
-#node,way    gnis:feature_id         text    delete # You may want to drop this, but it has some uses
-node,way    gnis:ftype              text    delete
-node,way    gnis:state_id           text    delete
+node,way    gnis:*                  text    delete
 
 # Geobase (CA)
-node,way    geobase:acquisitionTechnique text delete
-node,way    geobase:uuid            text    delete
-node,way    geobase:datasetName     text    delete
+node,way    geobase:*               text    delete
 # NHN (CA)
 node,way    accuracy:meters         text    delete
 node,way    sub_sea:type            text    delete
@@ -117,95 +75,28 @@ node,way    waterway:type           text    delete
 
 # KSJ2 (JA)
 # See also note:ja and source_ref above
-node,way    KSJ2:ADS                text    delete
-node,way    KSJ2:ARE                text    delete
-node,way    KSJ2:AdminArea          text    delete
-node,way    KSJ2:COP_label          text    delete
-node,way    KSJ2:DFD                text    delete
-node,way    KSJ2:INT                text    delete
-node,way    KSJ2:INT_label          text    delete
-node,way    KSJ2:LOC                text    delete
-node,way    KSJ2:LPN                text    delete
-node,way    KSJ2:OPC                text    delete
-node,way    KSJ2:PubFacAdmin        text    delete
-node,way    KSJ2:RAC                text    delete
-node,way    KSJ2:RAC_label          text    delete
-node,way    KSJ2:RIC                text    delete
-node,way    KSJ2:RIN                text    delete
-node,way    KSJ2:WSC                text    delete
-node,way    KSJ2:coordinate         text    delete
-node,way    KSJ2:curve_id           text    delete
-node,way    KSJ2:curve_type         text    delete
-node,way    KSJ2:filename           text    delete
-node,way    KSJ2:lake_id            text    delete
-node,way    KSJ2:lat                text    delete
-node,way    KSJ2:long               text    delete
-node,way    KSJ2:river_id           text    delete
+node,way    KSJ2:*                  text    delete
 # Yahoo/ALPS (JA)
-node,way    yh:LINE_NAME            text    delete
-node,way    yh:LINE_NUM             text    delete
-node,way    yh:STRUCTURE            text    delete
-node,way    yh:TOTYUMONO            text    delete
-node,way    yh:TYPE                 text    delete
-node,way    yh:WIDTH                text    delete
-node,way    yh:WIDTH_RANK           text    delete
+node,way    yh:*                    text    delete
 
 # osak (DK)
-node,way    osak:identifier         text    delete
-node,way    osak:municipality_no    text    delete
-node,way    osak:revision           text    delete
-node,way    osak:street_no          text    delete
-node,way    osak:subdivision        text    delete
+node,way    osak:*                  text    delete
 
 # kms (DK)
-node,way    kms:county_name         text    delete
-node,way    kms:county_no           text    delete
-node,way    kms:house_no            text    delete
-node,way    kms:last_updated        text    delete
-node,way    kms:municipality_name   text    delete
-node,way    kms:municipality_no     text    delete
-node,way    kms:parish_name         text    delete
-node,way    kms:parish_no           text    delete
-node,way    kms:street_name         text    delete
-node,way    kms:street_no           text    delete
-node,way    kms:zip_name            text    delete
-node,way    kms:zip_no              text    delete
+node,way    kms:*                   text    delete
 
 # ngbe (ES)
 # See also note:es and source:file above
-node,way    ngbe:codigo             text    delete
-node,way    ngbe:grupo              text    delete
-node,way    ngbe:hojabcn25          text    delete
-node,way    ngbe:huso               text    delete
-node,way    ngbe:id                 text    delete
-node,way    ngbe:lat_ed50           text    delete
-node,way    ngbe:lon_ed50           text    delete
-node,way    ngbe:subgrupo           text    delete
-node,way    ngbe:tema               text    delete
-node,way    ngbe:tipotexto          text    delete
-node,way    ngbe:version            text    delete
-node,way    ngbe:xutm_ed50          text    delete
-node,way    ngbe:yutm_ed50          text    delete
+node,way    ngbe:*                  text    delete
 
 # naptan (UK)
-node,way    naptan:verified         text    delete
-node,way    naptan:AtcoCode         text    delete
-node,way    naptan:CommonName       text    delete
-node,way    naptan:Bearing          text    delete
-node,way    naptan:Street           text    delete
-node,way    naptan:Indicator        text    delete
-node,way    naptan:NaptanCode       text    delete
+node,way    naptan:*                text    delete
 
 # Corine (CLC) (Europe)
-node,way    CLC:code                text    delete
-node,way    CLC:year                text    delete
-node,way    CLC:id                  text    delete
-node,way    CLC:shapeId             text    delete
-node,way    CLC:explanation         text    delete
+node,way    CLC:*                   text    delete
 
 # misc
 node,way    3dshapes:ggmodelk       text    delete
 node,way    AND_nosr_r              text    delete
 node,way    import                  text    delete
-node,way    it:fvg:ctrn:code        text    delete
-node,way    it:fvg:ctrn:revision    text    delete
+node,way    it:fvg:*                text    delete


### PR DESCRIPTION
Do we want to hold off until tests are written for wildcards? I guess we're not going to break anything existing because no one uses empty.style yet
