### PR TITLE
Add abandoned: tags to phstore list

### DIFF
--- a/default.style
+++ b/default.style
@@ -145,6 +145,16 @@ node,way   wood         text         linear
 node,way   z_order      int4         linear # This is calculated during import
 way        way_area     real                # This is calculated during import
 
+# Area tags
+# We don't make columns for these tags, but objects with them are areas.
+# Mainly for use with hstore
+way         abandoned:aeroway       text    phstore
+way         abandoned:amenity       text    phstore
+way         abandoned:building      text    phstore
+way         abandoned:landuse       text    phstore
+way         abandoned:power         text    phstore
+way         area:highway            text    phstore
+
 # Deleted tags
 # These are tags that are generally regarded as useless for most rendering.
 # Most of them are from imports or intended as internal information for mappers

--- a/empty.style
+++ b/empty.style
@@ -4,8 +4,13 @@
 
 # See default.style for documentation on all the flags
 
-# OsmType  Tag                 Type    Flags
+# OsmType   Tag                     Type    Flags
 # Insert your own columns here, or change phstore to polygon below
+way         abandoned:aeroway       text    phstore
+way         abandoned:amenity       text    phstore
+way         abandoned:building      text    phstore
+way         abandoned:landuse       text    phstore
+way         abandoned:power         text    phstore
 way         area:highway            text    phstore
 node,way    aeroway                 text    phstore
 node,way    amenity                 text    phstore


### PR DESCRIPTION
The non-abandoned version of these tags are areas, so the abandoned
ones should be too.

Necessary for hotosm/HDM-CartoCSS#126.

Also defines area:highway as an area in default.style

Test results might need tweaking, but the tests are failing for me for unrelated reasons.
