### PR TITLE
Disable ORDER BY way "clustering"

### DIFF
--- a/output-pgsql.c
+++ b/output-pgsql.c
@@ -1068,16 +1068,6 @@ static void *pgsql_out_stop_one(void *arg)
         fprintf(stderr, "Sorting data and creating indexes for %s\n", table->name);
         pgsql_exec(sql_conn, PGRES_COMMAND_OK, "ANALYZE %s;\n", table->name);
         fprintf(stderr, "Analyzing %s finished\n", table->name);
-        if (Options->tblsmain_data) {
-            pgsql_exec(sql_conn, PGRES_COMMAND_OK, "CREATE TABLE %s_tmp "
-                        "TABLESPACE %s AS SELECT * FROM %s ORDER BY way;\n",
-                        table->name, Options->tblsmain_data, table->name);
-        } else {
-            pgsql_exec(sql_conn, PGRES_COMMAND_OK, "CREATE TABLE %s_tmp AS SELECT * FROM %s ORDER BY way;\n", table->name, table->name);
-        }
-        pgsql_exec(sql_conn, PGRES_COMMAND_OK, "DROP TABLE %s;\n", table->name);
-        pgsql_exec(sql_conn, PGRES_COMMAND_OK, "ALTER TABLE %s_tmp RENAME TO %s;\n", table->name, table->name);
-        fprintf(stderr, "Copying %s to cluster by geometry finished\n", table->name);
         fprintf(stderr, "Creating geometry index on  %s\n", table->name);
         if (Options->tblsmain_index) {
             /* Use fillfactor 100 for un-updatable imports */


### PR DESCRIPTION
Testing indicates that a modified pinning number is no better with
ORDER BY way than by clustered/ordered on osm_id. As the table at
this point are approximately ordered by ID, skip ordering completely.

The modified pinning number is the pinning number, but instead of a
point, an area equivalent to a rendering meta-tile.

For high zooms and a true pinning number ordering by ID is effective,
probably because typically the ways right around a point were created
at about the same time.

For low zooms, a clustering on gist (way) may be desirable, but this
is something the user will have to consider, particularly as it takes
a decent amount of time to do this clustering, and significantly
increases the disk space requirements during the import process.

Benchmarks show the pinning number is within 10% for both a full planet and an extract and the ID-ordered z12 modified pinning number is 50% of the `ORDER BY way` z12 modified pinning number for the line table and 90% for the polygon table.

@apmon, I know there's some conflicts between this and the threading branch, but this also completely eliminates a section you had to change, making the merge simpler.
