### PR TITLE
Fix CPPFLAGS propagation in configure script

### DIFF
--- a/m4/ax_lib_geos.m4
+++ b/m4/ax_lib_geos.m4
@@ -94,7 +94,6 @@ AC_DEFUN([AX_LIB_GEOS],
             CPPFLAGS="$CPPFLAGS $GEOS_CFLAGS"
             AC_CHECK_HEADER([geos/version.h], [],
                              [AC_MSG_ERROR([development headers for geos not found])])
-            echo $ac_save_CPPFLAGS
             CPPFLAGS="$ac_save_CPPFLAGS"
 
             AC_DEFINE([HAVE_GEOS], [1],


### PR DESCRIPTION
CPPFLAGS were not correctly propagated from shell setting to Makefile, because of this missing line in m4/ax_lib_geos.m4.

This made debian hardening checks failing: http://qa.debian.org/bls/packages/o/osm2pgsql.html
