### PR TITLE
removed fillfactor from hstore gin indexes

### DIFF
--- a/output-pgsql.c
+++ b/output-pgsql.c
@@ -1112,7 +1112,7 @@ static void *pgsql_out_stop_one(void *arg)
                     if (Options->slim && !Options->droptemp) {
                         pgsql_exec(sql_conn, PGRES_COMMAND_OK, "CREATE INDEX %s_tags_index ON %s USING GIN (tags) TABLESPACE %s;\n", table->name, table->name, Options->tblsmain_index);
                     } else {
-                        pgsql_exec(sql_conn, PGRES_COMMAND_OK, "CREATE INDEX %s_tags_index ON %s USING GIN (tags) WITH (FILLFACTOR=100) TABLESPACE %s;\n", table->name, table->name, Options->tblsmain_index);
+                        pgsql_exec(sql_conn, PGRES_COMMAND_OK, "CREATE INDEX %s_tags_index ON %s USING GIN (tags) TABLESPACE %s;\n", table->name, table->name, Options->tblsmain_index);
                     }
                 }
                 for(i_column = 0; i_column < Options->n_hstore_columns; i_column++) {
@@ -1120,7 +1120,7 @@ static void *pgsql_out_stop_one(void *arg)
                         pgsql_exec(sql_conn, PGRES_COMMAND_OK, "CREATE INDEX %s_hstore_%i_index ON %s USING GIN (\"%s\") TABLESPACE %s;\n",
                                table->name, i_column,table->name, Options->hstore_columns[i_column], Options->tblsmain_index);
                     } else {
-                        pgsql_exec(sql_conn, PGRES_COMMAND_OK, "CREATE INDEX %s_hstore_%i_index ON %s USING GIN (\"%s\") WITH (FILLFACTOR=100) TABLESPACE %s;\n",
+                        pgsql_exec(sql_conn, PGRES_COMMAND_OK, "CREATE INDEX %s_hstore_%i_index ON %s USING GIN (\"%s\") TABLESPACE %s;\n",
                                table->name, i_column,table->name, Options->hstore_columns[i_column], Options->tblsmain_index);
                     }
                 }
@@ -1129,14 +1129,14 @@ static void *pgsql_out_stop_one(void *arg)
                     if (Options->slim && !Options->droptemp) {
                         pgsql_exec(sql_conn, PGRES_COMMAND_OK, "CREATE INDEX %s_tags_index ON %s USING GIN (tags);\n", table->name, table->name);
                     } else {
-                        pgsql_exec(sql_conn, PGRES_COMMAND_OK, "CREATE INDEX %s_tags_index ON %s USING GIN (tags) WITH (FILLFACTOR=100);\n", table->name, table->name);
+                        pgsql_exec(sql_conn, PGRES_COMMAND_OK, "CREATE INDEX %s_tags_index ON %s USING GIN (tags) ;\n", table->name, table->name);
                     }
                 }
                 for(i_column = 0; i_column < Options->n_hstore_columns; i_column++) {
                     if (Options->slim && !Options->droptemp) {
                         pgsql_exec(sql_conn, PGRES_COMMAND_OK, "CREATE INDEX %s_hstore_%i_index ON %s USING GIN (\"%s\");\n", table->name, i_column,table->name, Options->hstore_columns[i_column]);
                     } else {
-                        pgsql_exec(sql_conn, PGRES_COMMAND_OK, "CREATE INDEX %s_hstore_%i_index ON %s USING GIN (\"%s\") WITH (FILLFACTOR=100);\n", table->name, i_column,table->name, Options->hstore_columns[i_column]);
+                        pgsql_exec(sql_conn, PGRES_COMMAND_OK, "CREATE INDEX %s_hstore_%i_index ON %s USING GIN (\"%s\");\n", table->name, i_column,table->name, Options->hstore_columns[i_column]);
                     }
                 }
             }


### PR DESCRIPTION
fillfactor causes error in postgres 9.3 since it is
not a supported parameter to GIN indexes, see:
http://www.postgresql.org/docs/9.3/static/sql-createindex.html
