### PR TITLE
Fix style.lua error with non numerical layer values

### DIFF
--- a/style.lua
+++ b/style.lua
@@ -12,7 +12,7 @@ generic_keys = {'access','addr:housename','addr:housenumber','addr:interpolation
 
 function add_z_order(keyvalues)
    z_order = 0
-   if (keyvalues["layer"] ~= nil ) then
+   if (keyvalues["layer"] ~= nil and tonumber(keyvalues["layer"])) then
       z_order = 10*keyvalues["layer"]
    end
 


### PR DESCRIPTION
The value for the layer tag should be numeric. But there are a few non numeric values in the OSM db - http://taginfo.openstreetmap.org/keys/layer#values This causes an error of something like: "attempt to perform arithmetic on local 'layer' (a string value)". Thus we check to see if the value is a number.

Full props to @systemed for this!
