### PR TITLE
Remove duplicate libbz2-dev for ubuntu installs 

### DIFF
--- a/README
+++ b/README
@@ -74,7 +74,7 @@ e.g. on Fedora:
 # yum install geos-devel proj-devel postgresql-devel libxml2-devel bzip2-devel gcc-c++
 
 on Debian:
-# aptitude install libxml2-dev libgeos-dev libgeos++-dev libpq-dev libbz2-dev libproj-dev protobuf-c-compiler libprotobuf-c0-dev autoconf automake libtool make g++ libbz2-dev
+# aptitude install libxml2-dev libgeos-dev libgeos++-dev libpq-dev libbz2-dev libproj-dev protobuf-c-compiler libprotobuf-c0-dev autoconf automake libtool make g++
 
 To use lua tag transforms you need a lua interpreter and development packages installed on your system. These are normally lua5.2 and liblua5.2-dev
 


### PR DESCRIPTION
In commit 4366d21c3006c05fd89c60b29847e6db1a361599 (#149) libbz2-dev was added for Ubuntu installs, but libbz2-dev is already included in the list of packages to install.

This commit removes the duplicate entry.
