### PR TITLE
Added the capability to specify a target schema for the tables.

### DIFF
--- a/docs/osm2pgsql.1
+++ b/docs/osm2pgsql.1
@@ -1,4 +1,4 @@
-.TH OSM2PGSQL 1 "April 06, 2013"
+.TH OSM2PGSQL 1 "July 25, 2014"
 .\" Please adjust this date whenever revising the manpage.
 .SH NAME
 osm2pgsql \- Openstreetmap data to PostgreSQL converter.
@@ -62,6 +62,9 @@ This allows one to e.g. store the indices on faster storage like SSDs.
 .TP
 \fB\ \fR\-\-tablespace\-main\-data tablespacename
 Store the data tables (non slim) in the given tablespace.
+.TP
+\fB\-X\fR|\-\-schema
+Use the specified schema to store the tables.  Default is public.
 .TP
 \fB\ \fR\-\-tablespace\-main\-index tablespacename
 Store the indices of the main tables (non slim) in the given tablespace.

--- a/osm2pgsql.c
+++ b/osm2pgsql.c
@@ -149,7 +149,8 @@ Database options:\n\
                     environment variable or use -W).\n\
    -W|--password    Force password prompt.\n\
    -H|--host        Database server host name or socket location.\n\
-   -P|--port        Database server port.\n");
+   -P|--port        Database server port.\n\
+   -X|--schema      Target schema to store the tables in.  Default is public.\n");
 
     if (verbose) 
     {
@@ -413,6 +414,7 @@ int main(int argc, char *argv[])
     const char *host=NULL;
     const char *password=NULL;
     const char *port = "5432";
+    const char *schema = "public";
     const char *tblsmain_index = NULL; /* no default TABLESPACE for index on main tables */
     const char *tblsmain_data = NULL;  /* no default TABLESPACE for main tables */
     const char *tblsslim_index = NULL; /* no default TABLESPACE for index on slim mode tables */
@@ -456,6 +458,7 @@ int main(int argc, char *argv[])
             {"password", 0, 0, 'W'},
             {"host",     1, 0, 'H'},
             {"port",     1, 0, 'P'},
+            {"schema",   1, 0, 'X'},
             {"tablespace-index", 1, 0, 'i'},
             {"tablespace-slim-data", 1, 0, 200},
             {"tablespace-slim-index", 1, 0, 201},
@@ -487,7 +490,7 @@ int main(int argc, char *argv[])
             {0, 0, 0, 0}
         };
 
-        c = getopt_long (argc, argv, "ab:cd:KhlmMp:suvU:WH:P:i:IE:C:S:e:o:O:xkjGz:r:V", long_options, &option_index);
+        c = getopt_long (argc, argv, "ab:cd:KhlmMp:suvU:WH:P:X:i:IE:C:S:e:o:O:xkjGz:r:V", long_options, &option_index);
         if (c == -1)
             break;
 
@@ -510,6 +513,7 @@ int main(int argc, char *argv[])
             case 'W': pass_prompt=1; break;
             case 'H': host=optarg; break;
             case 'P': port=optarg; break;
+            case 'X': schema=optarg; break;
             case 'S': style=optarg; break;
             case 'i': tblsmain_index=tblsslim_index=optarg; break;
             case 200: tblsslim_data=optarg; break;    
@@ -684,6 +688,7 @@ int main(int argc, char *argv[])
     options.num_procs = num_procs;
     options.droptemp = droptemp;
     options.unlogged = unlogged;
+    options.schema = schema;
     options.flat_node_cache_enabled = flat_node_cache_enabled;
     options.flat_node_file = flat_nodes_file;
     options.excludepoly = excludepoly;

--- a/output-pgsql.c
+++ b/output-pgsql.c
@@ -853,6 +853,12 @@ static int pgsql_out_start(const struct output_options *options)
         tables[i].sql_conn = sql_conn;
         pgsql_exec(sql_conn, PGRES_COMMAND_OK, "SET synchronous_commit TO off;");
 
+        /* If non-default schema (not public) is specified, set the search path */
+        if (options->schema != "public")
+        {
+            pgsql_exec(sql_conn, PGRES_COMMAND_OK, "SET search_path TO %s,public", options->schema);
+        }
+
         if (!options->append) {
             pgsql_exec(sql_conn, PGRES_COMMAND_OK, "DROP TABLE IF EXISTS %s", tables[i].name);
         }

--- a/output.h
+++ b/output.h
@@ -51,6 +51,7 @@ struct output_options {
   int droptemp; /* drop slim mode temp tables after act */
   int unlogged; /* use unlogged tables where possible */
   int hstore_match_only; /* only copy rows that match an explicitly listed key */
+  char *schema; /* the target schema to use */
   int flat_node_cache_enabled;
   int excludepoly;
   const char *flat_node_file;


### PR DESCRIPTION
This adds the capability to use tables in a different schema than public. Pass -X or --schema to specify which schema to use.  Uses SET search_path TO schema now, as opposed to explicitly defining it per each table.