### PR TITLE
Fix memory errors

### DIFF
--- a/node-ram-cache.c
+++ b/node-ram-cache.c
@@ -356,7 +356,7 @@ void init_node_ram_cache( int strategy, int cacheSizeMB, int fixpointscale ) {
     cacheSize = (int64_t)cacheSizeMB*(1024*1024);
     /* How much we can fit, and make sure it's odd */
     maxBlocks = (cacheSize/(PER_BLOCK*sizeof(struct ramNode)));
-    maxSparseTuples = (cacheSize/sizeof(struct ramNodeID));
+    maxSparseTuples = (cacheSize/sizeof(struct ramNodeID))+1;
     
     allocStrategy = strategy;
     scale = fixpointscale;


### PR DESCRIPTION
After https://github.com/openstreetmap/osm2pgsql/commit/d1b6c5e563e8eb9d836d97fad094f0a1b35f92ea#diff-a4a10b448709d2cc5dc0c85fb36a2b1c
the RAM cache size can be zero, but `ram_cache_nodes_set_sparse` function often accesses `sparseBlock[0]`. It gives serious memory access errors and failures during testing (detected with Intel Inspector XE when fixing Windows builds https://github.com/openstreetmap/osm2pgsql/issues/17 ).

I am not sure the proposed fix is the best solution, but something should be done with this error.
