### PR TITLE
Support alt_name_* tags in output-gazetteer

### DIFF
--- a/output-gazetteer.c
+++ b/output-gazetteer.c
@@ -300,6 +300,7 @@ static int split_tags(struct keyval *tags, unsigned int flags, struct keyval *na
           strcmp(item->key, "old_name") == 0 ||
           (strncmp(item->key, "old_name:", 9) == 0) || 
           strcmp(item->key, "alt_name") == 0 ||
+          (strncmp(item->key, "alt_name_", 9) == 0) || 
           (strncmp(item->key, "alt_name:", 9) == 0) || 
           strcmp(item->key, "official_name") == 0 ||
           (strncmp(item->key, "official_name:", 14) == 0) || 


### PR DESCRIPTION
Allow for multiple alt_name_1, alt_name_2, etc.

Load for searching - nothing else will be done with them.
