### PR TITLE
Hide postgresql notices

### DIFF
--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -1224,6 +1224,8 @@ int middle_pgsql_t::start(const options_t *out_options_)
             if(!out_options->append)
                 build_indexes = 1;
         }
+
+        pgsql_exec(sql_conn, PGRES_COMMAND_OK, "SET client_min_messages = WARNING");
         if (dropcreate) {
             pgsql_exec(sql_conn, PGRES_COMMAND_OK, "DROP TABLE IF EXISTS %s", tables[i].name);
         }
@@ -1239,7 +1241,7 @@ int middle_pgsql_t::start(const options_t *out_options_)
               pgsql_exec(sql_conn, PGRES_COMMAND_OK, "%s", tables[i].create_index);
             }
         }
-
+        pgsql_exec(sql_conn, PGRES_COMMAND_OK, "RESET client_min_messages");
 
         if (tables[i].prepare) {
             pgsql_exec(sql_conn, PGRES_COMMAND_OK, "%s", tables[i].prepare);

--- a/table.cpp
+++ b/table.cpp
@@ -97,7 +97,7 @@ void table_t::start()
 
     connect();
     fprintf(stderr, "Setting up table: %s\n", name.c_str());
-
+    pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, "SET client_min_messages = WARNING");
     //we are making a new table
     if (!append)
     {
@@ -116,6 +116,7 @@ void table_t::start()
     /* These _tmp tables can be left behind if we run out of disk space */
     pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("DROP TABLE IF EXISTS %1%_tmp") % name).str());
 
+    pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, "RESET client_min_messages");
     begin();
 
     //making a new table


### PR DESCRIPTION
By using client_min_messages we can hide notices we expect to occur.
