### PR TITLE
move middle_t::cleanup code into destructor

### DIFF
--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -468,17 +468,6 @@ int middle_pgsql_t::local_nodes_get_list(struct osmNode *nodes, const osmid_t *n
     return count;
 }
 
-void middle_pgsql_t::cleanup(void)
-{
-    int i;
-
-    for (i=0; i<num_tables; i++) {
-        if (tables[i].sql_conn) {
-            PQfinish(tables[i].sql_conn);
-            tables[i].sql_conn = NULL;
-        }
-    }
-}
 
 int middle_pgsql_t::nodes_set(osmid_t id, double lat, double lon, struct keyval *tags) {
     cache->set( id, lat, lon, tags );
@@ -1417,6 +1406,12 @@ middle_pgsql_t::middle_pgsql_t()
 }
 
 middle_pgsql_t::~middle_pgsql_t() {
+    for (int i=0; i < num_tables; i++) {
+        if (tables[i].sql_conn) {
+            PQfinish(tables[i].sql_conn);
+        }
+    }
+
 }
 
 boost::shared_ptr<const middle_query_t> middle_pgsql_t::get_instance() const {

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -23,7 +23,6 @@ struct middle_pgsql_t : public slim_middle_t {
 
     int start(const options_t *out_options_);
     void stop(void);
-    void cleanup(void);
     void analyze(void);
     void end(void);
     void commit(void);

--- a/middle-ram.cpp
+++ b/middle-ram.cpp
@@ -292,11 +292,6 @@ void middle_ram_t::analyze(void)
     /* No need */
 }
 
-void middle_ram_t::cleanup(void)
-{
-    /* No need */
-}
-
 void middle_ram_t::end(void)
 {
     /* No need */

--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -20,7 +20,6 @@ struct middle_ram_t : public middle_t {
 
     int start(const options_t *out_options_);
     void stop(void);
-    void cleanup(void);
     void analyze(void);
     void end(void);
     void commit(void);

--- a/middle.hpp
+++ b/middle.hpp
@@ -37,7 +37,6 @@ struct middle_t : public middle_query_t {
 
     virtual int start(const options_t *out_options_) = 0;
     virtual void stop(void) = 0;
-    virtual void cleanup(void) = 0;
     virtual void analyze(void) = 0;
     virtual void end(void) = 0;
     virtual void commit(void) = 0;


### PR DESCRIPTION
Fixes a whole bunch of leaking postgres connections. cleanup() wasn't called anywhere anymore.
