### PR TITLE
Replace manually allocated strings in middle-pgsql with std::string

### DIFF
--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -256,9 +256,7 @@ const char *pgsql_store_tags(std::string &buffer, const struct keyval *tags, int
     if (!first) buffer += ',';
     buffer += '"';
     escape_tag( &buffer, i->key, escape );
-    buffer += '"';
-    buffer += ',';
-    buffer += '"';
+    buffer += "\",\"";
     escape_tag( &buffer, i->value, escape );
     buffer += '"';
 
@@ -396,7 +394,7 @@ int middle_pgsql_t::local_nodes_set(osmid_t id, double lat, double lon, const st
       pgsql_store_tags(buffer, tags, 1);
       buffer += '\n';
 
-      pgsql_CopyData(__FUNCTION__, node_table->sql_conn, buffer.c_str());
+      pgsql_CopyData(__FUNCTION__, node_table->sql_conn, buffer);
     } else {
         std::string idstr = (single_fmt % id).str();
     #ifdef FIXED_POINT
@@ -581,7 +579,7 @@ int middle_pgsql_t::ways_set(osmid_t way_id, osmid_t *nds, int nd_count, struct 
       pgsql_store_tags(buffer, tags, 1);
       buffer += '\n';
 
-      pgsql_CopyData(__FUNCTION__, way_table->sql_conn, buffer.c_str());
+      pgsql_CopyData(__FUNCTION__, way_table->sql_conn, buffer);
     } else {
       // Three params: id, nodes, tags */
       std::string idstr = (single_fmt % way_id).str();
@@ -815,7 +813,7 @@ int middle_pgsql_t::relations_set(osmid_t id, struct member *members, int member
       pgsql_store_tags(buffer, tags, 1);
       buffer += '\n';
 
-      pgsql_CopyData(__FUNCTION__, rel_table->sql_conn, buffer.c_str());
+      pgsql_CopyData(__FUNCTION__, rel_table->sql_conn, buffer);
     } else {
       std::string idstr = (single_fmt % id).str();
       std::string wstr = (single_fmt % node_count).str();

--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -73,6 +73,7 @@ enum table_id {
 // not thread safe, needs to be moved in the thread structure before
 // middle tables can be _written_ in multi-threaded mode.
 static boost::format single_fmt = boost::format("%1%");
+static boost::format column_fmt = boost::format("%1%\t");
 static boost::format latlon_fmt = boost::format("%.10g");
 
 
@@ -374,15 +375,12 @@ int middle_pgsql_t::local_nodes_set(osmid_t id, double lat, double lon, const st
     if (node_table->copyMode) {
       buffer.clear();
       // id
-      buffer.append((single_fmt % id).str());
-      buffer += '\t';
+      buffer.append((column_fmt % id).str());
 
       // lat, lon
 #ifdef FIXED_POINT
-      buffer.append((single_fmt % util::double_to_fix(lat, out_options->scale)).str());
-      buffer += '\t';
-      buffer.append((single_fmt % util::double_to_fix(lon, out_options->scale)).str());
-      buffer += '\t';
+      buffer.append((column_fmt % util::double_to_fix(lat, out_options->scale)).str());
+      buffer.append((column_fmt % util::double_to_fix(lon, out_options->scale)).str());
 #else
       buffer.append((latlon_fmt % lat).str());
       buffer += '\t';
@@ -570,8 +568,7 @@ int middle_pgsql_t::ways_set(osmid_t way_id, osmid_t *nds, int nd_count, struct 
     {
       buffer.clear();
       // id
-      buffer.append((single_fmt % way_id).str());
-      buffer += '\t';
+      buffer.append((column_fmt % way_id).str());
       // nodes
       pgsql_store_nodes(buffer, nds, nd_count);
       buffer += '\t';
@@ -795,14 +792,11 @@ int middle_pgsql_t::relations_set(osmid_t id, struct member *members, int member
     {
       buffer.clear();
       // id
-      buffer.append((single_fmt % id).str());
-      buffer += '\t';
+      buffer.append((column_fmt % id).str());
       // way_off
-      buffer.append((single_fmt % node_count).str());
-      buffer += '\t';
+      buffer.append((column_fmt % node_count).str());
       // rel_off
-      buffer.append((single_fmt % (node_count + way_count)).str());
-      buffer += '\t';
+      buffer.append((column_fmt % (node_count + way_count)).str());
       // parts
       pgsql_store_nodes(buffer, &all_parts[0], all_count);
       buffer += '\t';

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -19,7 +19,7 @@
 
 struct middle_pgsql_t : public slim_middle_t {
     middle_pgsql_t();
-    virtual ~middle_pgsql_t();
+    virtual ~middle_pgsql_t() {}
 
     int start(const options_t *out_options_);
     void stop(void);
@@ -54,37 +54,57 @@ struct middle_pgsql_t : public slim_middle_t {
     void *pgsql_stop_one(void *arg);
 
     struct table_desc {
-        table_desc(const char *name_ = NULL,
-                   const char *start_ = NULL,
-                   const char *create_ = NULL,
-                   const char *create_index_ = NULL,
-                   const char *prepare_ = NULL,
-                   const char *prepare_intarray_ = NULL,
-                   const char *copy_ = NULL,
-                   const char *analyze_ = NULL,
-                   const char *stop_ = NULL,
-                   const char *array_indexes_ = NULL);
+        table_desc(const char *name_ = "",
+                   const char *start_ = "",
+                   const char *create_ = "",
+                   const char *create_index_ = "",
+                   const char *prepare_ = "",
+                   const char *prepare_intarray_ = "",
+                   const char *copy_ = "",
+                   const char *analyze_ = "",
+                   const char *stop_ = "",
+                   const char *array_indexes_ = "")
+        : name(name_),
+          start(start_),
+          create(create_),
+          create_index(create_index_),
+          prepare(prepare_),
+          prepare_intarray(prepare_intarray_),
+          copy(copy_),
+          analyze(analyze_),
+          stop(stop_),
+          array_indexes(array_indexes_),
+          copyMode(0),
+          transactionMode(0),
+          sql_conn(NULL)
+        {}
 
-        const char *name;
-        const char *start;
-        const char *create;
-        const char *create_index;
-        const char *prepare;
-        const char *prepare_intarray;
-        const char *copy;
-        const char *analyze;
-        const char *stop;
-        const char *array_indexes;
+        ~table_desc();
+
+        int connect(const struct options_t *options);
+
+        std::string name;
+        std::string start;
+        std::string create;
+        std::string create_index;
+        std::string prepare;
+        std::string prepare_intarray;
+        std::string copy;
+        std::string analyze;
+        std::string stop;
+        std::string array_indexes;
 
         int copyMode;    /* True if we are in copy mode */
         int transactionMode;    /* True if we are in an extended transaction */
         struct pg_conn *sql_conn;
+
+        private:
+        void set_prefix_and_tbls(const options_t *options, std::string *str);
     };
 
     virtual boost::shared_ptr<const middle_query_t> get_instance() const;
 private:
 
-    int connect(table_desc& table);
     int local_nodes_set(const osmid_t& id, const double& lat, const double& lon, const struct keyval *tags);
     int local_nodes_get_list(struct osmNode *nodes, const osmid_t *ndids, const int& nd_count) const;
     int local_nodes_delete(osmid_t osm_id);

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -106,7 +106,7 @@ struct middle_pgsql_t : public slim_middle_t {
 private:
 
     int local_nodes_set(osmid_t id, double lat, double lon, const struct keyval *tags);
-    int local_nodes_get_list(struct osmNode *nodes, const osmid_t *ndids, const int& nd_count) const;
+    int local_nodes_get_list(struct osmNode *nodes, const osmid_t *ndids, int nd_count) const;
     int local_nodes_delete(osmid_t osm_id);
 
     std::vector<table_desc> tables;

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -105,7 +105,7 @@ struct middle_pgsql_t : public slim_middle_t {
     virtual boost::shared_ptr<const middle_query_t> get_instance() const;
 private:
 
-    int local_nodes_set(const osmid_t& id, const double& lat, const double& lon, const struct keyval *tags);
+    int local_nodes_set(osmid_t id, double lat, double lon, const struct keyval *tags);
     int local_nodes_get_list(struct osmNode *nodes, const osmid_t *ndids, const int& nd_count) const;
     int local_nodes_delete(osmid_t osm_id);
 
@@ -121,6 +121,7 @@ private:
     boost::shared_ptr<id_tracker> ways_pending_tracker, rels_pending_tracker;
 
     int build_indexes;
+    std::string buffer; // used for building the COPY string
 };
 
 #endif

--- a/pgsql.cpp
+++ b/pgsql.cpp
@@ -95,12 +95,12 @@ int pgsql_exec(PGconn *sql_conn, const ExecStatusType expect, const char *fmt, .
     return 0;
 }
 
-void pgsql_CopyData(const char *context, PGconn *sql_conn, const char *sql, int len)
+void pgsql_CopyData(const char *context, PGconn *sql_conn, const std::string &sql)
 {
 #ifdef DEBUG_PGSQL
     fprintf(stderr, "%s>>> %s\n", context, sql );
 #endif
-    int r = PQputCopyData(sql_conn, sql, len);
+    int r = PQputCopyData(sql_conn, sql.c_str(), sql.length());
     switch(r)
     {
         //need to wait for write ready

--- a/pgsql.hpp
+++ b/pgsql.hpp
@@ -12,7 +12,7 @@
 #include <boost/shared_ptr.hpp>
 
 PGresult *pgsql_execPrepared( PGconn *sql_conn, const char *stmtName, const int nParams, const char *const * paramValues, const ExecStatusType expect);
-void pgsql_CopyData(const char *context, PGconn *sql_conn, const char *sql, int len);
+void pgsql_CopyData(const char *context, PGconn *sql_conn, const std::string &sql);
 boost::shared_ptr<PGresult> pgsql_exec_simple(PGconn *sql_conn, const ExecStatusType expect, const std::string& sql);
 boost::shared_ptr<PGresult> pgsql_exec_simple(PGconn *sql_conn, const ExecStatusType expect, const char *sql);
 int pgsql_exec(PGconn *sql_conn, const ExecStatusType expect, const char *fmt, ...)
@@ -23,12 +23,4 @@ int pgsql_exec(PGconn *sql_conn, const ExecStatusType expect, const char *fmt, .
 
 void escape(const std::string &src, std::string& dst);
 
-
-inline void pgsql_CopyData(const char *context, PGconn *sql_conn, const char *sql) {
-    pgsql_CopyData(context, sql_conn, sql, strlen(sql));
-}
-
-inline void pgsql_CopyData(const char *context, PGconn *sql_conn, const std::string &sql) {
-    pgsql_CopyData(context, sql_conn, sql.c_str(), sql.length());
-}
 #endif


### PR DESCRIPTION
This removes all the remaining char* that were manually allocated through either malloc or strdup and replaces them with std::string. Namely they are

 * sql commands in the table descriptions
 * buffers for building tag and node lists
 
It fixes another couple of smaller memory leaks (see #228). Note that it also contains a test for #247 which is currently disabled because it fails.

@pnorman would you mind running another round of performance tests with the full planet? It would also be good to have some numbers on osc updates, if your setup permits to do that easily.