### PR TITLE
Remove nocache flag from religion

### DIFF
--- a/default.style
+++ b/default.style
@@ -126,7 +126,7 @@ node,way   power_source text         linear
 node,way   public_transport text     polygon
 node,way   railway      text         linear
 node,way   ref          text         linear
-node,way   religion     text         nocache
+node,way   religion     text
 node,way   route        text         linear
 node,way   service      text         linear
 node,way   shop         text         polygon


### PR DESCRIPTION
The `nocache` flag is depreciated and does nothing.

As `nocache` does nothing, there are no issues with updating and this is a change just to avoid confusion.

Fixes #235