### PR TITLE
Add recommended types to columns for extra attributes

### DIFF
--- a/default.style
+++ b/default.style
@@ -68,10 +68,14 @@
 # way_area - datatype real. The area of the way, in the units of the projection
 # (e.g. square mercator meters). Only applies to areas
 #
-# osm_user, osm_uid, osm_version, osm_timestamp - datatype text. Used with the
-# --extra-attributes option to include metadata in the database. If importing
-# with both --hstore and --extra-attributes the meta-data will end up in the
-# tags hstore column regardless of the style file.
+# osm_user - datatype text
+# osm_uid - datatype integer
+# osm_version - datatype integer
+# osm_changeset - datatype integer
+# osm_timestamp - datatype timestamptz(0).
+# Used with the --extra-attributes option to include metadata in the database.
+# If importing with both --hstore and --extra-attributes the meta-data will
+# end up in the tags hstore column regardless of the style file.
 
 # OsmType  Tag          DataType     Flags
 node,way   access       text         linear


### PR DESCRIPTION
By using non-text types the columns are small, indexes are smaller, and inequality and range comparisons are possible.