### PR TITLE
Add an option to specify the target schema for import

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ On FreeBSD instead bootstrap and then run
 
 ## Usage ##
 
-Osm2pgsql has one program, the executable itself, which has **43** command line
+Osm2pgsql has one program, the executable itself, which has **44** command line
 options.
 
 Before loading into a database, the database must be created and the PostGIS

--- a/docs/osm2pgsql.1
+++ b/docs/osm2pgsql.1
@@ -72,6 +72,9 @@ Store the slim mode tables in the given tablespace.
 \fB\ \fR\-\-tablespace\-slim\-index tablespacename
 Store the indices of the slim mode tables in the given tablespace.
 .TP
+\fB\-X\fR|\-\-schema
+Use the specified schema to store the tables
+.TP
 \fB\-l\fR|\-\-latlong
 Store data in degrees of latitude & longitude.
 .TP

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,6 @@
 # Command-line usage #
 
-Osm2pgsql has one program, the executable itself, which has **43** command line
+Osm2pgsql has one program, the executable itself, which has **44** command line
 options. A full list of options can be obtained with ``osm2pgsql -h -v``. This
 document provides an overview of options, and more importantly, why you might
 use them.
@@ -47,6 +47,10 @@ that only impact performance.
 osm2pgsql supports standard options for how to connect to PostgreSQL. If left
 unset, it will attempt to connect to the ``gis`` database using a unix socket.
 Most usage only requires setting ``--database``.
+
+``--schema`` allows a [PostgreSQL schema](http://www.postgresql.org/docs/current/static/ddl-schemas.html)
+to be set. This is similar to creating a dedicated user for osm2pgsql and using
+``ALTER ROLE ... SET search_path TO ...``.
 
 ``--tablespace`` options allow the location of main and slim tables and indexes
 to be set to different tablespaces independently, typically on machines with

--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -1074,6 +1074,8 @@ int middle_pgsql_t::connect(table_desc& table) {
         fprintf(stderr, "Connection to database failed: %s\n", PQerrorMessage(sql_conn));
         return 1;
     }
+
+    pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (boost::format("SET search_path TO %1%,public;") % out_options->schema.get()).str());
     table.sql_conn = sql_conn;
     return 0;
 }

--- a/options.cpp
+++ b/options.cpp
@@ -16,7 +16,7 @@
 
 namespace
 {
-    const char * short_options = "ab:cd:KhlmMp:suvU:WH:P:i:IE:C:S:e:o:O:xkjGz:r:V";
+    const char * short_options = "ab:cd:KhlmMp:suvU:WH:P:X:i:IE:C:S:e:o:O:xkjGz:r:V";
     const struct option long_options[] =
     {
         {"append",   0, 0, 'a'},
@@ -36,6 +36,7 @@ namespace
         {"password", 0, 0, 'W'},
         {"host",     1, 0, 'H'},
         {"port",     1, 0, 'P'},
+        {"schema",   1, 0, 'X'},
         {"tablespace-index", 1, 0, 'i'},
         {"tablespace-slim-data", 1, 0, 200},
         {"tablespace-slim-index", 1, 0, 201},
@@ -107,7 +108,8 @@ namespace
                         environment variable or use -W).\n\
        -W|--password    Force password prompt.\n\
        -H|--host        Database server host name or socket location.\n\
-       -P|--port        Database server port.\n");
+       -P|--port        Database server port.\n\
+       -X|--schema      Database target schema.\n");
 
         if (verbose)
         {
@@ -271,7 +273,7 @@ options_t::options_t():
     tag_transform_script(boost::none), tag_transform_node_func(boost::none), tag_transform_way_func(boost::none),
     tag_transform_rel_func(boost::none), tag_transform_rel_mem_func(boost::none),
     create(0), sanitize(0), long_usage_bool(0), pass_prompt(0), db("gis"), username(boost::none), host(boost::none),
-    password(boost::none), port("5432"), output_backend("pgsql"), input_reader("auto"), bbox(boost::none), extra_attributes(0), verbose(0)
+    password(boost::none), port("5432"), schema(boost::none), output_backend("pgsql"), input_reader("auto"), bbox(boost::none), extra_attributes(0), verbose(0)
 {
 
 }
@@ -348,6 +350,9 @@ options_t options_t::parse(int argc, char *argv[])
             break;
         case 'P':
             options.port = optarg;
+            break;
+        case 'X':
+            options.schema = optarg;
             break;
         case 'S':
             options.style = optarg;

--- a/options.hpp
+++ b/options.hpp
@@ -74,6 +74,7 @@ public:
     boost::optional<std::string> host;
     boost::optional<std::string> password;
     std::string port;
+    boost::optional<std::string> schema;
     std::string output_backend ;
     std::string input_reader;
     boost::optional<std::string> bbox;

--- a/output-gazetteer.cpp
+++ b/output-gazetteer.cpp
@@ -593,12 +593,22 @@ int output_gazetteer_t::connect() {
        return 1;
     }
 
+    if (m_options.schema)
+    {
+        pgsql_exec_simple(Connection, PGRES_COMMAND_OK, (boost::format("SET search_path TO %1%,public;") % m_options.schema.get()).str());
+    }
+
     if (m_options.append) {
         ConnectionDelete = PQconnectdb(m_options.conninfo.c_str());
         if (PQstatus(ConnectionDelete) != CONNECTION_OK)
         {
             std::cerr << "Connection to database failed: " << PQerrorMessage(Connection) << "\n";
             return 1;
+        }
+
+        if (m_options.schema)
+        {
+            pgsql_exec_simple(ConnectionDelete, PGRES_COMMAND_OK, (boost::format("SET search_path TO %1%,public;") % m_options.schema.get()).str());
         }
 
         pgsql_exec(ConnectionDelete, PGRES_COMMAND_OK, "PREPARE get_classes (CHAR(1), " POSTGRES_OSMID_TYPE ") AS SELECT class FROM place WHERE osm_type = $1 and osm_id = $2");

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -22,7 +22,8 @@ output_multi_t::output_multi_t(const std::string &name,
                           m_options.hstore_columns, m_processor->srid(), m_options.scale,
                           m_options.append, m_options.slim, m_options.droptemp,
                           m_options.hstore_mode, m_options.enable_hstore_index,
-                          m_options.tblsmain_data, m_options.tblsmain_index)),
+                          m_options.tblsmain_data, m_options.tblsmain_index,
+                          m_options.schema)),
       ways_pending_tracker(new id_tracker()), ways_done_tracker(new id_tracker()), rels_pending_tracker(new id_tracker()),
       m_expire(new expire_tiles(&m_options)) {
 }

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -714,7 +714,7 @@ output_pgsql_t::output_pgsql_t(const middle_query_t* mid_, const options_t &opti
             new table_t(
                 m_options.conninfo, name, type, columns, m_options.hstore_columns, SRID, m_options.scale,
                 m_options.append, m_options.slim, m_options.droptemp, m_options.hstore_mode,
-                m_options.enable_hstore_index, m_options.tblsmain_data, m_options.tblsmain_index
+                m_options.enable_hstore_index, m_options.tblsmain_data, m_options.tblsmain_index, m_options.schema
             )
         ));
     }

--- a/table.hpp
+++ b/table.hpp
@@ -20,7 +20,7 @@ class table_t
     public:
         table_t(const std::string& conninfo, const std::string& name, const std::string& type, const columns_t& columns, const hstores_t& hstore_columns, const int srid,
                 const int scale, const bool append, const bool slim, const bool droptemp, const int hstore_mode, const bool enable_hstore_index,
-                const boost::optional<std::string>& table_space, const boost::optional<std::string>& table_space_index);
+                const boost::optional<std::string>& table_space, const boost::optional<std::string>& table_space_index, const boost::optional<std::string>& schema);
         table_t(const table_t& other);
         ~table_t();
 
@@ -83,6 +83,7 @@ class table_t
         std::string copystr;
         boost::optional<std::string> table_space;
         boost::optional<std::string> table_space_index;
+        boost::optional<std::string> schema;
 
         fmt single_fmt, point_fmt, del_fmt;
 };

--- a/tests/test-parse-options.cpp
+++ b/tests/test-parse-options.cpp
@@ -241,6 +241,9 @@ void test_random_perms()
 
         add_arg_and_val_or_not("--number-processes", args, options.num_procs, rand() % 12);
 
+        if (options.schema) {
+            add_arg_and_val_or_not("--schema", args, options.schema->c_str(), get_random_string(6));
+        }
         //add_arg_or_not("--disable-parallel-indexing", args, options.parallel_indexing);
 
         add_arg_or_not("--unlogged", args, options.unlogged);


### PR DESCRIPTION
This allows a custom schema to be used, or for users where a different search_path is set, the public schema to be used.

Replaces #173