### PR TITLE
Remove 32-bit node ID support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,17 +49,6 @@ AC_SUBST(LFS_CFLAGS)
 AC_CHECK_FUNC(lseek64,[AC_DEFINE(HAVE_LSEEK64, [1], [lseek64 is present])],[AX_COMPILE_CHECK_SIZEOF(off_t)])
 AC_CHECK_FUNCS([posix_fallocate posix_fadvise sync_file_range fork])
 
-
-dnl legacy 32bit ID mode
-AC_ARG_ENABLE([64bit-ids],
-    AS_HELP_STRING([--disable-64bit-ids], [Disable 64bit IDs for OSM IDs]), 
-    [ if test "$enableval" = "yes"
-      then
-        AC_DEFINE(OSMID64, [1], [Enable 64bit OSM IDs])
-      fi
-    ], [ AC_DEFINE(OSMID64, [1], [Enable 64bit OSM IDs])])
-
-
 dnl Check for libxml2 library
 AX_LIB_XML2
 if test "$HAVE_XML2" = "no" 

--- a/osmtypes.hpp
+++ b/osmtypes.hpp
@@ -9,17 +9,10 @@
 #include <inttypes.h>
 #include <config.h>
 
-#ifdef OSMID64
 typedef int64_t osmid_t;
 #define strtoosmid strtoll
 #define PRIdOSMID PRId64
 #define POSTGRES_OSMID_TYPE "int8"
-#else
-typedef int32_t osmid_t;
-#define strtoosmid strtol
-#define PRIdOSMID PRId32
-#define POSTGRES_OSMID_TYPE "int4"
-#endif
 
 enum OsmType { OSMTYPE_WAY, OSMTYPE_NODE, OSMTYPE_RELATION };
 


### PR DESCRIPTION
OSM IDs are high enough that 64 bit node IDs are needed everywhere.

Projects using osm2pgsql on non-OpenStreetMap data are not generally
dealing with large enough datasets to need 32 bit IDs, and not
generally building their own osm2pgsql with the 32 bit option anyways.