### PR TITLE
Cleanup based on the output of LLVM's static analyzer

### DIFF
--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -1270,14 +1270,14 @@ void middle_pgsql_t::stop(void)
 {
     int i;
 #ifdef HAVE_PTHREAD
-    pthread_t threads[num_tables];
+    std::vector<pthread_t> threads(num_tables);
 #endif
 
     cache.reset();
     if (out_options->flat_node_cache_enabled) persistent_cache.reset();
 
 #ifdef HAVE_PTHREAD
-    pthread_thunk thunks[num_tables];
+    std::vector<pthread_thunk> thunks(num_tables);
     for (i=0; i<num_tables; i++) {
         thunks[i].obj = this;
         thunks[i].ptr = &tables[i];

--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -1263,7 +1263,7 @@ struct pthread_thunk {
 extern "C" void *pthread_middle_pgsql_stop_one(void *arg) {
     pthread_thunk *thunk = static_cast<pthread_thunk *>(arg);
     return thunk->obj->pgsql_stop_one(thunk->ptr);
-};
+}
 } // anonymous namespace
 
 void middle_pgsql_t::stop(void)

--- a/osm2pgsql.cpp
+++ b/osm2pgsql.cpp
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
 
         return 0;
     }//something went wrong along the way
-    catch(std::runtime_error& e)
+    catch(const std::runtime_error& e)
     {
         fprintf(stderr, "Osm2pgsql failed due to ERROR: %s\n", e.what());
         exit(EXIT_FAILURE);

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -666,7 +666,7 @@ output_pgsql_t::output_pgsql_t(const middle_query_t* mid_, const options_t &opti
     try {
         m_tagtransform.reset(new tagtransform(&m_options));
     }
-    catch(std::runtime_error& e) {
+    catch(const std::runtime_error& e) {
         fprintf(stderr, "%s\n", e.what());
         fprintf(stderr, "Error: Failed to initialise tag processing.\n");
         util::exit_nicely();

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -252,7 +252,7 @@ extern "C" void *pthread_output_pgsql_stop_one(void *arg) {
     pthread_thunk *thunk = static_cast<pthread_thunk *>(arg);
     thunk->ptr->stop();
     return NULL;
-};
+}
 } // anonymous namespace
 
 void output_pgsql_t::enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) {

--- a/parse-o5m.cpp
+++ b/parse-o5m.cpp
@@ -402,7 +402,7 @@ static void read_close() {
 return;
   fd= read_infop->fd;
   if(loglevel>=1) {  /* verbose */
-      fprintf(stderr,"osm2pgsql: Number of bytes read: %"PRIu64"\n",
+      fprintf(stderr,"osm2pgsql: Number of bytes read: %" PRIu64 "\n",
       read_infop->read__counter);
     }
   if(loglevel>=2) {

--- a/tests/regression-test.py
+++ b/tests/regression-test.py
@@ -336,7 +336,7 @@ class BaseTestCase(unittest.TestCase):
             self.conn=psycopg2.connect("dbname='osm2pgsql-test'")
             self.conn.autocommit = True
             self.cur = self.conn.cursor()
-        except Exception, e:
+        except Exception as e:
             print "I am unable to connect to the database." + e
 
     def dbClose(self):
@@ -352,7 +352,7 @@ class BaseTestCase(unittest.TestCase):
                 try:
                     self.cur.execute(sql_test_statements[i][2])
                     res = self.cur.fetchall()
-                except Exception, e:
+                except Exception as e:
                     self.assertEqual(0, 1, str(sql_test_statements[i][0]) + ": Failed to execute " + sql_test_statements[i][1] +
                                      " (" + sql_test_statements[i][2] + ") {" + str(self.parameters) +"}")
                 if (res == None):
@@ -507,13 +507,13 @@ def setupDB():
     try:
         gen_conn=psycopg2.connect("dbname='template1'")
         gen_conn.autocommit = True
-    except Exception, e:
+    except Exception as e:
         print "I am unable to connect to the database."
         exit(1)
 
     try:
         gen_cur = gen_conn.cursor()
-    except Exception, e:
+    except Exception as e:
         gen_conn.close()
         print "I am unable to connect to the database."
         exit(1)
@@ -521,7 +521,7 @@ def setupDB():
     try:
         gen_cur.execute("""DROP DATABASE IF EXISTS \"osm2pgsql-test\"""")
         gen_cur.execute("""CREATE DATABASE \"osm2pgsql-test\" WITH ENCODING 'UTF8'""")
-    except Exception, e:
+    except Exception as e:
         print "Failed to create osm2pgsql-test db" + e.pgerror
         exit(1);
     finally:
@@ -531,13 +531,13 @@ def setupDB():
     try:
         test_conn=psycopg2.connect("dbname='osm2pgsql-test'")
         test_conn.autocommit = True
-    except Exception, e:
+    except Exception as e:
         print "I am unable to connect to the database." + e
         exit(1)
 
     try:
         test_cur = test_conn.cursor()
-    except Exception, e:
+    except Exception as e:
         print "I am unable to connect to the database." + e
         gen_conn.close()
         exit(1)
@@ -558,7 +558,7 @@ def setupDB():
                 print "  sudo /bin/chown postgres.postgres tmp/psql-tablespace"
                 print "  psql -c \"CREATE TABLESPACE tablespacetest LOCATION '/tmp/psql-tablespace'\" postgres"
                 exit(77)
-        except Exception, e:
+        except Exception as e:
             print "Failed to create directory for tablespace" + str(e)
 
         # Check for postgis
@@ -578,7 +578,7 @@ def setupDB():
         # Check for hstore support
         try:
             test_cur.execute("""CREATE EXTENSION hstore;""")
-        except Exception, e:
+        except Exception as e:
             hst = findContribSql('hstore.sql')
             pgscript = open(hst).read()
             test_cur.execute(pgscript)
@@ -593,7 +593,7 @@ def tearDownDB():
         gen_conn=psycopg2.connect("dbname='template1'")
         gen_conn.autocommit = True
         gen_cur = gen_conn.cursor()
-    except Exception, e:
+    except Exception as e:
         print "I am unable to connect to the database."
         exit(1)
 
@@ -601,7 +601,7 @@ def tearDownDB():
         gen_cur.execute("""DROP DATABASE IF EXISTS \"osm2pgsql-test\"""")
         if (created_tablespace == 1):
             gen_cur.execute("""DROP TABLESPACE IF EXISTS \"tablespacetest\"""")
-    except Exception, e:
+    except Exception as e:
         print "Failed to clean up osm2pgsql-test db" + e.pgerror
         exit(1);
 

--- a/tests/test-expire-tiles.cpp
+++ b/tests/test-expire-tiles.cpp
@@ -19,7 +19,7 @@ void run_test(const char* test_name, void (*testfunc)())
         fprintf(stderr, "%s\n", test_name);
         testfunc();
     }
-    catch(std::exception& e)
+    catch(const std::exception& e)
     {
         fprintf(stderr, "%s\n", e.what());
         fprintf(stderr, "FAIL\n");

--- a/tests/test-parse-options.cpp
+++ b/tests/test-parse-options.cpp
@@ -24,7 +24,7 @@ void run_test(const char* test_name, void (*testfunc)())
         fprintf(stderr, "%s\n", test_name);
         testfunc();
     }
-    catch(std::exception& e)
+    catch(const std::exception& e)
     {
         fprintf(stderr, "%s\n", e.what());
         fprintf(stderr, "FAIL\n");
@@ -40,7 +40,7 @@ void parse_fail(const int argc, const char* argv[], const std::string& fail_mess
         options_t options = options_t::parse(argc, const_cast<char **>(argv));
         throw std::logic_error((boost::format("Expected '%1%'") % fail_message).str());
     }
-    catch(std::runtime_error& e)
+    catch(const std::runtime_error& e)
     {
         if(!alg::icontains(e.what(), fail_message))
             throw std::logic_error((boost::format("Expected '%1%' but instead got '%2%'") % fail_message % e.what()).str());
@@ -125,7 +125,7 @@ void test_outputs()
         out = outs.front().get();
         throw std::logic_error("Expected 'not recognised'");
     }
-    catch(std::runtime_error& e)
+    catch(const std::runtime_error& e)
     {
         if(!alg::icontains(e.what(), "not recognised"))
             throw std::logic_error((boost::format("Expected 'not recognised' but instead got '%2%'") % e.what()).str());

--- a/tests/test-pgsql-escape.cpp
+++ b/tests/test-pgsql-escape.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "pgsql.hpp"
 
 void test_escape(const char *in, const char *out) {


### PR DESCRIPTION
Mainly memory issues, heap corruptions.
But also non-standard VLA usages, ::qsort vs std::sort and minor issues.