### PR TITLE
Don't analyze before copying tables

### DIFF
--- a/table.cpp
+++ b/table.cpp
@@ -218,8 +218,6 @@ void table_t::stop()
         time(&start);
 
         fprintf(stderr, "Sorting data and creating indexes for %s\n", name.c_str());
-        pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("ANALYZE %1%") % name).str());
-        fprintf(stderr, "Analyzing %s finished\n", name.c_str());
 
         // Special handling for empty geometries because geohash chokes on
         // empty geometries on postgis 1.5.


### PR DESCRIPTION
osm2pgsql was running analyze twice on tables, once before indexes
and copying tables, once after. This first analyze wasn't needed.
The copying to new tables always runs a sequential scan, and
the index creation doesn't depend on planner statistics and also
forces a sequential scan of the table.

An analyze is run later on before osm2pgsql exits.