### PR TITLE
disable way-node index for gazetteer output

### DIFF
--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -94,6 +94,7 @@ private:
     struct table_desc *node_table, *way_table, *rel_table;
 
     int Append;
+    bool mark_pending;
 
     boost::shared_ptr<node_ram_cache> cache;
     boost::shared_ptr<node_persistent_cache> persistent_cache;


### PR DESCRIPTION
Gazetteer never supported marking of objects with changed nodes.
Now way lookup from nodes is no longer needed by the indexing
process either. Therefore disable the index and also marking of
pending ways and relations.