### PR TITLE
Do not forcefully delete created_by and source tags

### DIFF
--- a/parse-o5m.cpp
+++ b/parse-o5m.cpp
@@ -913,15 +913,13 @@ return 1;
         char* k,*v,*p;
 
         str_read(&bufp,&k,&v);
-        if(strcmp(k,"created_by") && strcmp(k,"source")) {
-          p= k;
-          while(*p!=0) {
-            if(*p==' ') *p= '_';
-            /* replace all blanks in key by underlines */
-            p++;
-            }
-          tags.addItem(k,v,false);
+        p= k;
+        while(*p!=0) {
+          if(*p==' ') *p= '_';
+          /* replace all blanks in key by underlines */
+          p++;
           }
+        tags.addItem(k,v,false);
       }  /* end   for all tags of this object */
 
       /* write object into database */

--- a/parse-pbf.cpp
+++ b/parse-pbf.cpp
@@ -176,10 +176,6 @@ int addProtobufItem(struct keyval *head, ProtobufCBinaryData key, ProtobufCBinar
 
   assert(keystr.find('\0') == std::string::npos);
 
-  /* drop certain keys (matching parse-xml2) */
-  if ((keystr == "created_by") || (keystr == "source"))
-    return 0;
-
   std::string valstr((const char *) val.data, val.len);
 
   assert(valstr.find('\0') == std::string::npos);

--- a/parse-xml2.cpp
+++ b/parse-xml2.cpp
@@ -172,19 +172,16 @@ void parse_xml2_t::StartElement(xmlTextReaderPtr reader, const xmlChar *name, st
     xk = xmlTextReaderGetAttribute(reader, BAD_CAST "k");
     assert(xk);
 
-    /* 'created_by' and 'source' are common and not interesting to mapnik renderer */
-    if (strcmp((char *)xk, "created_by") && strcmp((char *)xk, "source")) {
-      char *p;
-      xv = xmlTextReaderGetAttribute(reader, BAD_CAST "v");
-      assert(xv);
-      k  = (char *)xmlStrdup(xk);
-      while ((p = strchr(k, ' ')))
-        *p = '_';
+    char *p;
+    xv = xmlTextReaderGetAttribute(reader, BAD_CAST "v");
+    assert(xv);
+    k  = (char *)xmlStrdup(xk);
+    while ((p = strchr(k, ' ')))
+      *p = '_';
 
-      tags.addItem(k, (char *)xv, 0);
-      xmlFree(k);
-      xmlFree(xv);
-    }
+    tags.addItem(k, (char *)xv, 0);
+    xmlFree(k);
+    xmlFree(xv);
     xmlFree(xk);
   } else if (xmlStrEqual(name, BAD_CAST "nd")) {
       xid  = xmlTextReaderGetAttribute(reader, BAD_CAST "ref");


### PR DESCRIPTION
OSM PostGIS databases are used not only for Mapnik. Some tools need tags like `source`. Most styles already have these keys in "delete" lists, so it won't change much.

Fixes #130.