### PR TITLE
convert pending_job_t to a simple struct

### DIFF
--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -185,9 +185,9 @@ struct pending_threaded_processor : public middle_t::pending_processor {
 
             //process it
             if(ways)
-                outputs.at(job.second)->pending_way(job.first, append);
+                outputs.at(job.output_id)->pending_way(job.osm_id, append);
             else
-                outputs.at(job.second)->pending_relation(job.first, append);
+                outputs.at(job.output_id)->pending_relation(job.osm_id, append);
 
             mutex.lock();
             ++ids_done;
@@ -199,9 +199,9 @@ struct pending_threaded_processor : public middle_t::pending_processor {
         pending_job_t job;
         while (queue.pop(job)) {
             if(ways)
-                outputs.at(job.second)->pending_way(job.first, append);
+                outputs.at(job.output_id)->pending_way(job.osm_id, append);
             else
-                outputs.at(job.second)->pending_relation(job.first, append);
+                outputs.at(job.output_id)->pending_relation(job.osm_id, append);
             ++ids_done;
         }
     }

--- a/output.hpp
+++ b/output.hpp
@@ -19,7 +19,14 @@
 
 #include <utility>
 
-typedef std::pair<osmid_t, size_t> pending_job_t;
+struct pending_job_t {
+    osmid_t osm_id;
+    size_t  output_id;
+
+    pending_job_t() : osm_id(0), output_id(0) {}
+    pending_job_t(osmid_t id, size_t oid) : osm_id(id), output_id(oid) {}
+};
+
 #ifndef HAVE_LOCKFREE
 #include <stack>
 typedef std::stack<pending_job_t> pending_queue_t;


### PR DESCRIPTION
The lockfree queue requires a trivially assignable type which std::pair isn't, see #196.

I've confirmed that it compiles successfully against libc++ but could not actually run the tests because I don't have a clang-compiled boost available. Could somebody on OSX or FreeBSD check that this works?

cc @springmeyer 