### PR TITLE
Fix incorrect resizing of node cache in geometry processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ tests/test-middle-pgsql
 tests/test-pgsql-escape
 tests/test-parse-options
 tests/test-output-multi-line
+tests/test-output-multi-line-storage
 tests/test-output-multi-point
 tests/test-output-multi-point-multi-table
 tests/test-output-multi-polygon

--- a/Makefile.am
+++ b/Makefile.am
@@ -81,6 +81,7 @@ check_PROGRAMS = \
 	tests/test-middle-ram \
 	tests/test-middle-pgsql \
 	tests/test-output-multi-line \
+	tests/test-output-multi-line-storage \
 	tests/test-output-multi-point \
 	tests/test-output-multi-point-multi-table \
 	tests/test-output-multi-polygon \
@@ -97,6 +98,8 @@ tests_test_middle_pgsql_SOURCES = tests/test-middle-pgsql.cpp tests/middle-tests
 tests_test_middle_pgsql_LDADD = libosm2pgsql.la
 tests_test_output_multi_line_SOURCES = tests/test-output-multi-line.cpp tests/common-pg.cpp
 tests_test_output_multi_line_LDADD = libosm2pgsql.la
+tests_test_output_multi_line_storage_SOURCES = tests/test-output-multi-line-storage.cpp tests/common-pg.cpp
+tests_test_output_multi_line_storage_LDADD = libosm2pgsql.la
 tests_test_output_multi_point_SOURCES = tests/test-output-multi-point.cpp tests/common-pg.cpp
 tests_test_output_multi_point_LDADD = libosm2pgsql.la
 tests_test_output_multi_point_multi_table_SOURCES = tests/test-output-multi-point-multi-table.cpp tests/common-pg.cpp
@@ -159,6 +162,7 @@ tests_test_parse_xml2_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_middle_ram_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_middle_pgsql_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_output_multi_line_LDADD += $(GLOBAL_LDFLAGS)
+tests_test_output_multi_line_storage_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_output_multi_point_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_output_multi_point_multi_table_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_output_multi_polygon_LDADD += $(GLOBAL_LDFLAGS)

--- a/geometry-processor.cpp
+++ b/geometry-processor.cpp
@@ -75,11 +75,12 @@ way_helper::~way_helper()
 }
 size_t way_helper::set(const osmid_t *node_ids, size_t node_count, const middle_query_t *mid)
 {
-    //if we don't have enough space already get more
-    if(node_cache.size() < node_count)
-        node_cache.resize(node_count);
-    //get the node data
-    mid->nodes_get_list(&node_cache.front(), node_ids, node_count);
+    // other parts of the code assume that the node cache is the size of the way
+    // TODO: Fix this, and use std::vector everywhere
+    node_cache.resize(node_count);
+    // get the node data, and resize the node cache in case there were missing nodes
+    node_cache.resize(mid->nodes_get_list(&node_cache.front(), node_ids, node_count));
+    // equivalent to returning node_count for complete ways, different for partial extractsx
     return node_cache.size();
 }
 

--- a/tests/test-output-multi-line-storage.cpp
+++ b/tests/test-output-multi-line-storage.cpp
@@ -1,0 +1,111 @@
+#include <iostream>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <cassert>
+#include <sstream>
+#include <stdexcept>
+#include <memory>
+
+#include "osmtypes.hpp"
+#include "middle.hpp"
+#include "output-multi.hpp"
+#include "options.hpp"
+#include "middle-pgsql.hpp"
+#include "taginfo_impl.hpp"
+#include "parse.hpp"
+
+#include <libpq-fe.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <boost/scoped_ptr.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include "tests/middle-tests.hpp"
+#include "tests/common-pg.hpp"
+
+void check_count(pg::conn_ptr &conn, int expected, const std::string &query) {
+    pg::result_ptr res = conn->exec(query);
+
+    int ntuples = PQntuples(res->get());
+    if (ntuples != 1) {
+        throw std::runtime_error((boost::format("Expected only one tuple from a query "
+                                                "to check COUNT(*), but got %1%. Query "
+                                                "was: %2%.")
+                                  % ntuples % query).str());
+    }
+
+    std::string numstr = PQgetvalue(res->get(), 0, 0);
+    int count = boost::lexical_cast<int>(numstr);
+
+    if (count != expected) {
+        throw std::runtime_error((boost::format("Expected %1%, but got %2%, when running "
+                                                "query: %3%.")
+                                  % expected % count % query).str());
+    }
+}
+
+int main(int argc, char *argv[]) {
+    boost::scoped_ptr<pg::tempdb> db;
+
+    try {
+        db.reset(new pg::tempdb);
+    } catch (const std::exception &e) {
+        std::cerr << "Unable to setup database: " << e.what() << "\n";
+        return 77; // <-- code to skip this test.
+    }
+
+    try {
+        options_t options;
+        options.conninfo = db->conninfo().c_str();
+        options.num_procs = 1;
+        options.slim = 1;
+
+        options.projection.reset(new reprojection(PROJ_LATLONG));
+
+        options.output_backend = "multi";
+        options.style = "tests/test_output_multi_line_trivial.style.json";
+
+        //setup the front (input)
+        parse_delegate_t parser(options.extra_attributes, options.bbox, options.projection);
+
+        //setup the middle
+        boost::shared_ptr<middle_t> middle = middle_t::create_middle(options.slim);
+
+        //setup the backend (output)
+        std::vector<boost::shared_ptr<output_t> > outputs = output_t::create_outputs(middle.get(), options);
+
+        //let osmdata orchestrate between the middle and the outs
+        osmdata_t osmdata(middle, outputs);
+
+        osmdata.start();
+
+        if (parser.streamFile("libxml2", "tests/test_output_multi_line_storage.osm", options.sanitize, &osmdata) != 0) {
+            throw std::runtime_error("Unable to read input file `tests/test_output_multi_line_storage.osm'.");
+        }
+
+        osmdata.stop();
+
+        // start a new connection to run tests on
+        pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+
+        check_count(test_conn, 1, "select count(*) from pg_catalog.pg_class where relname = 'test_line'");
+        check_count(test_conn, 3, "select count(*) from test_line");
+
+        //check that we have the number of vertexes in each linestring
+        check_count(test_conn, 3, "SELECT ST_NumPoints(way) FROM test_line WHERE osm_id = 1");
+        check_count(test_conn, 2, "SELECT ST_NumPoints(way) FROM test_line WHERE osm_id = 2");
+        check_count(test_conn, 2, "SELECT ST_NumPoints(way) FROM test_line WHERE osm_id = 3");
+
+        return 0;
+
+    } catch (const std::exception &e) {
+        std::cerr << "ERROR: " << e.what() << std::endl;
+
+    } catch (...) {
+        std::cerr << "UNKNOWN ERROR" << std::endl;
+    }
+
+    return 1;
+}

--- a/tests/test_output_multi_line_storage.osm
+++ b/tests/test_output_multi_line_storage.osm
@@ -1,0 +1,35 @@
+<osm version="0.6">
+<!--
+  This file should create three ways which look like
+  6_____8
+
+  4___5
+
+        3
+       /
+  1___2
+
+  Node 7 is missing
+-->
+ <node id="1" lat="49.00" lon="-123.00"/>
+ <node id="2" lat="49.00" lon="-123.01"/>
+ <node id="3" lat="49.01" lon="-123.02"/>
+ <node id="4" lat="49.02" lon="-123.00"/>
+ <node id="5" lat="49.02" lon="-123.01"/>
+ <node id="6" lat="49.03" lon="-123.00"/>
+ <node id="8" lat="49.03" lon="-123.02"/>
+ <way id="1">
+  <nd ref="1"/>
+  <nd ref="2"/>
+  <nd ref="3"/>
+ </way>
+ <way id="2">
+  <nd ref="4"/>
+  <nd ref="5"/>
+ </way>
+ <way id="3">
+  <nd ref="6"/>
+  <nd ref="7"/>
+  <nd ref="8"/>
+ </way>
+</osm>

--- a/tests/test_output_multi_line_trivial.lua
+++ b/tests/test_output_multi_line_trivial.lua
@@ -1,0 +1,10 @@
+function drop_all (...)
+  return 1, {}
+end
+
+-- A generic way to process ways, given a function which determines if tags are interesting
+-- Takes an optional function to process tags. Always says it's a polygon if there's matching tags
+function test_ways (kv, num_keys)
+  tags = {}
+  return 0, tags, 1, 0
+end

--- a/tests/test_output_multi_line_trivial.style.json
+++ b/tests/test_output_multi_line_trivial.style.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "test_line",
+    "type": "line",
+    "tagtransform": "tests/test_output_multi_line_trivial.lua",
+    "tagtransform-node-function": "drop_all",
+    "tagtransform-way-function": "test_ways",
+    "tagtransform-relation-function": "drop_all",
+    "tagtransform-relation-member-function": "drop_all",
+    "tags": [
+      {"name": "foo", "type": "text"}
+    ]
+  }
+]


### PR DESCRIPTION
This is the quick fix to #274, but includes a testcase.

With the testcase, fixing it properly would make a reasonable place for someone to start with osm2pgsql.