### PR TITLE
Fix a bug where modified tags weren't being copied from Lua

### DIFF
--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -317,7 +317,7 @@ int output_multi_t::process_way(osmid_t id, const idlist_t &nodes, const taglist
                     m_expire->from_nodes_poly(m_way_helper.node_cache, id);
                 else
                     m_expire->from_nodes_line(m_way_helper.node_cache);
-                copy_to_table(id, wkt->geom.c_str(), tags);
+                copy_to_table(id, wkt->geom.c_str(), outtags);
             }
         }
     }

--- a/tests/test-output-multi-line-storage.cpp
+++ b/tests/test-output-multi-line-storage.cpp
@@ -98,6 +98,7 @@ int main(int argc, char *argv[]) {
         check_count(test_conn, 2, "SELECT ST_NumPoints(way) FROM test_line WHERE osm_id = 2");
         check_count(test_conn, 2, "SELECT ST_NumPoints(way) FROM test_line WHERE osm_id = 3");
 
+        check_count(test_conn, 3, "SELECT COUNT(*) FROM test_line WHERE foo = 'bar'");
         return 0;
 
     } catch (const std::exception &e) {

--- a/tests/test_output_multi_line_trivial.lua
+++ b/tests/test_output_multi_line_trivial.lua
@@ -5,6 +5,6 @@ end
 -- A generic way to process ways, given a function which determines if tags are interesting
 -- Takes an optional function to process tags. Always says it's a polygon if there's matching tags
 function test_ways (kv, num_keys)
-  tags = {}
+  tags = {["foo"] = "bar"}
   return 0, tags, 1, 0
 end


### PR DESCRIPTION
This fixes a regression in the std::vector changes and adds a test to fix a bug in checking #273.

The testcase is minimal, as nodes worked and should really be independently tested, as well as pgsql lua.