### PR TITLE
Fix multi tags redeclaration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ tests/test-output-multi-line-storage
 tests/test-output-multi-point
 tests/test-output-multi-point-multi-table
 tests/test-output-multi-polygon
+tests/test-output-multi-poly-trivial
 tests/test-output-pgsql
 tests/test-expire-tiles
 tests/*.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,6 +84,7 @@ check_PROGRAMS = \
 	tests/test-output-multi-point \
 	tests/test-output-multi-point-multi-table \
 	tests/test-output-multi-polygon \
+	tests/test-output-multi-poly-trivial \
 	tests/test-output-pgsql \
 	tests/test-pgsql-escape \
 	tests/test-parse-options \
@@ -107,6 +108,8 @@ tests_test_output_multi_point_multi_table_SOURCES = tests/test-output-multi-poin
 tests_test_output_multi_point_multi_table_LDADD = libosm2pgsql.la
 tests_test_output_multi_polygon_SOURCES = tests/test-output-multi-polygon.cpp tests/common-pg.cpp
 tests_test_output_multi_polygon_LDADD = libosm2pgsql.la
+tests_test_output_multi_poly_trivial_SOURCES = tests/test-output-multi-poly-trivial.cpp tests/common-pg.cpp
+tests_test_output_multi_poly_trivial_LDADD = libosm2pgsql.la
 tests_test_output_pgsql_SOURCES = tests/test-output-pgsql.cpp tests/common-pg.cpp
 tests_test_output_pgsql_LDADD = libosm2pgsql.la
 tests_test_pgsql_escape_SOURCES = tests/test-pgsql-escape.cpp
@@ -168,6 +171,7 @@ tests_test_output_multi_line_storage_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_output_multi_point_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_output_multi_point_multi_table_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_output_multi_polygon_LDADD += $(GLOBAL_LDFLAGS)
+tests_test_output_multi_poly_trivial_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_output_pgsql_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_pgsql_escape_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_parse_options_LDADD += $(GLOBAL_LDFLAGS)

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -331,9 +331,9 @@ int output_multi_t::process_relation(osmid_t id, const memberlist_t &members,
         relation_delete(id);
 
     //does this relation have anything interesting to us
-    taglist_t outtags;
+    taglist_t rel_outtags;
     unsigned filter = m_tagtransform->filter_rel_tags(tags, *m_export_list.get(),
-                                                      outtags, true);
+                                                      rel_outtags, true);
     if (!filter) {
         //TODO: move this into geometry processor, figure a way to come back for tag transform
         //grab ways/nodes of the members in the relation, bail if none were used
@@ -364,7 +364,7 @@ int output_multi_t::process_relation(osmid_t id, const memberlist_t &members,
         //all this trickery
         int make_boundary, make_polygon = 1;
         taglist_t outtags;
-        filter = m_tagtransform->filter_rel_member_tags(tags, filtered, m_relation_helper.roles,
+        filter = m_tagtransform->filter_rel_member_tags(rel_outtags, filtered, m_relation_helper.roles,
                                                         &m_relation_helper.superseeded.front(),
                                                         &make_boundary, &make_polygon, &roads,
                                                         *m_export_list.get(), outtags, true);

--- a/tests/test-output-multi-poly-trivial.cpp
+++ b/tests/test-output-multi-poly-trivial.cpp
@@ -95,7 +95,9 @@ void check_output_poly_trivial(int enable_multi, std::string conninfo) {
     check_count(test_conn, 1, "select count(*) from test_poly where foo='bar'");
     check_count(test_conn, 1, "select count(*) from test_poly where bar='baz'");
 
-    // this should be a 2-pointed multipolygon
+    // there should be two 5-pointed polygons in the multipolygon (note that
+    // it's 5 points including the duplicated first/last point)
+    check_count(test_conn, 2, "select count(*) from (select (st_dump(way)).geom as way from test_poly) x");
     check_count(test_conn, 5, "select distinct st_numpoints(st_exteriorring(way)) from (select (st_dump(way)).geom as way from test_poly) x");
 
   } else {
@@ -103,7 +105,8 @@ void check_output_poly_trivial(int enable_multi, std::string conninfo) {
     check_count(test_conn, 2, "select count(*) from test_poly where foo='bar'");
     check_count(test_conn, 2, "select count(*) from test_poly where bar='baz'");
 
-    // although there are 2 rows, they should both be 4-pointed polygons
+    // although there are 2 rows, they should both be 5-pointed polygons (note
+    // that it's 5 points including the duplicated first/last point)
     check_count(test_conn, 5, "select distinct st_numpoints(st_exteriorring(way)) from test_poly");
   }
 }

--- a/tests/test-output-multi-poly-trivial.cpp
+++ b/tests/test-output-multi-poly-trivial.cpp
@@ -1,0 +1,132 @@
+#include <iostream>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <cassert>
+#include <sstream>
+#include <stdexcept>
+#include <memory>
+
+#include "osmtypes.hpp"
+#include "middle.hpp"
+#include "output-multi.hpp"
+#include "options.hpp"
+#include "middle-pgsql.hpp"
+#include "taginfo_impl.hpp"
+#include "parse.hpp"
+
+#include <libpq-fe.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <boost/scoped_ptr.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include "tests/middle-tests.hpp"
+#include "tests/common-pg.hpp"
+
+void check_count(pg::conn_ptr &conn, int expected, const std::string &query) {
+    pg::result_ptr res = conn->exec(query);
+
+    int ntuples = PQntuples(res->get());
+    if (ntuples != 1) {
+        throw std::runtime_error((boost::format("Expected only one tuple from a query "
+                                                "to check COUNT(*), but got %1%. Query "
+                                                "was: %2%.")
+                                  % ntuples % query).str());
+    }
+
+    std::string numstr = PQgetvalue(res->get(), 0, 0);
+    int count = boost::lexical_cast<int>(numstr);
+
+    if (count != expected) {
+        throw std::runtime_error((boost::format("Expected %1%, but got %2%, when running "
+                                                "query: %3%.")
+                                  % expected % count % query).str());
+    }
+}
+
+void run_osm2pgsql(options_t &options) {
+  //setup the front (input)
+  parse_delegate_t parser(options.extra_attributes, options.bbox, options.projection);
+
+  //setup the middle
+  boost::shared_ptr<middle_t> middle = middle_t::create_middle(options.slim);
+
+  //setup the backend (output)
+  std::vector<boost::shared_ptr<output_t> > outputs = output_t::create_outputs(middle.get(), options);
+
+  //let osmdata orchestrate between the middle and the outs
+  osmdata_t osmdata(middle, outputs);
+
+  osmdata.start();
+
+  if (parser.streamFile("libxml2", "tests/test_output_multi_poly_trivial.osm", options.sanitize, &osmdata) != 0) {
+    throw std::runtime_error("Unable to read input file `tests/test_output_multi_poly_trivial.osm'.");
+  }
+
+  osmdata.stop();
+}
+
+void check_output_poly_trivial(int enable_multi, std::string conninfo) {
+  options_t options;
+  options.conninfo = conninfo.c_str();
+  options.num_procs = 1;
+  options.slim = 1;
+  options.enable_multi = enable_multi;
+
+  options.projection.reset(new reprojection(PROJ_LATLONG));
+
+  options.output_backend = "multi";
+  options.style = "tests/test_output_multi_poly_trivial.style.json";
+
+  run_osm2pgsql(options);
+
+  // start a new connection to run tests on
+  pg::conn_ptr test_conn = pg::conn::connect(conninfo);
+
+  // expect that the table exists
+  check_count(test_conn, 1, "select count(*) from pg_catalog.pg_class where relname = 'test_poly'");
+
+  // expect 2 polygons if not in multi(geometry) mode, or 1 if multi(geometry)
+  // mode is enabled.
+  if (enable_multi) {
+    check_count(test_conn, 1, "select count(*) from test_poly");
+    check_count(test_conn, 1, "select count(*) from test_poly where foo='bar'");
+
+    // this should be a 2-pointed multipolygon
+    check_count(test_conn, 5, "select distinct st_numpoints(st_exteriorring(way)) from (select (st_dump(way)).geom as way from test_poly) x");
+
+  } else {
+    check_count(test_conn, 2, "select count(*) from test_poly");
+    check_count(test_conn, 2, "select count(*) from test_poly where foo='bar'");
+
+    // although there are 2 rows, they should both be 4-pointed polygons
+    check_count(test_conn, 5, "select distinct st_numpoints(st_exteriorring(way)) from test_poly");
+  }
+}
+
+int main(int argc, char *argv[]) {
+    boost::scoped_ptr<pg::tempdb> db;
+
+    try {
+        db.reset(new pg::tempdb);
+    } catch (const std::exception &e) {
+        std::cerr << "Unable to setup database: " << e.what() << "\n";
+        return 77; // <-- code to skip this test.
+    }
+
+    try {
+        check_output_poly_trivial(0, db->conninfo());
+        check_output_poly_trivial(1, db->conninfo());
+        return 0;
+
+    } catch (const std::exception &e) {
+        std::cerr << "ERROR: " << e.what() << std::endl;
+
+    } catch (...) {
+        std::cerr << "UNKNOWN ERROR" << std::endl;
+    }
+
+    return 1;
+}

--- a/tests/test-output-multi-poly-trivial.cpp
+++ b/tests/test-output-multi-poly-trivial.cpp
@@ -93,6 +93,7 @@ void check_output_poly_trivial(int enable_multi, std::string conninfo) {
   if (enable_multi) {
     check_count(test_conn, 1, "select count(*) from test_poly");
     check_count(test_conn, 1, "select count(*) from test_poly where foo='bar'");
+    check_count(test_conn, 1, "select count(*) from test_poly where bar='baz'");
 
     // this should be a 2-pointed multipolygon
     check_count(test_conn, 5, "select distinct st_numpoints(st_exteriorring(way)) from (select (st_dump(way)).geom as way from test_poly) x");
@@ -100,6 +101,7 @@ void check_output_poly_trivial(int enable_multi, std::string conninfo) {
   } else {
     check_count(test_conn, 2, "select count(*) from test_poly");
     check_count(test_conn, 2, "select count(*) from test_poly where foo='bar'");
+    check_count(test_conn, 2, "select count(*) from test_poly where bar='baz'");
 
     // although there are 2 rows, they should both be 4-pointed polygons
     check_count(test_conn, 5, "select distinct st_numpoints(st_exteriorring(way)) from test_poly");

--- a/tests/test_output_multi_poly_trivial.lua
+++ b/tests/test_output_multi_poly_trivial.lua
@@ -1,0 +1,23 @@
+function drop_all (...)
+  return 1, {}
+end
+
+function drop_ways (...)
+  return 1, {}, 0, 0
+end
+
+function test_rels (kv, num_keys)
+  tags = {["foo"] = "bar"}
+  return 0, tags
+end
+
+function test_members (kv, member_tags, roles, num_members)
+  membersuperseeded = {}
+  for i = 1, num_members do
+    membersuperseeded[i] = 0
+  end
+
+  tags = kv
+
+  return 0, tags, membersuperseeded, 0, 0, 0
+end

--- a/tests/test_output_multi_poly_trivial.lua
+++ b/tests/test_output_multi_poly_trivial.lua
@@ -18,6 +18,7 @@ function test_members (kv, member_tags, roles, num_members)
   end
 
   tags = kv
+  tags["bar"] = "baz"
 
   return 0, tags, membersuperseeded, 0, 0, 0
 end

--- a/tests/test_output_multi_poly_trivial.osm
+++ b/tests/test_output_multi_poly_trivial.osm
@@ -10,14 +10,14 @@
 this file defines the above nodes, ways and a relation
 which contains both w1 and w2.
 -->
-  <node id="1" lon="0" lat="1"/>
-  <node id="2" lon="1" lat="1"/>
-  <node id="3" lon="2" lat="1"/>
-  <node id="4" lon="3" lat="1"/>
-  <node id="5" lon="0" lat="0"/>
-  <node id="6" lon="1" lat="0"/>
-  <node id="7" lon="2" lat="0"/>
-  <node id="8" lon="3" lat="0"/>
+  <node id="1" lon="0" lat="2"/>
+  <node id="2" lon="1" lat="2"/>
+  <node id="3" lon="2" lat="2"/>
+  <node id="4" lon="3" lat="2"/>
+  <node id="5" lon="0" lat="1"/>
+  <node id="6" lon="1" lat="1"/>
+  <node id="7" lon="2" lat="1"/>
+  <node id="8" lon="3" lat="1"/>
   <way id="1">
     <nd ref="1"/>
     <nd ref="2"/>

--- a/tests/test_output_multi_poly_trivial.osm
+++ b/tests/test_output_multi_poly_trivial.osm
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<osm version="0.6">
+<!--
+
+   1_____2     3_____4
+   |     |     |     |
+   |  w1 |     | w2  |
+   5_____6     7_____8
+
+this file defines the above nodes, ways and a relation
+which contains both w1 and w2.
+-->
+  <node id="1" lon="0" lat="1"/>
+  <node id="2" lon="1" lat="1"/>
+  <node id="3" lon="2" lat="1"/>
+  <node id="4" lon="3" lat="1"/>
+  <node id="5" lon="0" lat="0"/>
+  <node id="6" lon="1" lat="0"/>
+  <node id="7" lon="2" lat="0"/>
+  <node id="8" lon="3" lat="0"/>
+  <way id="1">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="6"/>
+    <nd ref="5"/>
+    <nd ref="1"/>
+  </way>
+  <way id="2">
+    <nd ref="3"/>
+    <nd ref="4"/>
+    <nd ref="8"/>
+    <nd ref="7"/>
+    <nd ref="3"/>
+  </way>
+  <relation id="1">
+    <member type="way" ref="1" role=""/>
+    <member type="way" ref="2" role=""/>
+  </relation>
+</osm>

--- a/tests/test_output_multi_poly_trivial.style.json
+++ b/tests/test_output_multi_poly_trivial.style.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "test_poly",
+    "type": "polygon",
+    "tagtransform": "tests/test_output_multi_poly_trivial.lua",
+    "tagtransform-node-function": "drop_all",
+    "tagtransform-way-function": "drop_ways",
+    "tagtransform-relation-function": "test_rels",
+    "tagtransform-relation-member-function": "test_members",
+    "tags": [
+      {"name": "foo", "type": "text"}
+    ]
+  }
+]

--- a/tests/test_output_multi_poly_trivial.style.json
+++ b/tests/test_output_multi_poly_trivial.style.json
@@ -8,7 +8,8 @@
     "tagtransform-relation-function": "test_rels",
     "tagtransform-relation-member-function": "test_members",
     "tags": [
-      {"name": "foo", "type": "text"}
+      {"name": "foo", "type": "text"},
+      {"name": "bar", "type": "text"}
     ]
   }
 ]


### PR DESCRIPTION
I think this is a fix for #336 - the re-use of `outtags` and passing the original relation tags to the member filter function rather than the previously filtered tags seems to have been causing missing tag values under some circumstances. Since this type of tag mangling is pretty common in multi-polygon processing, it's fairly likely that some missing tags would be fixed by this.

Also added a new test case which (hopefully) encapsulates the expected behaviour.
