### PR TITLE
Include iostream from test-pgsql-escape.cpp

### DIFF
--- a/tests/test-pgsql-escape.cpp
+++ b/tests/test-pgsql-escape.cpp
@@ -1,5 +1,6 @@
 #include "pgsql.hpp"
 
+#include <iostream>
 void test_escape(const char *in, const char *out) {
     std::string sql;
     escape(in, sql);


### PR DESCRIPTION
Fixes a compilation error with `make check` found on Centos.