### PR TITLE
Set polygon/linestring differently for some key values differently than the key in default style.lua 

### DIFF
--- a/stamp-h1
+++ b/stamp-h1
@@ -1,0 +1,1 @@
+timestamp for config.h

--- a/stamp-h1
+++ b/stamp-h1
@@ -1,1 +1,0 @@
-timestamp for config.h

--- a/style.lua
+++ b/style.lua
@@ -8,7 +8,8 @@ polygon_keys = { 'building', 'landuse', 'amenity', 'harbour', 'historic', 'leisu
 
 -- Objects with any of the following key/value combinations will be treated as polygon
 polygon_values = {
-      {'highway', 'services'}
+      {'highway', 'services'},
+      {'junction', 'yes'}
    }
 
 -- Objects with any of the following key/value combinations will be treated as linestring

--- a/style.lua
+++ b/style.lua
@@ -14,6 +14,7 @@ polygon_values = {
 
 -- Objects with any of the following key/value combinations will be treated as linestring
 linestring_values = {
+      {'leisure', 'track'},
       {'man_made', 'embankment'},
       {'man_made', 'breakwater'},
       {'man_made', 'groyne'},

--- a/style.lua
+++ b/style.lua
@@ -7,14 +7,28 @@ polygon_keys = { 'building', 'landuse', 'amenity', 'harbour', 'historic', 'leisu
       'wetland', 'water', 'aeroway' }
 
 -- Objects with any of the following key/value combinations will be treated as polygon
-polygon_values = {highway='services'}
+polygon_values = {
+      {'highway', 'services'}
+   }
 
 -- Objects with any of the following key/value combinations will be treated as linestring
-linestring_values = {man_made='embankment', man_made='breakwater', man_made='groyne',
-      natural='cliff', natural='tree_row', historic='citywalls',  waterway='derelict_canal',
-      waterway='ditch', waterway='drain', waterway='river', waterway='stream', waterway='wadi',
-      waterway='weir', power='line', power='minor_line'
-      }
+linestring_values = {
+      {'man_made', 'embankment'},
+      {'man_made', 'breakwater'},
+      {'man_made', 'groyne'},
+      {'natural', 'cliff'},
+      {'natural', 'tree_row'},
+      {'historic', 'citywalls'},
+      {'waterway', 'derelict_canal'},
+      {'waterway', 'ditch'},
+      {'waterway', 'drain'},
+      {'waterway', 'river'},
+      {'waterway', 'stream'},
+      {'waterway', 'wadi'},
+      {'waterway', 'weir'},
+      {'power', 'line'},
+      {'power', 'minor_line'}
+   }
 
 -- Objects without any of the following keys will be deleted
 generic_keys = {'access','addr:housename','addr:housenumber','addr:interpolation','admin_level','aerialway','aeroway','amenity','area','barrier',
@@ -129,7 +143,7 @@ function filter_tags_way (keyvalues, numberofkeys)
       return filter, keyvalues, polygon, roads
    end
 
-  -- Treat objects with a key in polygon_keys as polygon
+   -- Treat objects with a key in polygon_keys as polygon
    for i,k in ipairs(polygon_keys) do
       if keyvalues[k] then
          polygon=1
@@ -137,17 +151,17 @@ function filter_tags_way (keyvalues, numberofkeys)
       end
    end
 
-  -- Treat objects with a key/value combination in polygon_values as polygon
-   for k,v in pairs(polygon_values) do
-      if keyvalues[k] == v then
+   -- Treat objects with a key/value combination in polygon_values as polygon
+   for index,tag in pairs(polygon_values) do
+      if keyvalues[tag[1]] == tag[2] then
          polygon=1
          break
       end
    end
 
   -- Treat objects with a key/value combination in linestring_values not as polygon
-   for k,v in pairs(linestring_values) do
-      if keyvalues[k] == v then
+   for index,tag in pairs(linestring_values) do
+      if keyvalues[tag[1]] == tag[2] then
          polygon=0
          break
       end
@@ -202,14 +216,14 @@ function filter_tags_relation_member (keyvalues, keyvaluemembers, roles, memberc
          end
       end
       -- Then add key/value combinations in polygon_values
-      for k,v in pairs(polygon_values) do
-         if keyvalues[k] == v then
+      for index,tag in pairs(polygon_values) do
+         if keyvalues[tag[1]] == tag[2] then
             polytagcount = polytagcount + 1
          end
       end
       -- Then substract key/value combinations in linestring_values
-      for k,v in pairs(linestring_values) do
-         if keyvalues[k] == v then
+      for index,tag in pairs(linestring_values) do
+         if keyvalues[tag[1]] == tag[2] then
             polytagcount = polytagcount - 1
          end
       end

--- a/style.lua
+++ b/style.lua
@@ -10,7 +10,11 @@ polygon_keys = { 'building', 'landuse', 'amenity', 'harbour', 'historic', 'leisu
 polygon_values = {highway='services'}
 
 -- Objects with any of the following key/value combinations will be treated as linestring
-linestring_values = {man_made='embankment', natural='cliff'}
+linestring_values = {man_made='embankment', man_made='breakwater', man_made='groyne',
+      natural='cliff', natural='tree_row', historic='citywalls',  waterway='derelict_canal',
+      waterway='ditch', waterway='drain', waterway='river', waterway='stream', waterway='wadi',
+      waterway='weir', power='line', power='minor_line'
+      }
 
 -- Objects without any of the following keys will be deleted
 generic_keys = {'access','addr:housename','addr:housenumber','addr:interpolation','admin_level','aerialway','aeroway','amenity','area','barrier',

--- a/style.lua
+++ b/style.lua
@@ -146,8 +146,17 @@ function filter_tags_way (keyvalues, numberofkeys)
    -- Treat objects with a key in polygon_keys as polygon
    for i,k in ipairs(polygon_keys) do
       if keyvalues[k] then
-         polygon=1
-         break
+         polygontag = 1
+         -- However, if the key/value combination occurs in linestring_values, do not treat the object as polygon
+         for index,tag in pairs(linestring_values) do
+            if k == tag[1] and keyvalues[k] == tag[2] then
+               polygontag = 0
+               break
+            end
+         end
+         if polygontag == 1 then
+            polygon = 1
+         end
       end
    end
 
@@ -155,14 +164,6 @@ function filter_tags_way (keyvalues, numberofkeys)
    for index,tag in pairs(polygon_values) do
       if keyvalues[tag[1]] == tag[2] then
          polygon=1
-         break
-      end
-   end
-
-  -- Treat objects with a key/value combination in linestring_values not as polygon
-   for index,tag in pairs(linestring_values) do
-      if keyvalues[tag[1]] == tag[2] then
-         polygon=0
          break
       end
    end
@@ -212,19 +213,25 @@ function filter_tags_relation_member (keyvalues, keyvaluemembers, roles, memberc
       -- First count keys in polygon_keys
       for i,k in ipairs(polygon_keys) do
          if keyvalues[k] then
-            polytagcount = polytagcount + 1
+            polygontag = 1
+            -- However, if the key/value combination occurs in linestring_values, do not count the object as polygon
+            for index,tag in pairs(linestring_values) do
+               if k == tag[1] and keyvalues[k] == tag[2] then
+                  polygontag = 0
+                  break
+               end
+            end
+            if polygontag == 1 then
+               polytagcount = polytagcount + 1
+            end
          end
       end
-      -- Then add key/value combinations in polygon_values
+
+      -- Treat objects with a key/value combination in polygon_values as polygon
       for index,tag in pairs(polygon_values) do
          if keyvalues[tag[1]] == tag[2] then
             polytagcount = polytagcount + 1
-         end
-      end
-      -- Then substract key/value combinations in linestring_values
-      for index,tag in pairs(linestring_values) do
-         if keyvalues[tag[1]] == tag[2] then
-            polytagcount = polytagcount - 1
+            break
          end
       end
 

--- a/style.lua
+++ b/style.lua
@@ -212,7 +212,7 @@ function filter_tags_relation_member (keyvalues, keyvaluemembers, roles, memberc
    elseif (type == "multipolygon") then
       -- Treat as polygon
       polygon = 1
-      polytagcount = 0;
+      haspolygontags = false
       -- Count the number of polygon tags
       -- First count keys in polygon_keys
       for i,k in ipairs(polygon_keys) do
@@ -226,17 +226,17 @@ function filter_tags_relation_member (keyvalues, keyvaluemembers, roles, memberc
                end
             end
             if polygontag == 1 then
-               polytagcount = polytagcount + 1
+               haspolygontags = true
                break
             end
          end
       end
 
       -- Treat objects with a key/value combination in polygon_values as polygon
-      if polygon == 0 then
+      if not haspolygontags then
          for index,tag in pairs(polygon_values) do
             if keyvalues[tag[1]] == tag[2] then
-               polytagcount = polytagcount + 1
+               haspolygontags = true
                break
             end
          end
@@ -244,7 +244,7 @@ function filter_tags_relation_member (keyvalues, keyvaluemembers, roles, memberc
 
       -- If the multipolygon has no polygon keys or polygon key/value combinations,
       -- add tags from all outer elements to the multipolygon itself
-      if (polytagcount <= 0) then
+      if not haspolygontags then
          for i = 1,membercount do
             if (roles[i] == "outer") then
                for k,v in pairs(keyvaluemembers[i]) do

--- a/style.lua
+++ b/style.lua
@@ -157,15 +157,18 @@ function filter_tags_way (keyvalues, numberofkeys)
          end
          if polygontag == 1 then
             polygon = 1
+            break
          end
       end
    end
 
    -- Treat objects with a key/value combination in polygon_values as polygon
-   for index,tag in pairs(polygon_values) do
-      if keyvalues[tag[1]] == tag[2] then
-         polygon=1
-         break
+   if polygon == 0 then
+      for index,tag in pairs(polygon_values) do
+         if keyvalues[tag[1]] == tag[2] then
+            polygon=1
+            break
+         end
       end
    end
    
@@ -224,15 +227,18 @@ function filter_tags_relation_member (keyvalues, keyvaluemembers, roles, memberc
             end
             if polygontag == 1 then
                polytagcount = polytagcount + 1
+               break
             end
          end
       end
 
       -- Treat objects with a key/value combination in polygon_values as polygon
-      for index,tag in pairs(polygon_values) do
-         if keyvalues[tag[1]] == tag[2] then
-            polytagcount = polytagcount + 1
-            break
+      if polygon == 0 then
+         for index,tag in pairs(polygon_values) do
+            if keyvalues[tag[1]] == tag[2] then
+               polytagcount = polytagcount + 1
+               break
+            end
          end
       end
 


### PR DESCRIPTION
This allows the decision whether an object is treated as polygon or linestring
to be set in the style.lua file.

In particular, it treats the following values as linestring:
man_made=embankment, man_made=breakwater, man_made=groyne, natural=cliff, natural=tree_row, historic=citywalls,  waterway=derelict_canal, waterway=ditch, waterway=drain, waterway=river, waterway=stream, waterway=wadi, waterway=weir, power=line, power=minor_line. It also treats highway=services as polygon.

Including this in the default style.lua file has the following advantages:
- It serves as an easy-to-extend example of how the polygon/linestring decision
  can be made based on key.
- It provides sane defaults - it can be expected that most users of the style
  want to treat man_made=embankment and natural=cliff as linestring, and
  highway=services as polygon.

This resolves the following downstream bugs in openstreetmap-carto:
- https://github.com/gravitystorm/openstreetmap-carto/issues/892
- https://github.com/gravitystorm/openstreetmap-carto/issues/268
- https://github.com/gravitystorm/openstreetmap-carto/issues/137

This builds on #345, and thus assumes #345 is merged first.
