### PR TITLE
Add column flags to sample .style files

### DIFF
--- a/default.style
+++ b/default.style
@@ -86,9 +86,9 @@ node,way   admin_level  text         linear
 node,way   aerialway    text         linear
 node,way   aeroway      text         polygon
 node,way   amenity      text         polygon
-node,way   area         text         # hard coded support for area=1/yes => polygon is in osm2pgsql
+node,way   area         text         polygon # hard coded support for area=1/yes => polygon is in osm2pgsql
 node,way   barrier      text         linear
-node,way   bicycle      text
+node,way   bicycle      text         linear
 node,way   brand        text         linear
 node,way   bridge       text         linear
 node,way   boundary     text         linear
@@ -123,14 +123,14 @@ node,way   office       text         polygon
 node,way   oneway       text         linear
 node,way   operator     text         linear
 node,way   place        text         polygon
-node       poi          text
+node       poi          text         linear
 node,way   population   text         linear
 node,way   power        text         polygon
 node,way   power_source text         linear
 node,way   public_transport text     polygon
 node,way   railway      text         linear
 node,way   ref          text         linear
-node,way   religion     text
+node,way   religion     text         linear
 node,way   route        text         linear
 node,way   service      text         linear
 node,way   shop         text         polygon
@@ -147,7 +147,7 @@ node,way   wetland      text         polygon
 node,way   width        text         linear
 node,way   wood         text         linear
 node,way   z_order      int4         linear # This is calculated during import
-way        way_area     real                # This is calculated during import
+way        way_area     real         linear # This is calculated during import
 
 # Area tags
 # We don't make columns for these tags, but objects with them are areas.

--- a/empty.style
+++ b/empty.style
@@ -34,7 +34,7 @@ node,way    water                   text    phstore
 node,way    waterway                text    phstore
 node,way    wetland                 text    phstore
 node,way    z_order                 int4    linear  # This is calculated during import
-way         way_area                real            # This is calculated during import
+way         way_area                real    linear  # This is calculated during import
 
 # Deleted tags
 # These are tags that are generally regarded as useless for most rendering.


### PR DESCRIPTION
The behavior for columns without any flags is badly defined, and changing the lines above them can have odd results.

Passes the regression test.

Fixes part of #327