### PR TITLE
Remove unused floating-point based node storage code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,13 +158,6 @@ AX_PROG_LUA([5.0],[],[
     ],[AC_MSG_WARN([cannot find Lua includes])])
 ],[AC_MSG_WARN([cannot find Lua interpreter])])
 
-dnl Enable fixed point
-AC_ARG_WITH([fixed-point],
-  [AS_HELP_STRING([--without-fixed-point],
-    [use double instead of fixed point floats for coordinates])],
-    [],
-    [AC_DEFINE([FIXED_POINT], [1], [Store +-20,000km Mercator co-ordinates as fixed point 32bit number with maximum precision])])
-
 dnl Generate Makefile
 AC_OUTPUT(Makefile)
 

--- a/node-persistent-cache.cpp
+++ b/node-persistent-cache.cpp
@@ -126,13 +126,8 @@ static void ramNodes_clear(struct ramNode * nodes, int size)
     int i;
     for (i = 0; i < size; i++)
     {
-#ifdef FIXED_POINT
         nodes[i].lon = INT_MIN;
         nodes[i].lat = INT_MIN;
-#else
-        nodes[i].lon = NAN;
-        nodes[i].lat = NAN;
-#endif
     }
 }
 
@@ -426,13 +421,8 @@ int node_persistent_cache::set_create(osmid_t id, double lat, double lon)
         writeNodeBlock.used = 0;
         writeNodeBlock.block_offset = block_offset;
     }
-#ifdef FIXED_POINT
     writeNodeBlock.nodes[id & WRITE_NODE_BLOCK_MASK].lat = util::double_to_fix(lat, scale_);
     writeNodeBlock.nodes[id & WRITE_NODE_BLOCK_MASK].lon = util::double_to_fix(lon, scale_);
-#else
-    writeNodeBlock.nodes[id & WRITE_NODE_BLOCK_MASK].lat = lat;
-    writeNodeBlock.nodes[id & WRITE_NODE_BLOCK_MASK].lon = lon;
-#endif
     writeNodeBlock.used++;
     writeNodeBlock.dirty = 1;
 
@@ -448,7 +438,6 @@ int node_persistent_cache::set_append(osmid_t id, double lat, double lon)
     if (block_id < 0)
         block_id = load_block(block_offset);
 
-#ifdef FIXED_POINT
     if (isnan(lat) && isnan(lon))
     {
         readNodeBlockCache[block_id].nodes[id & READ_NODE_BLOCK_MASK].lat =
@@ -463,10 +452,6 @@ int node_persistent_cache::set_append(osmid_t id, double lat, double lon)
         readNodeBlockCache[block_id].nodes[id & READ_NODE_BLOCK_MASK].lon =
                 util::double_to_fix(lon, scale_);
     }
-#else
-    readNodeBlockCache[block_id].nodes[id & READ_NODE_BLOCK_MASK].lat = lat;
-    readNodeBlockCache[block_id].nodes[id & READ_NODE_BLOCK_MASK].lon = lon;
-#endif
     readNodeBlockCache[block_id].used++;
     readNodeBlockCache[block_id].dirty = 1;
 
@@ -494,7 +479,6 @@ int node_persistent_cache::get(struct osmNode *out, osmid_t id)
 
     readNodeBlockCache[block_id].used++;
 
-#ifdef FIXED_POINT
     if ((readNodeBlockCache[block_id].nodes[id & READ_NODE_BLOCK_MASK].lat
             == INT_MIN)
             && (readNodeBlockCache[block_id].nodes[id & READ_NODE_BLOCK_MASK].lon
@@ -510,19 +494,6 @@ int node_persistent_cache::get(struct osmNode *out, osmid_t id)
                 util::fix_to_double(readNodeBlockCache[block_id].nodes[id & READ_NODE_BLOCK_MASK].lon, scale_);
         return 0;
     }
-#else
-    if ((isnan(readNodeBlockCache[block_id].nodes[id & READ_NODE_BLOCK_MASK].lat)) &&
-            (isnan(readNodeBlockCache[block_id].nodes[id & READ_NODE_BLOCK_MASK].lon)))
-    {
-        return 1;
-    }
-    else
-    {
-        out->lat = readNodeBlockCache[block_id].nodes[id & READ_NODE_BLOCK_MASK].lat;
-        out->lon = readNodeBlockCache[block_id].nodes[id & READ_NODE_BLOCK_MASK].lon;
-        return 0;
-    }
-#endif
 
     return 0;
 }

--- a/node-ram-cache.cpp
+++ b/node-ram-cache.cpp
@@ -116,13 +116,8 @@ int node_ram_cache::set_sparse(osmid_t id, double lat, double lon) {
         }
     }
     sparseBlock[sizeSparseTuples].id = id;
-#ifdef FIXED_POINT
     sparseBlock[sizeSparseTuples].coord.lat = util::double_to_fix(lat, scale_);
     sparseBlock[sizeSparseTuples].coord.lon = util::double_to_fix(lon, scale_);
-#else
-    sparseBlock[sizeSparseTuples].coord.lat = lat;
-    sparseBlock[sizeSparseTuples].coord.lon = lon;
-#endif
     sizeSparseTuples++;
     cacheUsed += sizeof(ramNodeID);
     storedNodes++;
@@ -159,13 +154,8 @@ int node_ram_cache::set_dense(osmid_t id, double lat, double lon) {
                     for (i = 0; i < (1 << BLOCK_SHIFT); i++) {
                         if (queue[usedBlocks -1]->nodes[i].lat || queue[usedBlocks -1]->nodes[i].lon) {
                             set_sparse(block2id(queue[usedBlocks - 1]->block_offset,i),
-#ifdef FIXED_POINT
                                                        util::fix_to_double(queue[usedBlocks -1]->nodes[i].lat, scale_),
                                                        util::fix_to_double(queue[usedBlocks -1]->nodes[i].lon, scale_)
-#else
-                                                       queue[usedBlocks -1]->nodes[i].lat,
-                                                       queue[usedBlocks -1]->nodes[i].lon
-#endif
                                                        );
                         }
                     }
@@ -253,13 +243,8 @@ int node_ram_cache::set_dense(osmid_t id, double lat, double lon) {
         }
     }
 
-#ifdef FIXED_POINT
     blocks[block].nodes[offset].lat = util::double_to_fix(lat, scale_);
     blocks[block].nodes[offset].lon = util::double_to_fix(lon, scale_);
-#else
-    blocks[block].nodes[offset].lat = lat;
-    blocks[block].nodes[offset].lon = lon;
-#endif
     blocks[block].used++;
     storedNodes++;
     return 0;
@@ -273,13 +258,8 @@ int node_ram_cache::get_sparse(osmNode *out, osmid_t id) {
 
     while (minPos <= maxPos) {
         if ( sparseBlock[pivotPos].id == id ) {
-#ifdef FIXED_POINT
             out->lat = util::fix_to_double(sparseBlock[pivotPos].coord.lat, scale_);
             out->lon = util::fix_to_double(sparseBlock[pivotPos].coord.lon, scale_);
-#else
-            out->lat = sparseBlock[pivotPos].coord.lat;
-            out->lon = sparseBlock[pivotPos].coord.lon;
-#endif
             return 0;
         }
         if ( (pivotPos == minPos) || (pivotPos == maxPos)) return 1;
@@ -306,13 +286,8 @@ int node_ram_cache::get_dense(osmNode *out, osmid_t id) {
     if (!blocks[block].nodes[offset].lat && !blocks[block].nodes[offset].lon)
         return 1;
 
-#ifdef FIXED_POINT
     out->lat = util::fix_to_double(blocks[block].nodes[offset].lat, scale_);
     out->lon = util::fix_to_double(blocks[block].nodes[offset].lon, scale_);
-#else
-    out->lat = blocks[block].nodes[offset].lat;
-    out->lon = blocks[block].nodes[offset].lon;
-#endif
 
     return 0;
 }

--- a/node-ram-cache.hpp
+++ b/node-ram-cache.hpp
@@ -21,13 +21,8 @@
 #define ALLOC_LOSSY 8
 
 struct ramNode {
-#ifdef FIXED_POINT
     int lon;
     int lat;
-#else
-    double lon;
-    double lat;
-#endif
 };
 
 struct ramNodeID {

--- a/processor-point.cpp
+++ b/processor-point.cpp
@@ -1,4 +1,3 @@
-#include "config.h" // for FIXED_POINT
 #include "processor-point.hpp"
 #include "util.hpp"
 
@@ -13,11 +12,9 @@ processor_point::~processor_point() {
 }
 
 geometry_builder::maybe_wkt_t processor_point::process_node(double lat, double lon) {
-#ifdef FIXED_POINT
     // guarantee that we use the same values as in the node cache
     lon = util::fix_to_double(util::double_to_fix(lon, m_scale), m_scale);
     lat = util::fix_to_double(util::double_to_fix(lat, m_scale), m_scale);
-#endif
     geometry_builder::maybe_wkt_t wkt(new geometry_builder::wkt_t());
     wkt->geom = (boost::format("POINT(%.15g %.15g)") % lon % lat).str();
     return wkt;

--- a/processor-point.hpp
+++ b/processor-point.hpp
@@ -10,7 +10,7 @@ struct processor_point : public geometry_processor {
     geometry_builder::maybe_wkt_t process_node(double lat, double lon);
 
 private:
-    double m_scale; // <-- used only when FIXED_POINT is defined
+    double m_scale;
 };
 
 #endif /* PROCESSOR_POINT_HPP */

--- a/table.cpp
+++ b/table.cpp
@@ -1,4 +1,3 @@
-#include "config.h" // for FIXED_POINT
 #include "table.hpp"
 #include "options.hpp"
 #include "util.hpp"
@@ -301,11 +300,9 @@ void table_t::stop_copy()
 
 void table_t::write_node(const osmid_t id, const taglist_t &tags, double lat, double lon)
 {
-#ifdef FIXED_POINT
     // guarantee that we use the same values as in the node cache
     lon = util::fix_to_double(util::double_to_fix(lon, scale), scale);
     lat = util::fix_to_double(util::double_to_fix(lat, scale), scale);
-#endif
 
     write_wkt(id, tags, (point_fmt % lon % lat).str().c_str());
 }


### PR DESCRIPTION
The only way to use this code used to be to edit the source and modify defines, so it has received no testing over the last few years and is dead code.
