### PR TITLE
Reduce memory usage of node cache

### DIFF
--- a/node-persistent-cache.cpp
+++ b/node-persistent-cache.cpp
@@ -460,7 +460,6 @@ void node_persistent_cache::set_read_mode()
 
     if (writeNodeBlock.dirty()) {
         assert(!append_mode);
-        fprintf(stderr, "Switching to read mode\n");
         nodes_set_create_writeout_block();
         writeNodeBlock.reset_used();
         writeNodeBlock.block_offset++;
@@ -482,8 +481,6 @@ void node_persistent_cache::set_read_mode()
     }
 
     read_mode = true;
-
-    fprintf(stderr, "Switching to read mode done\n");
 }
 
 node_persistent_cache::node_persistent_cache(const options_t *options, int append,

--- a/node-ram-cache.cpp
+++ b/node-ram-cache.cpp
@@ -108,7 +108,11 @@ ramNode *node_ram_cache::next_chunk() {
 
 
 int node_ram_cache::set_sparse(osmid_t id, const ramNode &coord) {
-    if ((sizeSparseTuples > maxSparseTuples) || ( cacheUsed > cacheSize)) {
+    // Sparse cache depends on ordered nodes, reject out-of-order ids.
+    // Also check that there is still space.
+    if ((maxSparseId && id < maxSparseId)
+        || (sizeSparseTuples > maxSparseTuples)
+        || ( cacheUsed > cacheSize)) {
         if ((allocStrategy & ALLOC_LOSSY) > 0)
             return 1;
         else {
@@ -116,6 +120,7 @@ int node_ram_cache::set_sparse(osmid_t id, const ramNode &coord) {
             util::exit_nicely();
         }
     }
+    maxSparseId = id;
     sparseBlock[sizeSparseTuples].id = id;
     sparseBlock[sizeSparseTuples].coord = coord;
 
@@ -294,7 +299,7 @@ int node_ram_cache::get_dense(osmNode *out, osmid_t id) {
 node_ram_cache::node_ram_cache( int strategy, int cacheSizeMB, int fixpointscale )
     : allocStrategy(ALLOC_DENSE), blocks(NULL), usedBlocks(0),
       maxBlocks(0), blockCache(NULL), queue(NULL), sparseBlock(NULL),
-      maxSparseTuples(0), sizeSparseTuples(0), cacheUsed(0),
+      maxSparseTuples(0), sizeSparseTuples(0), maxSparseId(0), cacheUsed(0),
       cacheSize(0), storedNodes(0), totalNodes(0), nodesCacheHits(0),
       nodesCacheLookups(0), warn_node_order(0) {
 

--- a/node-ram-cache.hpp
+++ b/node-ram-cache.hpp
@@ -97,9 +97,9 @@ public:
     int used() const { return _used >> 1; }
 
     ramNode *nodes;
-    int block_offset;
+    int32_t block_offset;
 private:
-    int _used; // 0-bit indicates dirty
+    int32_t _used; // 0-bit indicates dirty
 };
 
 struct node_ram_cache : public boost::noncopyable

--- a/node-ram-cache.hpp
+++ b/node-ram-cache.hpp
@@ -83,11 +83,23 @@ struct ramNodeID {
     ramNode coord;
 };
 
-struct ramNodeBlock {
+class ramNodeBlock {
+public:
+    ramNodeBlock() : nodes(NULL), block_offset(-1), _used(0) {}
+
+    void set_dirty() { _used |= 1; }
+    bool dirty() const { return _used & 1; }
+
+    void reset_used() { _used = 0; }
+    void inc_used() { _used += 2; }
+    void dec_used() { _used -= 2; }
+    void set_used(int used) { _used = (used << 1) || (_used & 1); }
+    int used() const { return _used >> 1; }
+
     ramNode *nodes;
-    osmid_t block_offset;
-    int used;
-    int dirty;
+    int block_offset;
+private:
+    int _used; // 0-bit indicates dirty
 };
 
 struct node_ram_cache : public boost::noncopyable

--- a/node-ram-cache.hpp
+++ b/node-ram-cache.hpp
@@ -132,6 +132,7 @@ private:
     ramNodeID *sparseBlock;
     int64_t maxSparseTuples;
     int64_t sizeSparseTuples;
+    osmid_t maxSparseId;
 
     int64_t cacheUsed, cacheSize;
     osmid_t storedNodes, totalNodes;


### PR DESCRIPTION
Reduces preallocation of memory and implements more dense management structures for the ram node cache. For a planet import, the reduction in total memory is around 800MB. This helps a bit with #351 but won't completely fix it.

Passes the tests but still needs to be tested more thoroughly with different variations of ram cache configuration before merging.