### PR TITLE
Extend node storage tests to flat nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tests/.dirstamp
 tests/test-parse-xml2
 tests/test-middle-ram
 tests/test-middle-pgsql
+tests/test-middle-flat
 tests/test-pgsql-escape
 tests/test-parse-options
 tests/test-output-multi-tags
@@ -58,7 +59,7 @@ tests/test-output-pgsql
 tests/test-expire-tiles
 tests/*.log
 tests/*.trs
-tests/test_output_pgsql_area_way.flat.nodes.bin
+tests/*.flat.nodes.bin
 
 .libs/
 *.lo

--- a/Makefile.am
+++ b/Makefile.am
@@ -51,6 +51,7 @@ check_PROGRAMS = \
 	tests/test-parse-xml2 \
 	tests/test-middle-ram \
 	tests/test-middle-pgsql \
+	tests/test-middle-flat \
 	tests/test-output-multi-tags \
 	tests/test-output-multi-line \
 	tests/test-output-multi-line-storage \
@@ -69,6 +70,8 @@ tests_test_middle_ram_SOURCES = tests/test-middle-ram.cpp tests/middle-tests.cpp
 tests_test_middle_ram_LDADD = libosm2pgsql.la
 tests_test_middle_pgsql_SOURCES = tests/test-middle-pgsql.cpp tests/middle-tests.cpp tests/common-pg.cpp
 tests_test_middle_pgsql_LDADD = libosm2pgsql.la
+tests_test_middle_flat_SOURCES = tests/test-middle-flat.cpp tests/middle-tests.cpp tests/common-pg.cpp
+tests_test_middle_flat_LDADD = libosm2pgsql.la
 tests_test_output_multi_tags_SOURCES = tests/test-output-multi-tags.cpp tests/common-pg.cpp
 tests_test_output_multi_tags_LDADD = libosm2pgsql.la
 tests_test_output_multi_line_SOURCES = tests/test-output-multi-line.cpp tests/common-pg.cpp
@@ -91,6 +94,8 @@ tests_test_parse_options_SOURCES = tests/test-parse-options.cpp
 tests_test_parse_options_LDADD = libosm2pgsql.la
 tests_test_expire_tiles_SOURCES = tests/test-expire-tiles.cpp
 tests_test_expire_tiles_LDADD = libosm2pgsql.la
+
+MOSTLYCLEANFILES = tests/test_middle_flat.flat.nodes.bin tests/test_output_pgsql_area_way.flat.nodes.bin
 
 TESTS = $(check_PROGRAMS) tests/regression-test.sh
 TEST_EXTENSIONS = .sh
@@ -138,6 +143,7 @@ osm2pgsql_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_parse_xml2_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_middle_ram_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_middle_pgsql_LDADD += $(GLOBAL_LDFLAGS)
+tests_test_middle_flat_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_output_multi_tags_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_output_multi_line_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_output_multi_line_storage_LDADD += $(GLOBAL_LDFLAGS)

--- a/tests/test-middle-flat.cpp
+++ b/tests/test-middle-flat.cpp
@@ -1,0 +1,112 @@
+#include <iostream>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <cassert>
+#include <sstream>
+#include <stdexcept>
+#include <memory>
+
+#include "osmtypes.hpp"
+#include "output-null.hpp"
+#include "options.hpp"
+#include "middle-pgsql.hpp"
+
+#include <libpq-fe.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <boost/scoped_ptr.hpp>
+
+#include "tests/middle-tests.hpp"
+#include "tests/common-pg.hpp"
+
+/* This is basically the same as test-middle-pgsql, but with flat nodes. */
+
+void run_tests(options_t options, const std::string cache_type) {
+  options.append = 0;
+  options.create = 1;
+  options.flat_node_cache_enabled = true;
+  // flat nodes truncates the file each time it's started, so we can reuse the same file
+  options.flat_node_file = boost::optional<std::string>("tests/test_middle_flat.flat.nodes.bin");
+
+  {
+    middle_pgsql_t mid_pgsql;
+    output_null_t out_test(&mid_pgsql, options);
+
+    mid_pgsql.start(&options);
+
+    if (test_node_set(&mid_pgsql) != 0) { throw std::runtime_error("test_node_set failed."); }
+
+    mid_pgsql.commit();
+    mid_pgsql.stop();
+  }
+  {
+    middle_pgsql_t mid_pgsql;
+    output_null_t out_test(&mid_pgsql, options);
+
+    mid_pgsql.start(&options);
+
+    if (test_nodes_comprehensive_set(&mid_pgsql) != 0) { throw std::runtime_error("test_nodes_comprehensive_set failed."); }
+
+    mid_pgsql.commit();
+    mid_pgsql.stop();
+  }
+  /* This should work, but doesn't. More tests are needed that look at updates
+     without the complication of ways.
+  */
+/*  {
+    middle_pgsql_t mid_pgsql;
+    output_null_t out_test(&mid_pgsql, options);
+
+    mid_pgsql.start(&options);
+    mid_pgsql.commit();
+    mid_pgsql.stop();
+    // Switch to append mode because this tests updates
+    options.append = 1;
+    options.create = 0;
+    mid_pgsql.start(&options);
+    if (test_way_set(&mid_pgsql) != 0) { throw std::runtime_error("test_way_set failed."); }
+
+    mid_pgsql.commit();
+    mid_pgsql.stop();
+  }*/
+}
+int main(int argc, char *argv[]) {
+  boost::scoped_ptr<pg::tempdb> db;
+
+  try {
+    db.reset(new pg::tempdb);
+  } catch (const std::exception &e) {
+    std::cerr << "Unable to setup database: " << e.what() << "\n";
+    return 77; // <-- code to skip this test.
+  }
+
+  try {
+    options_t options;
+    options.conninfo = db->conninfo().c_str();
+    options.scale = 10000000;
+    options.cache = 1;
+    options.num_procs = 1;
+    options.prefix = "osm2pgsql_test";
+    options.slim = 1;
+
+    options.alloc_chunkwise = ALLOC_SPARSE | ALLOC_DENSE; // what you get with optimized
+    run_tests(options, "optimized");
+    options.alloc_chunkwise = ALLOC_SPARSE;
+    run_tests(options, "sparse");
+
+    options.alloc_chunkwise = ALLOC_DENSE;
+    run_tests(options, "dense");
+
+    options.alloc_chunkwise = ALLOC_DENSE | ALLOC_DENSE_CHUNK; // what you get with chunk
+    run_tests(options, "chunk");
+  } catch (const std::exception &e) {
+    std::cerr << "ERROR: " << e.what() << std::endl;
+    return 1;
+  } catch (...) {
+    std::cerr << "UNKNOWN ERROR" << std::endl;
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
There's something odd with test_way_set, but the other tests work and pass.

I'm not quite happy with test_way_set, and think some smaller unit tests are needed for testing append mode.