### PR TITLE
Populate name column for route relations

### DIFF
--- a/tagtransform.cpp
+++ b/tagtransform.cpp
@@ -118,7 +118,7 @@ unsigned int c_filter_rel_member_tags(const taglist_t &rel_tags,
         if (is_route && (it->key == "name"))
             out_tags.push_dedupe(tag("route_name", it->value));
         //copy all other tags except for "type"
-        else if (it->key != "type")
+        if (it->key != "type")
             out_tags.push_dedupe(*it);
     }
 


### PR DESCRIPTION
The C transforms used to turn the name tag into a route_name tag on
route relations, for reasons that are not entirely clear. This change
doesn't remove route_name, but does also populate the name column,
eliminating a source of confusion to users.

Fixes #315