### PR TITLE
Disable autovacuum on the rendering tables during import

### DIFF
--- a/table.cpp
+++ b/table.cpp
@@ -146,6 +146,10 @@ void table_t::start()
         else
             sql[sql.length() - 1] = ')';
 
+        // The final tables are created with CREATE TABLE AS ... SELECT * FROM ...
+        // This means that they won't get this autovacuum setting, so it doesn't
+        // doesn't need to be RESET on these tables
+        sql += " WITH ( autovacuum_enabled = FALSE )";
         //add the main table space
         if (table_space)
             sql += " TABLESPACE " + table_space.get();


### PR DESCRIPTION
Although the tables are only growing and will not trigger autovacuum,
they may still trigger autoanalyze which is controlled by the same
storage setting.

This does not change the slim tables, which are part of middle-pgsql.

Closes #155 - for output pgsql tables. I'm not if the issue is applicable to gazetteer, and I'd rather not touch the middle tables