### PR TITLE
Schema tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ tests/test-output-multi-poly-trivial
 tests/test-output-pgsql
 tests/test-output-pgsql-tablespace
 tests/test-output-pgsql-z_order
+tests/test-output-pgsql-schema
 tests/test-expire-tiles
 tests/test-hstore-match-only
 tests/*.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,7 @@ check_PROGRAMS = \
 	tests/test-output-multi-poly-trivial \
 	tests/test-output-pgsql \
 	tests/test-output-pgsql-z_order \
-	tests/test-output-pgsql-tablespace \
+	tests/test-output-pgsql-schema \
 	tests/test-pgsql-escape \
 	tests/test-parse-options \
 	tests/test-expire-tiles \
@@ -93,6 +93,8 @@ tests_test_output_pgsql_tablespace_SOURCES = tests/test-output-pgsql-tablespace.
 tests_test_output_pgsql_tablespace_LDADD = libosm2pgsql.la
 tests_test_output_pgsql_z_order_SOURCES = tests/test-output-pgsql-z_order.cpp tests/common-pg.cpp
 tests_test_output_pgsql_z_order_LDADD = libosm2pgsql.la
+tests_test_output_pgsql_schema_SOURCES = tests/test-output-pgsql-schema.cpp tests/common-pg.cpp
+tests_test_output_pgsql_schema_LDADD = libosm2pgsql.la
 tests_test_pgsql_escape_SOURCES = tests/test-pgsql-escape.cpp
 tests_test_pgsql_escape_LDADD = libosm2pgsql.la
 tests_test_parse_options_SOURCES = tests/test-parse-options.cpp
@@ -152,6 +154,7 @@ tests_test_output_multi_poly_trivial_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_output_pgsql_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_output_pgsql_tablespace_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_output_pgsql_z_order_LDADD += $(GLOBAL_LDFLAGS)
+tests_test_output_pgsql_schema_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_pgsql_escape_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_parse_options_LDADD += $(GLOBAL_LDFLAGS)
 tests_test_expire_tiles_LDADD += $(GLOBAL_LDFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -57,6 +57,7 @@ check_PROGRAMS = \
 	tests/test-output-multi-poly-trivial \
 	tests/test-output-pgsql \
 	tests/test-output-pgsql-z_order \
+	tests/test-output-pgsql-tablespace \
 	tests/test-output-pgsql-schema \
 	tests/test-pgsql-escape \
 	tests/test-parse-options \

--- a/tests/common-pg.hpp
+++ b/tests/common-pg.hpp
@@ -59,12 +59,19 @@ struct tempdb
     database_options_t database_options;
 
     void check_tblspc();
+    void check_count(int expected, const std::string &query);
+    void check_number(double expected, const std::string &query);
+    void check_string(const std::string &expected, const std::string &query);
+    void assert_has_table(const std::string &table_name);
 
 private:
-    // Sets up an extension, trying first with 9.1 CREATE EXTENSION, and falling back to trying to find extension_files
-    void setup_extension(conn_ptr db, const std::string &extension, const std::vector<std::string> &extension_files = std::vector<std::string>());
+    /**
+     * Sets up an extension, trying first with 9.1 CREATE EXTENSION, and falling back to trying to find extension_files
+     */
+    void setup_extension(const std::string &extension, const std::vector<std::string> &extension_files = std::vector<std::string>());
 
     conn_ptr m_conn;
+    conn_ptr m_postgres_conn; /// Connection to the "postgres" db. used to create and drop test DBs
 };
 
 } // namespace pg

--- a/tests/common-pg.hpp
+++ b/tests/common-pg.hpp
@@ -59,19 +59,50 @@ struct tempdb
     database_options_t database_options;
 
     void check_tblspc();
+    /**
+     * Checks the result of a query with COUNT(*).
+     * It will work with any integer-returning query.
+     * \param[in] expected expected result
+     * \param[in] query SQL query to run. Must return one tuple.
+     * \throws std::runtime_error if query result is not expected
+     */
     void check_count(int expected, const std::string &query);
+
+    /**
+     * Checks a floating point number.
+     * It allows a small variance around the expected result to allow for
+     * floating point differences.
+     * The query must only return one tuple
+     * \param[in] expected expected result
+     * \param[in] query SQL query to run. Must return one tuple.
+     * \throws std::runtime_error if query result is not expected
+     */
     void check_number(double expected, const std::string &query);
+
+    /**
+     * Check the string a query returns.
+     * \param[in] expected expected result
+     * \param[in] query SQL query to run. Must return one tuple.
+     * \throws std::runtime_error if query result is not expected
+     */
     void check_string(const std::string &expected, const std::string &query);
+    /**
+     * Assert that the database has a certain table_name
+     * \param[in] table_name Name of the table to check, optionally schema-qualified
+     * \throws std::runtime_error if missing the table
+     */
     void assert_has_table(const std::string &table_name);
 
 private:
     /**
-     * Sets up an extension, trying first with 9.1 CREATE EXTENSION, and falling back to trying to find extension_files
+     * Sets up an extension, trying first with 9.1 CREATE EXTENSION, and falling
+     * back to trying to find extension_files. The fallback is not likely to
+     * work on systems not based on Debian.
      */
     void setup_extension(const std::string &extension, const std::vector<std::string> &extension_files = std::vector<std::string>());
 
-    conn_ptr m_conn;
-    conn_ptr m_postgres_conn; /// Connection to the "postgres" db. used to create and drop test DBs
+    conn_ptr m_conn; ///< connection to the test DB
+    conn_ptr m_postgres_conn; ///< Connection to the "postgres" db, used to create and drop test DBs
 };
 
 } // namespace pg

--- a/tests/test-middle-flat.cpp
+++ b/tests/test-middle-flat.cpp
@@ -12,7 +12,6 @@
 #include "options.hpp"
 #include "middle-pgsql.hpp"
 
-#include <libpq-fe.h>
 #include <sys/types.h>
 #include <unistd.h>
 

--- a/tests/test-middle-pgsql.cpp
+++ b/tests/test-middle-pgsql.cpp
@@ -12,7 +12,6 @@
 #include "options.hpp"
 #include "middle-pgsql.hpp"
 
-#include <libpq-fe.h>
 #include <sys/types.h>
 #include <unistd.h>
 

--- a/tests/test-output-multi-line-storage.cpp
+++ b/tests/test-output-multi-line-storage.cpp
@@ -15,7 +15,6 @@
 #include "taginfo_impl.hpp"
 #include "parse.hpp"
 
-#include <libpq-fe.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -23,27 +22,6 @@
 
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
-
-void check_count(pg::conn_ptr &conn, int expected, const std::string &query) {
-    pg::result_ptr res = conn->exec(query);
-
-    int ntuples = PQntuples(res->get());
-    if (ntuples != 1) {
-        throw std::runtime_error((boost::format("Expected only one tuple from a query "
-                                                "to check COUNT(*), but got %1%. Query "
-                                                "was: %2%.")
-                                  % ntuples % query).str());
-    }
-
-    std::string numstr = PQgetvalue(res->get(), 0, 0);
-    int count = boost::lexical_cast<int>(numstr);
-
-    if (count != expected) {
-        throw std::runtime_error((boost::format("Expected %1%, but got %2%, when running "
-                                                "query: %3%.")
-                                  % expected % count % query).str());
-    }
-}
 
 int main(int argc, char *argv[]) {
     std::unique_ptr<pg::tempdb> db;
@@ -84,18 +62,15 @@ int main(int argc, char *argv[]) {
 
         osmdata.stop();
 
-        // start a new connection to run tests on
-        pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
-
-        check_count(test_conn, 1, "select count(*) from pg_catalog.pg_class where relname = 'test_line'");
-        check_count(test_conn, 3, "select count(*) from test_line");
+        db->check_count(1, "select count(*) from pg_catalog.pg_class where relname = 'test_line'");
+        db->check_count(3, "select count(*) from test_line");
 
         //check that we have the number of vertexes in each linestring
-        check_count(test_conn, 3, "SELECT ST_NumPoints(way) FROM test_line WHERE osm_id = 1");
-        check_count(test_conn, 2, "SELECT ST_NumPoints(way) FROM test_line WHERE osm_id = 2");
-        check_count(test_conn, 2, "SELECT ST_NumPoints(way) FROM test_line WHERE osm_id = 3");
+        db->check_count(3, "SELECT ST_NumPoints(way) FROM test_line WHERE osm_id = 1");
+        db->check_count(2, "SELECT ST_NumPoints(way) FROM test_line WHERE osm_id = 2");
+        db->check_count(2, "SELECT ST_NumPoints(way) FROM test_line WHERE osm_id = 3");
 
-        check_count(test_conn, 3, "SELECT COUNT(*) FROM test_line WHERE foo = 'bar'");
+        db->check_count(3, "SELECT COUNT(*) FROM test_line WHERE foo = 'bar'");
         return 0;
 
     } catch (const std::exception &e) {

--- a/tests/test-output-multi-line.cpp
+++ b/tests/test-output-multi-line.cpp
@@ -15,7 +15,7 @@
 #include "taginfo_impl.hpp"
 #include "parse.hpp"
 
-#include <libpq-fe.h>
+
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -23,27 +23,6 @@
 
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
-
-void check_count(pg::conn_ptr &conn, int expected, const std::string &query) {
-    pg::result_ptr res = conn->exec(query);
-
-    int ntuples = PQntuples(res->get());
-    if (ntuples != 1) {
-        throw std::runtime_error((boost::format("Expected only one tuple from a query "
-                                                "to check COUNT(*), but got %1%. Query "
-                                                "was: %2%.")
-                                  % ntuples % query).str());
-    }
-
-    std::string numstr = PQgetvalue(res->get(), 0, 0);
-    int count = boost::lexical_cast<int>(numstr);
-
-    if (count != expected) {
-        throw std::runtime_error((boost::format("Expected %1%, but got %2%, when running "
-                                                "query: %3%.")
-                                  % expected % count % query).str());
-    }
-}
 
 int main(int argc, char *argv[]) {
     std::unique_ptr<pg::tempdb> db;
@@ -83,29 +62,27 @@ int main(int argc, char *argv[]) {
         osmdata.stop();
 
         // start a new connection to run tests on
-        pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
-
-        check_count(test_conn, 1, "select count(*) from pg_catalog.pg_class where relname = 'foobar_highways'");
-        check_count(test_conn, 2753, "select count(*) from foobar_highways");
+        db->check_count(1, "select count(*) from pg_catalog.pg_class where relname = 'foobar_highways'");
+        db->check_count(2753, "select count(*) from foobar_highways");
 
         //check that we have the right spread
-        check_count(test_conn, 13, "select count(*) from foobar_highways where highway='bridleway'");
-        check_count(test_conn, 3, "select count(*) from foobar_highways where highway='construction'");
-        check_count(test_conn, 96, "select count(*) from foobar_highways where highway='cycleway'");
-        check_count(test_conn, 249, "select count(*) from foobar_highways where highway='footway'");
-        check_count(test_conn, 18, "select count(*) from foobar_highways where highway='living_street'");
-        check_count(test_conn, 171, "select count(*) from foobar_highways where highway='path'");
-        check_count(test_conn, 6, "select count(*) from foobar_highways where highway='pedestrian'");
-        check_count(test_conn, 81, "select count(*) from foobar_highways where highway='primary'");
-        check_count(test_conn, 842, "select count(*) from foobar_highways where highway='residential'");
-        check_count(test_conn, 3, "select count(*) from foobar_highways where highway='road'");
-        check_count(test_conn, 90, "select count(*) from foobar_highways where highway='secondary'");
-        check_count(test_conn, 1, "select count(*) from foobar_highways where highway='secondary_link'");
-        check_count(test_conn, 352, "select count(*) from foobar_highways where highway='service'");
-        check_count(test_conn, 34, "select count(*) from foobar_highways where highway='steps'");
-        check_count(test_conn, 33, "select count(*) from foobar_highways where highway='tertiary'");
-        check_count(test_conn, 597, "select count(*) from foobar_highways where highway='track'");
-        check_count(test_conn, 164, "select count(*) from foobar_highways where highway='unclassified'");
+        db->check_count(13, "select count(*) from foobar_highways where highway='bridleway'");
+        db->check_count(3, "select count(*) from foobar_highways where highway='construction'");
+        db->check_count(96, "select count(*) from foobar_highways where highway='cycleway'");
+        db->check_count(249, "select count(*) from foobar_highways where highway='footway'");
+        db->check_count(18, "select count(*) from foobar_highways where highway='living_street'");
+        db->check_count(171, "select count(*) from foobar_highways where highway='path'");
+        db->check_count(6, "select count(*) from foobar_highways where highway='pedestrian'");
+        db->check_count(81, "select count(*) from foobar_highways where highway='primary'");
+        db->check_count(842, "select count(*) from foobar_highways where highway='residential'");
+        db->check_count(3, "select count(*) from foobar_highways where highway='road'");
+        db->check_count(90, "select count(*) from foobar_highways where highway='secondary'");
+        db->check_count(1, "select count(*) from foobar_highways where highway='secondary_link'");
+        db->check_count(352, "select count(*) from foobar_highways where highway='service'");
+        db->check_count(34, "select count(*) from foobar_highways where highway='steps'");
+        db->check_count(33, "select count(*) from foobar_highways where highway='tertiary'");
+        db->check_count(597, "select count(*) from foobar_highways where highway='track'");
+        db->check_count(164, "select count(*) from foobar_highways where highway='unclassified'");
         return 0;
 
     } catch (const std::exception &e) {

--- a/tests/test-output-multi-poly-trivial.cpp
+++ b/tests/test-output-multi-poly-trivial.cpp
@@ -15,7 +15,6 @@
 #include "taginfo_impl.hpp"
 #include "parse.hpp"
 
-#include <libpq-fe.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -23,27 +22,6 @@
 
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
-
-void check_count(pg::conn_ptr &conn, int expected, const std::string &query) {
-    pg::result_ptr res = conn->exec(query);
-
-    int ntuples = PQntuples(res->get());
-    if (ntuples != 1) {
-        throw std::runtime_error((boost::format("Expected only one tuple from a query "
-                                                "to check COUNT(*), but got %1%. Query "
-                                                "was: %2%.")
-                                  % ntuples % query).str());
-    }
-
-    std::string numstr = PQgetvalue(res->get(), 0, 0);
-    int count = boost::lexical_cast<int>(numstr);
-
-    if (count != expected) {
-        throw std::runtime_error((boost::format("Expected %1%, but got %2%, when running "
-                                                "query: %3%.")
-                                  % expected % count % query).str());
-    }
-}
 
 void run_osm2pgsql(options_t &options) {
   //setup the front (input)
@@ -65,9 +43,9 @@ void run_osm2pgsql(options_t &options) {
   osmdata.stop();
 }
 
-void check_output_poly_trivial(bool enable_multi, database_options_t &database_options) {
+void check_output_poly_trivial(bool enable_multi, std::shared_ptr<pg::tempdb> db) {
   options_t options;
-  options.database_options = database_options;
+  options.database_options = db->database_options;
   options.num_procs = 1;
   options.slim = 1;
   options.enable_multi = enable_multi;
@@ -79,37 +57,34 @@ void check_output_poly_trivial(bool enable_multi, database_options_t &database_o
 
   run_osm2pgsql(options);
 
-  // start a new connection to run tests on
-  pg::conn_ptr test_conn = pg::conn::connect(database_options);
-
   // expect that the table exists
-  check_count(test_conn, 1, "select count(*) from pg_catalog.pg_class where relname = 'test_poly'");
+  db->check_count(1, "select count(*) from pg_catalog.pg_class where relname = 'test_poly'");
 
   // expect 2 polygons if not in multi(geometry) mode, or 1 if multi(geometry)
   // mode is enabled.
   if (enable_multi) {
-    check_count(test_conn, 1, "select count(*) from test_poly");
-    check_count(test_conn, 1, "select count(*) from test_poly where foo='bar'");
-    check_count(test_conn, 1, "select count(*) from test_poly where bar='baz'");
+    db->check_count(1, "select count(*) from test_poly");
+    db->check_count(1, "select count(*) from test_poly where foo='bar'");
+    db->check_count(1, "select count(*) from test_poly where bar='baz'");
 
     // there should be two 5-pointed polygons in the multipolygon (note that
     // it's 5 points including the duplicated first/last point)
-    check_count(test_conn, 2, "select count(*) from (select (st_dump(way)).geom as way from test_poly) x");
-    check_count(test_conn, 5, "select distinct st_numpoints(st_exteriorring(way)) from (select (st_dump(way)).geom as way from test_poly) x");
+    db->check_count(2, "select count(*) from (select (st_dump(way)).geom as way from test_poly) x");
+    db->check_count(5, "select distinct st_numpoints(st_exteriorring(way)) from (select (st_dump(way)).geom as way from test_poly) x");
 
   } else {
-    check_count(test_conn, 2, "select count(*) from test_poly");
-    check_count(test_conn, 2, "select count(*) from test_poly where foo='bar'");
-    check_count(test_conn, 2, "select count(*) from test_poly where bar='baz'");
+    db->check_count(2, "select count(*) from test_poly");
+    db->check_count(2, "select count(*) from test_poly where foo='bar'");
+    db->check_count(2, "select count(*) from test_poly where bar='baz'");
 
     // although there are 2 rows, they should both be 5-pointed polygons (note
     // that it's 5 points including the duplicated first/last point)
-    check_count(test_conn, 5, "select distinct st_numpoints(st_exteriorring(way)) from test_poly");
+    db->check_count(5, "select distinct st_numpoints(st_exteriorring(way)) from test_poly");
   }
 }
 
 int main(int argc, char *argv[]) {
-    std::unique_ptr<pg::tempdb> db;
+    std::shared_ptr<pg::tempdb> db;
 
     try {
         db.reset(new pg::tempdb);
@@ -119,8 +94,8 @@ int main(int argc, char *argv[]) {
     }
 
     try {
-        check_output_poly_trivial(0, db->database_options);
-        check_output_poly_trivial(1, db->database_options);
+        check_output_poly_trivial(0, db);
+        check_output_poly_trivial(1, db);
         return 0;
 
     } catch (const std::exception &e) {

--- a/tests/test-output-pgsql-z_order.cpp
+++ b/tests/test-output-pgsql-z_order.cpp
@@ -16,7 +16,6 @@
 #include "taginfo_impl.hpp"
 #include "parse.hpp"
 
-#include <libpq-fe.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -48,56 +47,6 @@ void run_test(const char* test_name, void (*testfunc)()) {
     fprintf(stderr, "PASS\n");
 }
 #define RUN_TEST(x) run_test(#x, &(x))
-
-void check_string(pg::conn_ptr &conn, std::string expected, const std::string &query) {
-    pg::result_ptr res = conn->exec(query);
-
-    int ntuples = PQntuples(res->get());
-    if (ntuples != 1) {
-        throw std::runtime_error((boost::format("Expected only one tuple from a query "
-                                                "to check a string, but got %1%. Query "
-                                                "was: %2%.")
-                                  % ntuples % query).str());
-    }
-
-    std::string actual = PQgetvalue(res->get(), 0, 0);
-
-    if (actual != expected) {
-        throw std::runtime_error((boost::format("Expected %1%, but got %2%, when running "
-                                                "query: %3%.")
-                                  % expected % actual % query).str());
-    }
-}
-
-
-void check_count(pg::conn_ptr &conn, int expected, const std::string &query) {
-    pg::result_ptr res = conn->exec(query);
-
-    int ntuples = PQntuples(res->get());
-    if (ntuples != 1) {
-        throw std::runtime_error((boost::format("Expected only one tuple from a query "
-                                                "to check COUNT(*), but got %1%. Query "
-                                                "was: %2%.")
-                                  % ntuples % query).str());
-    }
-
-    std::string numstr = PQgetvalue(res->get(), 0, 0);
-    int count = boost::lexical_cast<int>(numstr);
-
-    if (count != expected) {
-        throw std::runtime_error((boost::format("Expected %1%, but got %2%, when running "
-                                                "query: %3%.")
-                                  % expected % count % query).str());
-    }
-}
-
-void assert_has_table(pg::conn_ptr &test_conn, const std::string &table_name) {
-    std::string query = (boost::format("select count(*) from pg_catalog.pg_class "
-                                       "where relname = '%1%'")
-                         % table_name).str();
-
-    check_count(test_conn, 1, query);
-}
 
 // "simple" test modeled on the basic regression test from
 // the python script. this is just to check everything is
@@ -136,21 +85,18 @@ void test_z_order() {
 
     osmdata.stop();
 
-    // start a new connection to run tests on
-    pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
+    db->assert_has_table("osm2pgsql_test_point");
+    db->assert_has_table("osm2pgsql_test_line");
+    db->assert_has_table("osm2pgsql_test_polygon");
+    db->assert_has_table("osm2pgsql_test_roads");
 
-    assert_has_table(test_conn, "osm2pgsql_test_point");
-    assert_has_table(test_conn, "osm2pgsql_test_line");
-    assert_has_table(test_conn, "osm2pgsql_test_polygon");
-    assert_has_table(test_conn, "osm2pgsql_test_roads");
+    db->check_string("motorway", "SELECT highway FROM osm2pgsql_test_line WHERE layer IS NULL ORDER BY z_order DESC LIMIT 1 OFFSET 0");
+    db->check_string("trunk", "SELECT highway FROM osm2pgsql_test_line WHERE layer IS NULL ORDER BY z_order DESC LIMIT 1 OFFSET 1");
+    db->check_string("primary", "SELECT highway FROM osm2pgsql_test_line WHERE layer IS NULL ORDER BY z_order DESC LIMIT 1 OFFSET 2");
+    db->check_string("secondary", "SELECT highway FROM osm2pgsql_test_line WHERE layer IS NULL ORDER BY z_order DESC LIMIT 1 OFFSET 3");
+    db->check_string("tertiary", "SELECT highway FROM osm2pgsql_test_line WHERE layer IS NULL ORDER BY z_order DESC LIMIT 1 OFFSET 4");
 
-    check_string(test_conn, "motorway", "SELECT highway FROM osm2pgsql_test_line WHERE layer IS NULL ORDER BY z_order DESC LIMIT 1 OFFSET 0");
-    check_string(test_conn, "trunk", "SELECT highway FROM osm2pgsql_test_line WHERE layer IS NULL ORDER BY z_order DESC LIMIT 1 OFFSET 1");
-    check_string(test_conn, "primary", "SELECT highway FROM osm2pgsql_test_line WHERE layer IS NULL ORDER BY z_order DESC LIMIT 1 OFFSET 2");
-    check_string(test_conn, "secondary", "SELECT highway FROM osm2pgsql_test_line WHERE layer IS NULL ORDER BY z_order DESC LIMIT 1 OFFSET 3");
-    check_string(test_conn, "tertiary", "SELECT highway FROM osm2pgsql_test_line WHERE layer IS NULL ORDER BY z_order DESC LIMIT 1 OFFSET 4");
-
-    check_string(test_conn, "residential", "SELECT highway FROM osm2pgsql_test_line ORDER BY z_order DESC LIMIT 1 OFFSET 0");
+    db->check_string("residential", "SELECT highway FROM osm2pgsql_test_line ORDER BY z_order DESC LIMIT 1 OFFSET 0");
 }
 
 } // anonymous namespace


### PR DESCRIPTION
* Adds a passing test that if osm2pgsql is using the public schema it won't interfere with another schema not in the search_path

* refactors common pg test code into common-pg

I have a failing test I've written for using another schema, but I need to think about that behavior a bit more.