### PR TITLE
Refactor options_t

### DIFF
--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -1028,7 +1028,7 @@ int middle_pgsql_t::connect(table_desc& table) {
     set_prefix_and_tbls(out_options, &(table.array_indexes));
 
     fprintf(stderr, "Setting up table: %s\n", table.name);
-    sql_conn = PQconnectdb(out_options->conninfo.c_str());
+    sql_conn = PQconnectdb(out_options->database_options.conninfo().c_str());
 
     // Check to see that the backend connection was successfully made */
     if (PQstatus(sql_conn) != CONNECTION_OK) {

--- a/options.cpp
+++ b/options.cpp
@@ -276,9 +276,8 @@ options_t::~options_t()
 {
 }
 
-options_t options_t::parse(int argc, char *argv[])
+options_t::options_t(int argc, char *argv[]): options_t()
 {
-    options_t options;
     const char *temparg;
     int c;
 
@@ -292,158 +291,158 @@ options_t options_t::parse(int argc, char *argv[])
         //handle the current arg
         switch (c) {
         case 'a':
-            options.append = true;
+            append = true;
             break;
         case 'b':
-            options.bbox = optarg;
+            bbox = optarg;
             break;
         case 'c':
-            options.create = true;
+            create = true;
             break;
         case 'v':
-            options.verbose = true;
+            verbose = true;
             break;
         case 's':
-            options.slim = true;
+            slim = true;
             break;
         case 'K':
-            options.keep_coastlines = true;
+            keep_coastlines = true;
             break;
         case 'l':
-            options.projection.reset(new reprojection(PROJ_LATLONG));
+            projection.reset(new reprojection(PROJ_LATLONG));
             break;
         case 'm':
-            options.projection.reset(new reprojection(PROJ_SPHERE_MERC));
+            projection.reset(new reprojection(PROJ_SPHERE_MERC));
             break;
         case 'E':
-            options.projection.reset(new reprojection(-atoi(optarg)));
+            projection.reset(new reprojection(-atoi(optarg)));
             break;
         case 'p':
-            options.prefix = optarg;
+            prefix = optarg;
             break;
         case 'd':
-            options.db = optarg;
+            db = optarg;
             break;
         case 'C':
-            options.cache = atoi(optarg);
+            cache = atoi(optarg);
             break;
         case 'U':
-            options.username = optarg;
+            username = optarg;
             break;
         case 'W':
-            options.pass_prompt = true;
+            pass_prompt = true;
             break;
         case 'H':
-            options.host = optarg;
+            host = optarg;
             break;
         case 'P':
-            options.port = optarg;
+            port = optarg;
             break;
         case 'S':
-            options.style = optarg;
+            style = optarg;
             break;
         case 'i':
-            options.tblsmain_index = options.tblsslim_index = optarg;
+            tblsmain_index = tblsslim_index = optarg;
             break;
         case 200:
-            options.tblsslim_data = optarg;
+            tblsslim_data = optarg;
             break;
         case 201:
-            options.tblsslim_index = optarg;
+            tblsslim_index = optarg;
             break;
         case 202:
-            options.tblsmain_data = optarg;
+            tblsmain_data = optarg;
             break;
         case 203:
-            options.tblsmain_index = optarg;
+            tblsmain_index = optarg;
             break;
         case 'e':
-            options.expire_tiles_zoom_min = atoi(optarg);
+            expire_tiles_zoom_min = atoi(optarg);
             temparg = strchr(optarg, '-');
             if (temparg)
-                options.expire_tiles_zoom = atoi(temparg + 1);
-            if (options.expire_tiles_zoom < options.expire_tiles_zoom_min)
-                options.expire_tiles_zoom = options.expire_tiles_zoom_min;
+                expire_tiles_zoom = atoi(temparg + 1);
+            if (expire_tiles_zoom < expire_tiles_zoom_min)
+                expire_tiles_zoom = expire_tiles_zoom_min;
             break;
         case 'o':
-            options.expire_tiles_filename = optarg;
+            expire_tiles_filename = optarg;
             break;
         case 'O':
-            options.output_backend = optarg;
+            output_backend = optarg;
             break;
         case 'x':
-            options.extra_attributes = true;
+            extra_attributes = true;
             break;
         case 'k':
-            if (options.hstore_mode != HSTORE_NONE) {
+            if (hstore_mode != HSTORE_NONE) {
                 throw std::runtime_error("You can not specify both --hstore (-k) and --hstore-all (-j)\n");
             }
-            options.hstore_mode = HSTORE_NORM;
+            hstore_mode = HSTORE_NORM;
             break;
         case 208:
-            options.hstore_match_only = true;
+            hstore_match_only = true;
             break;
         case 'j':
-            if (options.hstore_mode != HSTORE_NONE) {
+            if (hstore_mode != HSTORE_NONE) {
                 throw std::runtime_error("You can not specify both --hstore (-k) and --hstore-all (-j)\n");
             }
-            options.hstore_mode = HSTORE_ALL;
+            hstore_mode = HSTORE_ALL;
             break;
         case 'z':
-            options.hstore_columns.push_back(optarg);
+            hstore_columns.push_back(optarg);
             break;
         case 'G':
-            options.enable_multi = true;
+            enable_multi = true;
             break;
         case 'r':
-            options.input_reader = optarg;
+            input_reader = optarg;
             break;
         case 'h':
-            options.long_usage_bool = true;
+            long_usage_bool = true;
             break;
         case 'I':
 #ifdef HAVE_PTHREAD
-            options.parallel_indexing = false;
+            parallel_indexing = false;
 #endif
             break;
         case 204:
             if (strcmp(optarg, "dense") == 0)
-                options.alloc_chunkwise = ALLOC_DENSE;
+                alloc_chunkwise = ALLOC_DENSE;
             else if (strcmp(optarg, "chunk") == 0)
-                options.alloc_chunkwise = ALLOC_DENSE | ALLOC_DENSE_CHUNK;
+                alloc_chunkwise = ALLOC_DENSE | ALLOC_DENSE_CHUNK;
             else if (strcmp(optarg, "sparse") == 0)
-                options.alloc_chunkwise = ALLOC_SPARSE;
+                alloc_chunkwise = ALLOC_SPARSE;
             else if (strcmp(optarg, "optimized") == 0)
-                options.alloc_chunkwise = ALLOC_DENSE | ALLOC_SPARSE;
+                alloc_chunkwise = ALLOC_DENSE | ALLOC_SPARSE;
             else {
                 throw std::runtime_error((boost::format("Unrecognized cache strategy %1%.\n") % optarg).str());
             }
             break;
         case 205:
 #ifdef HAVE_FORK
-            options.num_procs = atoi(optarg);
+            num_procs = atoi(optarg);
 #else
             fprintf(stderr, "WARNING: osm2pgsql was compiled without fork, only using one process!\n");
 #endif
             break;
         case 206:
-            options.droptemp = true;
+            droptemp = true;
             break;
         case 207:
-            options.unlogged = true;
+            unlogged = true;
             break;
         case 209:
-            options.flat_node_cache_enabled = true;
-            options.flat_node_file = optarg;
+            flat_node_cache_enabled = true;
+            flat_node_file = optarg;
             break;
         case 210:
-            options.excludepoly = true;
+            excludepoly = true;
             break;
         case 211:
-            options.enable_hstore_index = true;
+            enable_hstore_index = true;
             break;
         case 212:
-            options.tag_transform_script = optarg;
+            tag_transform_script = optarg;
             break;
         case 'V':
             exit (EXIT_SUCCESS);
@@ -456,8 +455,8 @@ options_t options_t::parse(int argc, char *argv[])
     } //end while
 
     //they were looking for usage info
-    if (options.long_usage_bool) {
-        long_usage(argv[0], options.verbose);
+    if (long_usage_bool) {
+        long_usage(argv[0], verbose);
     }
 
     //we require some input files!
@@ -467,73 +466,71 @@ options_t options_t::parse(int argc, char *argv[])
 
     //get the input files
     while (optind < argc) {
-        options.input_files.push_back(std::string(argv[optind]));
+        input_files.push_back(std::string(argv[optind]));
         optind++;
     }
 
-    if (options.append && options.create) {
+    if (append && create) {
         throw std::runtime_error("--append and --create options can not be used at the same time!\n");
     }
 
-    if (options.append && !options.slim) {
+    if (append && !slim) {
         throw std::runtime_error("--append can only be used with slim mode!\n");
     }
 
-    if (options.droptemp && !options.slim) {
+    if (droptemp && !slim) {
         throw std::runtime_error("--drop only makes sense with --slim.\n");
     }
 
-    if (options.unlogged && !options.create) {
+    if (unlogged && !create) {
         fprintf(stderr, "Warning: --unlogged only makes sense with --create; ignored.\n");
-        options.unlogged = false;
+        unlogged = false;
     }
 
-    if (options.hstore_mode == HSTORE_NONE && options.hstore_columns.size() == 0 && options.hstore_match_only) {
+    if (hstore_mode == HSTORE_NONE && hstore_columns.size() == 0 && hstore_match_only) {
         fprintf(stderr, "Warning: --hstore-match-only only makes sense with --hstore, --hstore-all, or --hstore-column; ignored.\n");
-        options.hstore_match_only = false;
+        hstore_match_only = false;
     }
 
-    if (options.enable_hstore_index && options.hstore_mode == HSTORE_NONE && options.hstore_columns.size() == 0) {
+    if (enable_hstore_index && hstore_mode == HSTORE_NONE && hstore_columns.size() == 0) {
         fprintf(stderr, "Warning: --hstore-add-index only makes sense with hstore enabled.\n");
-        options.enable_hstore_index = false;
+        enable_hstore_index = false;
     }
 
-    if (options.cache < 0)
-        options.cache = 0;
+    if (cache < 0)
+        cache = 0;
 
-    if (options.cache == 0) {
+    if (cache == 0) {
         fprintf(stderr, "WARNING: ram cache is disabled. This will likely slow down processing a lot.\n\n");
     }
-    if (sizeof(int*) == 4 && !options.slim) {
+    if (sizeof(int*) == 4 && !slim) {
         fprintf(stderr, "\n!! You are running this on 32bit system, so at most\n");
         fprintf(stderr, "!! 3GB of RAM can be used. If you encounter unexpected\n");
         fprintf(stderr, "!! exceptions during import, you should try running in slim\n");
         fprintf(stderr, "!! mode using parameter -s.\n");
     }
 
-    if (options.pass_prompt) {
+    if (pass_prompt) {
         char *prompt = simple_prompt("Password:", 100, 0);
         if (prompt == nullptr) {
-            options.password = boost::none;
+            password = boost::none;
         } else {
-            options.password = std::string(prompt);
+            password = std::string(prompt);
         }
     } else {
         char *pgpass = getenv("PGPASS");
         if (pgpass == nullptr) {
-            options.password = boost::none;
+            password = boost::none;
         } else {
-            options.password = std::string(pgpass);
+            password = std::string(pgpass);
         }
     }
 
-    if (options.num_procs < 1)
-        options.num_procs = 1;
+    if (num_procs < 1)
+        num_procs = 1;
 
     //NOTE: this is hugely important if you set it inappropriately and are are caching nodes
     //you could get overflow when working with larger coordinates (mercator) and larger scales
-    options.scale = (options.projection->get_proj_id() == PROJ_LATLONG) ? 10000000 : 100;
-    options.conninfo = build_conninfo(options.db, options.username, options.password, options.host, options.port);
-
-    return options;
+    scale = (projection->get_proj_id() == PROJ_LATLONG) ? 10000000 : 100;
+    conninfo = build_conninfo(db, username, password, host, port);
 }

--- a/options.cpp
+++ b/options.cpp
@@ -230,7 +230,7 @@ namespace
 
 database_options_t::database_options_t():
     db("gis"), username(boost::none), host(boost::none),
-    password(boost::none), port("5432")
+    password(boost::none), port(boost::none)
 {
 
 }
@@ -250,7 +250,9 @@ std::string database_options_t::conninfo() const
     if (host) {
         out << " host='" << *host << "'";
     }
-    out << " port='" << port << "'";
+    if (port) {
+        out << " port='" << port << "'";
+    }
 
     return out.str();
 }
@@ -518,13 +520,6 @@ options_t::options_t(int argc, char *argv[]): options_t()
             database_options.password = boost::none;
         } else {
             database_options.password = std::string(prompt);
-        }
-    } else {
-        char *pgpass = getenv("PGPASS");
-        if (pgpass == nullptr) {
-            database_options.password = boost::none;
-        } else {
-            database_options.password = std::string(pgpass);
         }
     }
 

--- a/options.hpp
+++ b/options.hpp
@@ -30,7 +30,7 @@ public:
     boost::optional<std::string> username;
     boost::optional<std::string> host;
     boost::optional<std::string> password;
-    std::string port;
+    boost::optional<std::string> port;
 
     std::string conninfo() const;
 };

--- a/options.hpp
+++ b/options.hpp
@@ -21,6 +21,21 @@
 enum { DEFAULT_SCALE = 100 };
 
 /**
+ * Database options, not specific to a table
+ */
+class database_options_t {
+public:
+    database_options_t();
+    std::string db;
+    boost::optional<std::string> username;
+    boost::optional<std::string> host;
+    boost::optional<std::string> password;
+    std::string port;
+
+    std::string conninfo() const;
+};
+
+/**
  * Structure for storing command-line and other options
  */
 struct options_t {
@@ -33,7 +48,6 @@ public:
     options_t(int argc, char *argv[]);
     virtual ~options_t();
 
-    std::string conninfo; ///< Connection info string
     std::string prefix; ///< prefix for table names
     int scale; ///< scale for converting coordinates to fixed point
     std::shared_ptr<reprojection> projection; ///< SRS of projection
@@ -78,11 +92,7 @@ public:
     bool long_usage_bool;
     bool pass_prompt;
 
-    std::string db;
-    boost::optional<std::string> username;
-    boost::optional<std::string> host;
-    boost::optional<std::string> password;
-    std::string port;
+    database_options_t database_options;
     std::string output_backend;
     std::string input_reader;
     boost::optional<std::string> bbox;

--- a/options.hpp
+++ b/options.hpp
@@ -101,7 +101,10 @@ public:
 
     std::vector<std::string> input_files;
 private:
-
+    /**
+     * Check input options for sanity
+     */
+    void check_options();
 };
 
 #endif

--- a/options.hpp
+++ b/options.hpp
@@ -25,14 +25,13 @@ enum { DEFAULT_SCALE = 100 };
  */
 struct options_t {
 public:
-    /* construct with sensible defaults */
+  // fixme: bring back old comment
     options_t();
-    virtual ~options_t();
-
     /**
      * Parse the options from the command line
      */
-    static options_t parse(int argc, char *argv[]);
+    options_t(int argc, char *argv[]);
+    virtual ~options_t();
 
     std::string conninfo; ///< Connection info string
     std::string prefix; ///< prefix for table names

--- a/osm2pgsql.cpp
+++ b/osm2pgsql.cpp
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
         osmdata_t osmdata(middle, outputs);
 
         //check the database
-        check_db(options.conninfo.c_str(), options.unlogged);
+        check_db(options.database_options.conninfo().c_str(), options.unlogged);
 
         fprintf(stderr, "Using projection SRS %d (%s)\n",
                 options.projection->project_getprojinfo()->srs,

--- a/osm2pgsql.cpp
+++ b/osm2pgsql.cpp
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
     try
     {
         //parse the args into the different options members
-        options_t options = options_t::parse(argc, argv);
+        options_t options = options_t(argc, argv);
         if(options.long_usage_bool)
             return 0;
 

--- a/output-gazetteer.cpp
+++ b/output-gazetteer.cpp
@@ -576,7 +576,7 @@ void output_gazetteer_t::delete_place(char osm_type, osmid_t osm_id)
 
 int output_gazetteer_t::connect() {
     /* Connection to the database */
-    Connection = PQconnectdb(m_options.conninfo.c_str());
+    Connection = PQconnectdb(m_options.database_options.conninfo().c_str());
 
     /* Check to see that the backend connection was successfully made */
     if (PQstatus(Connection) != CONNECTION_OK) {
@@ -585,7 +585,7 @@ int output_gazetteer_t::connect() {
     }
 
     if (m_options.append) {
-        ConnectionDelete = PQconnectdb(m_options.conninfo.c_str());
+        ConnectionDelete = PQconnectdb(m_options.database_options.conninfo().c_str());
         if (PQstatus(ConnectionDelete) != CONNECTION_OK)
         {
             std::cerr << "Connection to database failed: " << PQerrorMessage(Connection) << "\n";

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -21,7 +21,7 @@ output_multi_t::output_multi_t(const std::string &name,
       m_processor(processor_),
       //TODO: we could in fact have something that is interested in nodes and ways..
       m_osm_type(m_processor->interests(geometry_processor::interest_node) ? OSMTYPE_NODE : OSMTYPE_WAY),
-      m_table(new table_t(m_options.conninfo, name, m_processor->column_type(),
+      m_table(new table_t(m_options.database_options.conninfo(), name, m_processor->column_type(),
                           m_export_list->normal_columns(m_osm_type),
                           m_options.hstore_columns, m_processor->srid(),
                           m_options.append, m_options.slim, m_options.droptemp,

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -716,7 +716,7 @@ output_pgsql_t::output_pgsql_t(const middle_query_t* mid_, const options_t &opti
         //have a different tablespace/hstores/etc per table
         m_tables.push_back(std::shared_ptr<table_t>(
             new table_t(
-                m_options.conninfo, name, type, columns, m_options.hstore_columns, SRID,
+                m_options.database_options.conninfo(), name, type, columns, m_options.hstore_columns, SRID,
                 m_options.append, m_options.slim, m_options.droptemp, m_options.hstore_mode,
                 m_options.enable_hstore_index, m_options.tblsmain_data, m_options.tblsmain_index
             )

--- a/tests/common-pg.hpp
+++ b/tests/common-pg.hpp
@@ -7,6 +7,9 @@
 #include <boost/noncopyable.hpp>
 #include <libpq-fe.h>
 
+// reuse the database_options_t class
+#include "options.hpp"
+
 /* Some RAII objects to make writing stuff that needs a temporary database
  * easier, and to keep track of and free connections and results objects.
  */
@@ -23,6 +26,7 @@ struct conn
       public std::enable_shared_from_this<conn> {
 
     static conn_ptr connect(const std::string &conninfo);
+    static conn_ptr connect(const database_options_t &database_options);
     result_ptr exec(const std::string &query);
     result_ptr exec(const boost::format &fmt);
     PGconn *get();
@@ -52,7 +56,7 @@ struct tempdb
     tempdb();
     ~tempdb();
 
-    const std::string &conninfo() const;
+    database_options_t database_options;
 
     void check_tblspc();
 
@@ -61,8 +65,6 @@ private:
     void setup_extension(conn_ptr db, const std::string &extension, const std::vector<std::string> &extension_files = std::vector<std::string>());
 
     conn_ptr m_conn;
-    std::string m_db_name;
-    std::string m_conninfo;
 };
 
 } // namespace pg

--- a/tests/test-hstore-match-only.cpp
+++ b/tests/test-hstore-match-only.cpp
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
     try {
         std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
         options_t options;
-        options.conninfo = db->conninfo().c_str();
+        options.database_options = db->database_options;
         options.num_procs = 1;
         options.prefix = "osm2pgsql_test";
         options.style="tests/hstore-match-only.style";
@@ -90,7 +90,7 @@ int main(int argc, char *argv[]) {
         osmdata.stop();
 
         // start a new connection to run tests on
-        pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+        pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
 
         // tables should not contain any tag columns
         check_count(test_conn, 4, "select count(column_name) from information_schema.columns where table_name='osm2pgsql_test_point'");

--- a/tests/test-middle-flat.cpp
+++ b/tests/test-middle-flat.cpp
@@ -82,7 +82,7 @@ int main(int argc, char *argv[]) {
 
   try {
     options_t options;
-    options.conninfo = db->conninfo().c_str();
+    options.database_options = db->database_options;
     options.scale = 10000000;
     options.cache = 1;
     options.num_procs = 1;

--- a/tests/test-middle-pgsql.cpp
+++ b/tests/test-middle-pgsql.cpp
@@ -73,7 +73,7 @@ int main(int argc, char *argv[]) {
 
   try {
     options_t options;
-    options.conninfo = db->conninfo().c_str();
+    options.database_options = db->database_options;
     options.scale = 10000000;
     options.cache = 1;
     options.num_procs = 1;

--- a/tests/test-output-multi-line-storage.cpp
+++ b/tests/test-output-multi-line-storage.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) {
 
     try {
         options_t options;
-        options.conninfo = db->conninfo().c_str();
+        options.database_options = db->database_options;
         options.num_procs = 1;
         options.slim = true;
 
@@ -85,7 +85,7 @@ int main(int argc, char *argv[]) {
         osmdata.stop();
 
         // start a new connection to run tests on
-        pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+        pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
 
         check_count(test_conn, 1, "select count(*) from pg_catalog.pg_class where relname = 'test_line'");
         check_count(test_conn, 3, "select count(*) from test_line");

--- a/tests/test-output-multi-line.cpp
+++ b/tests/test-output-multi-line.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[]) {
     try {
         std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
         options_t options;
-        options.conninfo = db->conninfo().c_str();
+        options.database_options = db->database_options;
         options.num_procs = 1;
         options.slim = true;
 
@@ -83,7 +83,7 @@ int main(int argc, char *argv[]) {
         osmdata.stop();
 
         // start a new connection to run tests on
-        pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+        pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
 
         check_count(test_conn, 1, "select count(*) from pg_catalog.pg_class where relname = 'foobar_highways'");
         check_count(test_conn, 2753, "select count(*) from foobar_highways");

--- a/tests/test-output-multi-point-multi-table.cpp
+++ b/tests/test-output-multi-point-multi-table.cpp
@@ -63,7 +63,7 @@ int main(int argc, char *argv[]) {
     try {
         std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
         options_t options;
-        options.conninfo = db->conninfo().c_str();
+        options.database_options = db->database_options;
         options.num_procs = 1;
         options.prefix = "osm2pgsql_test";
         options.slim = true;
@@ -98,7 +98,7 @@ int main(int argc, char *argv[]) {
         osmdata.stop();
 
         // start a new connection to run tests on
-        pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+        pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
 
         for (int i = 0; i < 10; ++i) {
             std::string name = (boost::format("foobar_%d") % i).str();

--- a/tests/test-output-multi-point.cpp
+++ b/tests/test-output-multi-point.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[]) {
     try {
         std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
         options_t options;
-        options.conninfo = db->conninfo().c_str();
+        options.database_options = db->database_options;
         options.num_procs = 1;
         options.prefix = "osm2pgsql_test";
         options.slim = true;
@@ -84,7 +84,7 @@ int main(int argc, char *argv[]) {
         osmdata.stop();
 
         // start a new connection to run tests on
-        pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+        pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
 
         check_count(test_conn, 1,
                     "select count(*) from pg_catalog.pg_class "

--- a/tests/test-output-multi-poly-trivial.cpp
+++ b/tests/test-output-multi-poly-trivial.cpp
@@ -65,9 +65,9 @@ void run_osm2pgsql(options_t &options) {
   osmdata.stop();
 }
 
-void check_output_poly_trivial(bool enable_multi, std::string conninfo) {
+void check_output_poly_trivial(bool enable_multi, database_options_t &database_options) {
   options_t options;
-  options.conninfo = conninfo.c_str();
+  options.database_options = database_options;
   options.num_procs = 1;
   options.slim = 1;
   options.enable_multi = enable_multi;
@@ -80,7 +80,7 @@ void check_output_poly_trivial(bool enable_multi, std::string conninfo) {
   run_osm2pgsql(options);
 
   // start a new connection to run tests on
-  pg::conn_ptr test_conn = pg::conn::connect(conninfo);
+  pg::conn_ptr test_conn = pg::conn::connect(database_options);
 
   // expect that the table exists
   check_count(test_conn, 1, "select count(*) from pg_catalog.pg_class where relname = 'test_poly'");
@@ -119,8 +119,8 @@ int main(int argc, char *argv[]) {
     }
 
     try {
-        check_output_poly_trivial(0, db->conninfo());
-        check_output_poly_trivial(1, db->conninfo());
+        check_output_poly_trivial(0, db->database_options);
+        check_output_poly_trivial(1, db->database_options);
         return 0;
 
     } catch (const std::exception &e) {

--- a/tests/test-output-multi-polygon.cpp
+++ b/tests/test-output-multi-polygon.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[]) {
     try {
         std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
         options_t options;
-        options.conninfo = db->conninfo().c_str();
+        options.database_options = db->database_options;
         options.num_procs = 1;
         options.prefix = "osm2pgsql_test";
         options.slim = true;
@@ -83,7 +83,7 @@ int main(int argc, char *argv[]) {
         osmdata.stop();
 
         // start a new connection to run tests on
-        pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+        pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
 
         check_count(test_conn, 1, "select count(*) from pg_catalog.pg_class where relname = 'foobar_buildings'");
         check_count(test_conn, 0, "select count(*) from foobar_buildings where building is null");

--- a/tests/test-output-multi-tags.cpp
+++ b/tests/test-output-multi-tags.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) {
 
     try {
         options_t options;
-        options.conninfo = db->conninfo().c_str();
+        options.database_options = db->database_options;
         options.num_procs = 1;
         options.slim = true;
 
@@ -85,7 +85,7 @@ int main(int argc, char *argv[]) {
         osmdata.stop();
 
         // start a new connection to run tests on
-        pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+        pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
 
         // Check we got the right tables
         check_count(test_conn, 1, "select count(*) from pg_catalog.pg_class where relname = 'test_points_1'");

--- a/tests/test-output-pgsql-tablespace.cpp
+++ b/tests/test-output-pgsql-tablespace.cpp
@@ -96,7 +96,7 @@ void test_regression_simple() {
     char *argv[] = { &proc_name[0], &input_file[0], nullptr };
 
     std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
-    options_t options = options_t::parse(2, argv);
+    options_t options = options_t(2, argv);
     options.conninfo = db->conninfo().c_str();
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";

--- a/tests/test-output-pgsql-tablespace.cpp
+++ b/tests/test-output-pgsql-tablespace.cpp
@@ -97,7 +97,7 @@ void test_regression_simple() {
 
     std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
     options_t options = options_t(2, argv);
-    options.conninfo = db->conninfo().c_str();
+    options.database_options = db->database_options;
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";
     options.slim = true;
@@ -121,7 +121,7 @@ void test_regression_simple() {
     osmdata.stop();
 
     // start a new connection to run tests on
-    pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+    pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
 
     assert_has_table(test_conn, "osm2pgsql_test_point");
     assert_has_table(test_conn, "osm2pgsql_test_line");

--- a/tests/test-output-pgsql-z_order.cpp
+++ b/tests/test-output-pgsql-z_order.cpp
@@ -117,7 +117,7 @@ void test_z_order() {
 
     std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
     options_t options = options_t(2, argv);
-    options.conninfo = db->conninfo().c_str();
+    options.database_options = db->database_options;
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";
     options.style = "default.style";
@@ -137,7 +137,7 @@ void test_z_order() {
     osmdata.stop();
 
     // start a new connection to run tests on
-    pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+    pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
 
     assert_has_table(test_conn, "osm2pgsql_test_point");
     assert_has_table(test_conn, "osm2pgsql_test_line");

--- a/tests/test-output-pgsql-z_order.cpp
+++ b/tests/test-output-pgsql-z_order.cpp
@@ -116,7 +116,7 @@ void test_z_order() {
     char *argv[] = { &proc_name[0], &input_file[0], nullptr };
 
     std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
-    options_t options = options_t::parse(2, argv);
+    options_t options = options_t(2, argv);
     options.conninfo = db->conninfo().c_str();
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";

--- a/tests/test-output-pgsql.cpp
+++ b/tests/test-output-pgsql.cpp
@@ -116,7 +116,7 @@ void test_regression_simple() {
     char *argv[] = { &proc_name[0], &input_file[0], nullptr };
 
     std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
-    options_t options = options_t::parse(2, argv);
+    options_t options = options_t(2, argv);
     options.conninfo = db->conninfo().c_str();
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";
@@ -176,7 +176,7 @@ void test_latlong() {
     char *argv[] = { &proc_name[0], &input_file[0], nullptr };
 
     std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
-    options_t options = options_t::parse(2, argv);
+    options_t options = options_t(2, argv);
     options.conninfo = db->conninfo().c_str();
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";
@@ -240,7 +240,7 @@ void test_area_way_simple() {
     char *argv[] = { &proc_name[0], &input_file[0], nullptr };
 
     std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
-    options_t options = options_t::parse(2, argv);
+    options_t options = options_t(2, argv);
     options.conninfo = db->conninfo().c_str();
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";
@@ -291,7 +291,7 @@ void test_route_rel() {
     char *argv[] = { &proc_name[0], &input_file[0], nullptr };
 
     std::shared_ptr<middle_ram_t> mid_ram(new middle_ram_t());
-    options_t options = options_t::parse(2, argv);
+    options_t options = options_t(2, argv);
     options.conninfo = db->conninfo().c_str();
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";
@@ -342,7 +342,7 @@ void test_clone() {
     char *argv[] = { &proc_name[0], &input_file[0], nullptr };
 
     std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
-    options_t options = options_t::parse(2, argv);
+    options_t options = options_t(2, argv);
     options.conninfo = db->conninfo().c_str();
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";

--- a/tests/test-output-pgsql.cpp
+++ b/tests/test-output-pgsql.cpp
@@ -117,7 +117,7 @@ void test_regression_simple() {
 
     std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
     options_t options = options_t(2, argv);
-    options.conninfo = db->conninfo().c_str();
+    options.database_options = db->database_options;
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";
     options.slim = true;
@@ -138,7 +138,7 @@ void test_regression_simple() {
     osmdata.stop();
 
     // start a new connection to run tests on
-    pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+    pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
 
     assert_has_table(test_conn, "osm2pgsql_test_point");
     assert_has_table(test_conn, "osm2pgsql_test_line");
@@ -177,7 +177,7 @@ void test_latlong() {
 
     std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
     options_t options = options_t(2, argv);
-    options.conninfo = db->conninfo().c_str();
+    options.database_options = db->database_options;
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";
     options.slim = true;
@@ -201,7 +201,7 @@ void test_latlong() {
     osmdata.stop();
 
     // start a new connection to run tests on
-    pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+    pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
 
     assert_has_table(test_conn, "osm2pgsql_test_point");
     assert_has_table(test_conn, "osm2pgsql_test_line");
@@ -241,7 +241,7 @@ void test_area_way_simple() {
 
     std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
     options_t options = options_t(2, argv);
-    options.conninfo = db->conninfo().c_str();
+    options.database_options = db->database_options;
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";
     options.slim = true;
@@ -264,7 +264,7 @@ void test_area_way_simple() {
     osmdata.stop();
 
     // start a new connection to run tests on
-    pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+    pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
 
     assert_has_table(test_conn, "osm2pgsql_test_point");
     assert_has_table(test_conn, "osm2pgsql_test_line");
@@ -292,7 +292,7 @@ void test_route_rel() {
 
     std::shared_ptr<middle_ram_t> mid_ram(new middle_ram_t());
     options_t options = options_t(2, argv);
-    options.conninfo = db->conninfo().c_str();
+    options.database_options = db->database_options;
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";
     options.slim = false;
@@ -313,7 +313,7 @@ void test_route_rel() {
     osmdata.stop();
 
     // start a new connection to run tests on
-    pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+    pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
 
     assert_has_table(test_conn, "osm2pgsql_test_point");
     assert_has_table(test_conn, "osm2pgsql_test_line");
@@ -343,7 +343,7 @@ void test_clone() {
 
     std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
     options_t options = options_t(2, argv);
-    options.conninfo = db->conninfo().c_str();
+    options.database_options = db->database_options;
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";
     options.slim = true;
@@ -368,7 +368,7 @@ void test_clone() {
     osmdata.stop();
 
     // start a new connection to run tests on
-    pg::conn_ptr test_conn = pg::conn::connect(db->conninfo());
+    pg::conn_ptr test_conn = pg::conn::connect(db->database_options);
 
     assert_has_table(test_conn, "osm2pgsql_test_point");
     assert_has_table(test_conn, "osm2pgsql_test_line");

--- a/tests/test-parse-options.cpp
+++ b/tests/test-parse-options.cpp
@@ -37,7 +37,7 @@ void parse_fail(const int argc, const char* argv[], const std::string& fail_mess
 {
     try
     {
-        options_t options = options_t::parse(argc, const_cast<char **>(argv));
+        options_t options = options_t(argc, const_cast<char **>(argv));
         throw std::logic_error((boost::format("Expected '%1%'") % fail_message).str());
     }
     catch(const std::runtime_error& e)
@@ -68,7 +68,7 @@ void test_incompatible_args()
 void test_middles()
 {
     const char* a1[] = {"osm2pgsql", "--slim", "tests/liechtenstein-2013-08-03.osm.pbf"};
-    options_t options = options_t::parse(len(a1), const_cast<char **>(a1));
+    options_t options = options_t(len(a1), const_cast<char **>(a1));
     std::shared_ptr<middle_t> mid = middle_t::create_middle(options.slim);
     if(dynamic_cast<middle_pgsql_t *>(mid.get()) == nullptr)
     {
@@ -76,7 +76,7 @@ void test_middles()
     }
 
     const char* a2[] = {"osm2pgsql", "tests/liechtenstein-2013-08-03.osm.pbf"};
-    options = options_t::parse(len(a2), const_cast<char **>(a2));
+    options = options_t(len(a2), const_cast<char **>(a2));
     mid = middle_t::create_middle(options.slim);
     if(dynamic_cast<middle_ram_t *>(mid.get()) == nullptr)
     {
@@ -87,7 +87,7 @@ void test_middles()
 void test_outputs()
 {
     const char* a1[] = {"osm2pgsql", "-O", "pgsql", "--style", "default.style", "tests/liechtenstein-2013-08-03.osm.pbf"};
-    options_t options = options_t::parse(len(a1), const_cast<char **>(a1));
+    options_t options = options_t(len(a1), const_cast<char **>(a1));
     std::shared_ptr<middle_t> mid = middle_t::create_middle(options.slim);
     std::vector<std::shared_ptr<output_t> > outs = output_t::create_outputs(mid.get(), options);
     output_t* out = outs.front().get();
@@ -97,7 +97,7 @@ void test_outputs()
     }
 
     const char* a2[] = {"osm2pgsql", "-O", "gazetteer", "--style", "default.style", "tests/liechtenstein-2013-08-03.osm.pbf"};
-    options = options_t::parse(len(a2), const_cast<char **>(a2));
+    options = options_t(len(a2), const_cast<char **>(a2));
     mid = middle_t::create_middle(options.slim);
     outs = output_t::create_outputs(mid.get(), options);
     out = outs.front().get();
@@ -107,7 +107,7 @@ void test_outputs()
     }
 
     const char* a3[] = {"osm2pgsql", "-O", "null", "--style", "default.style", "tests/liechtenstein-2013-08-03.osm.pbf"};
-    options = options_t::parse(len(a3), const_cast<char **>(a3));
+    options = options_t(len(a3), const_cast<char **>(a3));
     mid = middle_t::create_middle(options.slim);
     outs = output_t::create_outputs(mid.get(), options);
     out = outs.front().get();
@@ -117,7 +117,7 @@ void test_outputs()
     }
 
     const char* a4[] = {"osm2pgsql", "-O", "keine_richtige_ausgabe", "--style", "default.style", "tests/liechtenstein-2013-08-03.osm.pbf"};
-    options = options_t::parse(len(a4), const_cast<char **>(a4));
+    options = options_t(len(a4), const_cast<char **>(a4));
     mid = middle_t::create_middle(options.slim);
     try
     {
@@ -274,7 +274,7 @@ void test_random_perms()
         argv[args.size()] = nullptr;
         for(std::vector<std::string>::const_iterator arg = args.begin(); arg != args.end(); ++arg)
             argv[arg - args.begin()] = arg->c_str();
-        options_t::parse(args.size(), const_cast<char **>(argv));
+        options_t(args.size(), const_cast<char **>(argv));
         delete[] argv;
     }
 }

--- a/tests/test-parse-options.cpp
+++ b/tests/test-parse-options.cpp
@@ -215,12 +215,12 @@ void test_random_perms()
         args.push_back(style);
 
         add_arg_and_val_or_not("--cache", args, options.cache, rand() % 800);
-        add_arg_and_val_or_not("--database", args, options.db.c_str(), get_random_string(6));
-        if (options.username) {
-            add_arg_and_val_or_not("--username", args, options.username->c_str(), get_random_string(6));
+        add_arg_and_val_or_not("--database", args, options.database_options.db.c_str(), get_random_string(6));
+        if (options.database_options.username) {
+            add_arg_and_val_or_not("--username", args, options.database_options.username->c_str(), get_random_string(6));
         }
-        if (options.host) {
-            add_arg_and_val_or_not("--host", args, options.host->c_str(), get_random_string(6));
+        if (options.database_options.host) {
+            add_arg_and_val_or_not("--host", args, options.database_options.host->c_str(), get_random_string(6));
         }
         //add_arg_and_val_or_not("--port", args, options.port, rand() % 9999);
 


### PR DESCRIPTION
* Uses a delegating constructor instead of `options_t::parse`
* Moves DB options into their own class
* Don't try to duplicate libpq logic for port
* Split up the giant parse function
* Default to number of hardware threads