### PR TITLE
Refactor table_t constructor

### DIFF
--- a/options.hpp
+++ b/options.hpp
@@ -40,7 +40,9 @@ public:
  */
 struct options_t {
 public:
-  // fixme: bring back old comment
+    /**
+     * construct with sensible defaults
+     */
     options_t();
     /**
      * Parse the options from the command line

--- a/options.hpp
+++ b/options.hpp
@@ -35,6 +35,16 @@ public:
     std::string conninfo() const;
 };
 
+class table_options_t {
+public:
+    table_options_t();
+    int hstore_mode; ///< add an additional hstore column with objects key/value pairs, and what type of hstore column
+    bool hstore_match_only; ///< only copy rows that match an explicitly listed key
+    std::vector<std::string> hstore_columns; ///< list of columns that should be written into their own hstore column
+    bool enable_hstore_index; ///< add an index on the hstore column
+    boost::optional<std::string> tblsmain_index; ///< Pg Tablespace to store indexes on main tables (no default TABLESPACE)
+    boost::optional<std::string> tblsmain_data; ///< Pg Tablespace to store main tables (no default TABLESPACE)
+};
 /**
  * Structure for storing command-line and other options
  */
@@ -56,25 +66,19 @@ public:
     bool append; ///< Append to existing data
     bool slim; ///< In slim mode
     int cache; ///< Memory usable for cache in MB
-    boost::optional<std::string> tblsmain_index; ///< Pg Tablespace to store indexes on main tables (no default TABLESPACE)
     boost::optional<std::string> tblsslim_index; ///< Pg Tablespace to store indexes on slim tables (no default TABLESPACE)
-    boost::optional<std::string> tblsmain_data; ///< Pg Tablespace to store main tables (no default TABLESPACE)
     boost::optional<std::string> tblsslim_data; ///< Pg Tablespace to store slim tables (no default TABLESPACE)
     std::string style; ///< style file to use
     int expire_tiles_zoom; ///< Zoom level for tile expiry list
     int expire_tiles_zoom_min; ///< Minimum zoom level for tile expiry list
     std::string expire_tiles_filename; ///< File name to output expired tiles list to
-    int hstore_mode; ///< add an additional hstore column with objects key/value pairs, and what type of hstore column
-    bool enable_hstore_index; ///< add an index on the hstore column
     bool enable_multi; ///< Output multi-geometries intead of several simple geometries
-    std::vector<std::string> hstore_columns; ///< list of columns that should be written into their own hstore column
     bool keep_coastlines;
     bool parallel_indexing;
     int alloc_chunkwise;
     int num_procs;
     bool droptemp; ///< drop slim mode temp tables after act
     bool unlogged; ///< use unlogged tables where possible
-    bool hstore_match_only; ///< only copy rows that match an explicitly listed key
     bool flat_node_cache_enabled;
     bool excludepoly;
     boost::optional<std::string> flat_node_file;
@@ -95,6 +99,11 @@ public:
     bool pass_prompt;
 
     database_options_t database_options;
+    /**
+     * With the multi backend, each table can have different options. These are
+     * the global defaults passed in on the command line.
+     */
+    table_options_t global_table_options;
     std::string output_backend;
     std::string input_reader;
     boost::optional<std::string> bbox;

--- a/output-gazetteer.cpp
+++ b/output-gazetteer.cpp
@@ -616,15 +616,15 @@ int output_gazetteer_t::start()
       pgsql_exec(Connection, PGRES_COMMAND_OK, "DROP TABLE IF EXISTS place");
 
       /* Create the new table */
-      if (m_options.tblsmain_data) {
+      if (m_options.global_table_options.tblsmain_data) {
           pgsql_exec(Connection, PGRES_COMMAND_OK,
-                     CREATE_PLACE_TABLE, "TABLESPACE", m_options.tblsmain_data->c_str());
+                     CREATE_PLACE_TABLE, "TABLESPACE", m_options.global_table_options.tblsmain_data->c_str());
       } else {
           pgsql_exec(Connection, PGRES_COMMAND_OK, CREATE_PLACE_TABLE, "", "");
       }
-      if (m_options.tblsmain_index) {
+      if (m_options.global_table_options.tblsmain_index) {
           pgsql_exec(Connection, PGRES_COMMAND_OK,
-                     CREATE_PLACE_ID_INDEX, "TABLESPACE", m_options.tblsmain_index->c_str());
+                     CREATE_PLACE_ID_INDEX, "TABLESPACE", m_options.global_table_options.tblsmain_index->c_str());
       } else {
           pgsql_exec(Connection, PGRES_COMMAND_OK, CREATE_PLACE_ID_INDEX, "", "");
       }

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -23,8 +23,7 @@ output_multi_t::output_multi_t(const std::string &name,
       m_osm_type(m_processor->interests(geometry_processor::interest_node) ? OSMTYPE_NODE : OSMTYPE_WAY),
       m_table(new table_t(m_options.database_options.conninfo(), name,
                           m_processor->column_type(), m_export_list->normal_columns(m_osm_type),
-                          m_options.global_table_options, m_processor->srid(),
-                          m_options.append, m_options.slim, m_options.droptemp)),
+                          m_options.global_table_options, m_options)),
       ways_pending_tracker(new id_tracker()), ways_done_tracker(new id_tracker()), rels_pending_tracker(new id_tracker()),
       m_expire(new expire_tiles(&m_options)) {
 }

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -21,12 +21,10 @@ output_multi_t::output_multi_t(const std::string &name,
       m_processor(processor_),
       //TODO: we could in fact have something that is interested in nodes and ways..
       m_osm_type(m_processor->interests(geometry_processor::interest_node) ? OSMTYPE_NODE : OSMTYPE_WAY),
-      m_table(new table_t(m_options.database_options.conninfo(), name, m_processor->column_type(),
-                          m_export_list->normal_columns(m_osm_type),
-                          m_options.global_table_options.hstore_columns, m_processor->srid(),
-                          m_options.append, m_options.slim, m_options.droptemp,
-                          m_options.global_table_options.hstore_mode, m_options.global_table_options.enable_hstore_index,
-                          m_options.global_table_options.tblsmain_data, m_options.global_table_options.tblsmain_index)),
+      m_table(new table_t(m_options.database_options.conninfo(), name,
+                          m_processor->column_type(), m_export_list->normal_columns(m_osm_type),
+                          m_options.global_table_options, m_processor->srid(),
+                          m_options.append, m_options.slim, m_options.droptemp)),
       ways_pending_tracker(new id_tracker()), ways_done_tracker(new id_tracker()), rels_pending_tracker(new id_tracker()),
       m_expire(new expire_tiles(&m_options)) {
 }

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -23,10 +23,10 @@ output_multi_t::output_multi_t(const std::string &name,
       m_osm_type(m_processor->interests(geometry_processor::interest_node) ? OSMTYPE_NODE : OSMTYPE_WAY),
       m_table(new table_t(m_options.database_options.conninfo(), name, m_processor->column_type(),
                           m_export_list->normal_columns(m_osm_type),
-                          m_options.hstore_columns, m_processor->srid(),
+                          m_options.global_table_options.hstore_columns, m_processor->srid(),
                           m_options.append, m_options.slim, m_options.droptemp,
-                          m_options.hstore_mode, m_options.enable_hstore_index,
-                          m_options.tblsmain_data, m_options.tblsmain_index)),
+                          m_options.global_table_options.hstore_mode, m_options.global_table_options.enable_hstore_index,
+                          m_options.global_table_options.tblsmain_data, m_options.global_table_options.tblsmain_index)),
       ways_pending_tracker(new id_tracker()), ways_done_tracker(new id_tracker()), rels_pending_tracker(new id_tracker()),
       m_expire(new expire_tiles(&m_options)) {
 }

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -732,9 +732,9 @@ output_pgsql_t::output_pgsql_t(const middle_query_t* mid_, const options_t &opti
         //have a different tablespace/hstores/etc per table
         m_tables.push_back(std::shared_ptr<table_t>(
             new table_t(
-                m_options.database_options.conninfo(), name, type, columns, m_options.global_table_options.hstore_columns, SRID,
-                m_options.append, m_options.slim, m_options.droptemp, m_options.global_table_options.hstore_mode,
-                m_options.global_table_options.enable_hstore_index, m_options.global_table_options.tblsmain_data, m_options.global_table_options.tblsmain_index
+                m_options.database_options.conninfo(), name, type, columns,
+                m_options.global_table_options, SRID, m_options.append, m_options.slim,
+                m_options.droptemp
             )
         ));
     }

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -724,9 +724,6 @@ output_pgsql_t::output_pgsql_t(const middle_query_t* mid_, const options_t &opti
                 util::exit_nicely();
         }
 
-        //tremble in awe of this massive constructor! seriously we are trying to avoid passing an
-        //options object because we want to make use of the table_t in output_mutli_t which could
-        //have a different tablespace/hstores/etc per table
         m_tables.push_back(std::shared_ptr<table_t>(
             new table_t(
                 m_options.database_options.conninfo(), name, type, columns,

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -732,9 +732,9 @@ output_pgsql_t::output_pgsql_t(const middle_query_t* mid_, const options_t &opti
         //have a different tablespace/hstores/etc per table
         m_tables.push_back(std::shared_ptr<table_t>(
             new table_t(
-                m_options.database_options.conninfo(), name, type, columns, m_options.hstore_columns, SRID,
-                m_options.append, m_options.slim, m_options.droptemp, m_options.hstore_mode,
-                m_options.enable_hstore_index, m_options.tblsmain_data, m_options.tblsmain_index
+                m_options.database_options.conninfo(), name, type, columns, m_options.global_table_options.hstore_columns, SRID,
+                m_options.append, m_options.slim, m_options.droptemp, m_options.global_table_options.hstore_mode,
+                m_options.global_table_options.enable_hstore_index, m_options.global_table_options.tblsmain_data, m_options.global_table_options.tblsmain_index
             )
         ));
     }

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -52,8 +52,6 @@
 #define BOOST_DIAGNOSTIC_INFO(e) boost::diagnostic_information((e))
 #endif
 
-#define SRID (reproj->project_getprojinfo()->srs)
-
 /* FIXME: Shouldn't malloc this all to begin with but call realloc()
    as required. The program will most likely segfault if it reads a
    style file with more styles than this */
@@ -676,7 +674,6 @@ output_pgsql_t::output_pgsql_t(const middle_query_t* mid_, const options_t &opti
       ways_done_tracker(new id_tracker()),
       rels_pending_tracker(new id_tracker()) {
 
-    reproj = m_options.projection;
     builder.set_exclude_broken_polygon(m_options.excludepoly);
 
     m_export_list.reset(new export_list());
@@ -733,18 +730,16 @@ output_pgsql_t::output_pgsql_t(const middle_query_t* mid_, const options_t &opti
         m_tables.push_back(std::shared_ptr<table_t>(
             new table_t(
                 m_options.database_options.conninfo(), name, type, columns,
-                m_options.global_table_options, SRID, m_options.append, m_options.slim,
-                m_options.droptemp
-            )
+                m_options.global_table_options, m_options)
         ));
     }
 }
 
 output_pgsql_t::output_pgsql_t(const output_pgsql_t& other):
-    output_t(other.m_mid, other.m_options), m_tagtransform(new tagtransform(&m_options)), m_enable_way_area(other.m_enable_way_area),
-    m_export_list(new export_list(*other.m_export_list)), reproj(other.reproj),
-    expire(new expire_tiles(&m_options)),
-    ways_pending_tracker(new id_tracker()), ways_done_tracker(new id_tracker()), rels_pending_tracker(new id_tracker())
+    output_t(other.m_mid, other.m_options), m_tagtransform(new tagtransform(&m_options)),
+    m_enable_way_area(other.m_enable_way_area), m_export_list(new export_list(*other.m_export_list)),
+    expire(new expire_tiles(&m_options)), ways_pending_tracker(new id_tracker()),
+    ways_done_tracker(new id_tracker()), rels_pending_tracker(new id_tracker())
 {
     builder.set_exclude_broken_polygon(m_options.excludepoly);
     for(std::vector<std::shared_ptr<table_t> >::const_iterator t = other.m_tables.begin(); t != other.m_tables.end(); ++t) {

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -81,7 +81,6 @@ protected:
 
     geometry_builder builder;
 
-    std::shared_ptr<reprojection> reproj;
     std::shared_ptr<expire_tiles> expire;
 
     std::shared_ptr<id_tracker> ways_pending_tracker, ways_done_tracker, rels_pending_tracker;

--- a/output.cpp
+++ b/output.cpp
@@ -40,21 +40,21 @@ std::shared_ptr<output_t> parse_multi_single(const pt::ptree &conf,
     new_opts.tag_transform_rel_func = conf.get_optional<std::string>("tagtransform-relation-function");
     new_opts.tag_transform_rel_mem_func = conf.get_optional<std::string>("tagtransform-relation-member-function");
 
-    new_opts.tblsmain_index = conf.get_optional<std::string>("tablespace-index");
-    new_opts.tblsmain_data = conf.get_optional<std::string>("tablespace-data");
-    override_if<int>(new_opts.hstore_mode, "enable-hstore", conf);
-    override_if<bool>(new_opts.enable_hstore_index, "enable-hstore-index", conf);
+    new_opts.global_table_options.tblsmain_index = conf.get_optional<std::string>("tablespace-index");
+    new_opts.global_table_options.tblsmain_data = conf.get_optional<std::string>("tablespace-data");
+    override_if<int>(new_opts.global_table_options.hstore_mode, "enable-hstore", conf);
+    override_if<bool>(new_opts.global_table_options.enable_hstore_index, "enable-hstore-index", conf);
     override_if<bool>(new_opts.enable_multi, "enable-multi", conf);
-    override_if<bool>(new_opts.hstore_match_only, "hstore-match-only", conf);
+    override_if<bool>(new_opts.global_table_options.hstore_match_only, "hstore-match-only", conf);
 
     hstores_t hstore_columns;
     boost::optional<const pt::ptree &> hstores = conf.get_child_optional("hstores");
     if (hstores) {
         for (const pt::ptree::value_type &val: *hstores) {
-            hstore_columns.push_back(val.second.get_value<std::string>());
+            hstore_columns.emplace_back(val.second.get_value<std::string>());
         }
     }
-    new_opts.hstore_columns = hstore_columns;
+    new_opts.global_table_options.hstore_columns = hstore_columns;
 
     std::shared_ptr<geometry_processor> processor =
         geometry_processor::create(proc_type, &new_opts);

--- a/table.cpp
+++ b/table.cpp
@@ -16,11 +16,10 @@ typedef boost::format fmt;
 
 
 table_t::table_t(const std::string& conninfo, const std::string& name, const std::string& type, const columns_t& columns,
-        const table_options_t& table_options,
-        const int srid, const bool append, const bool slim, const bool droptemp):
+        const table_options_t& table_options, const options_t& options):
     conninfo(conninfo), name(name), type(type), table_options(table_options),
-    sql_conn(nullptr), copyMode(false), srid((fmt("%1%") % srid).str()),
-    append(append), slim(slim), drop_temp(droptemp), columns(columns)
+    sql_conn(nullptr), copyMode(false), srid((fmt("%1%") % options.projection->project_getprojinfo()->srs).str()),
+    append(options.append), slim(options.slim), drop_temp(options.droptemp), columns(columns)
 {
     //if we dont have any columns
     if(columns.size() == 0)

--- a/table.cpp
+++ b/table.cpp
@@ -15,12 +15,12 @@ typedef boost::format fmt;
 #define BUFFER_SEND_SIZE 1024
 
 
-table_t::table_t(const string& conninfo, const string& name, const string& type, const columns_t& columns, const hstores_t& hstore_columns,
-    const int srid, const bool append, const bool slim, const bool drop_temp, const int hstore_mode,
-    const bool enable_hstore_index, const boost::optional<string>& table_space, const boost::optional<string>& table_space_index) :
-    conninfo(conninfo), name(name), type(type), sql_conn(nullptr), copyMode(false), srid((fmt("%1%") % srid).str()),
-    append(append), slim(slim), drop_temp(drop_temp), hstore_mode(hstore_mode), enable_hstore_index(enable_hstore_index),
-    columns(columns), hstore_columns(hstore_columns), table_space(table_space), table_space_index(table_space_index)
+table_t::table_t(const std::string& conninfo, const std::string& name, const std::string& type, const columns_t& columns,
+        const table_options_t& table_options,
+        const int srid, const bool append, const bool slim, const bool droptemp):
+    conninfo(conninfo), name(name), type(type), table_options(table_options),
+    sql_conn(nullptr), copyMode(false), srid((fmt("%1%") % srid).str()),
+    append(append), slim(slim), drop_temp(droptemp), columns(columns)
 {
     //if we dont have any columns
     if(columns.size() == 0)
@@ -36,10 +36,12 @@ table_t::table_t(const string& conninfo, const string& name, const string& type,
 }
 
 table_t::table_t(const table_t& other):
-    conninfo(other.conninfo), name(other.name), type(other.type), sql_conn(nullptr), copyMode(false), buffer(), srid(other.srid),
-    append(other.append), slim(other.slim), drop_temp(other.drop_temp), hstore_mode(other.hstore_mode), enable_hstore_index(other.enable_hstore_index),
-    columns(other.columns), hstore_columns(other.hstore_columns), copystr(other.copystr), table_space(other.table_space),
-    table_space_index(other.table_space_index), single_fmt(other.single_fmt), point_fmt(other.point_fmt), del_fmt(other.del_fmt)
+    conninfo(other.conninfo), name(other.name), type(other.type),
+    table_options(other.table_options), sql_conn(nullptr), copyMode(false),
+    buffer(), srid(other.srid), append(other.append), slim(other.slim),
+    drop_temp(other.drop_temp), columns(other.columns), copystr(other.copystr),
+    single_fmt(other.single_fmt), point_fmt(other.point_fmt),
+    del_fmt(other.del_fmt)
 {
     // if the other table has already started, then we want to execute
     // the same stuff to get into the same state. but if it hasn't, then
@@ -127,11 +129,11 @@ void table_t::start()
             sql += (fmt("\"%1%\" %2%,") % column->first % column->second).str();
 
         //then with the hstore columns
-        for(hstores_t::const_iterator hcolumn = hstore_columns.begin(); hcolumn != hstore_columns.end(); ++hcolumn)
+        for(hstores_t::const_iterator hcolumn = table_options.hstore_columns.begin(); hcolumn != table_options.hstore_columns.end(); ++hcolumn)
             sql += (fmt("\"%1%\" hstore,") % (*hcolumn)).str();
 
         //add tags column
-        if (hstore_mode != HSTORE_NONE)
+        if (table_options.hstore_mode != HSTORE_NONE)
             sql += "\"tags\" hstore)";
         //or remove the last ", " from the end
         else
@@ -142,8 +144,8 @@ void table_t::start()
         // doesn't need to be RESET on these tables
         sql += " WITH ( autovacuum_enabled = FALSE )";
         //add the main table space
-        if (table_space)
-            sql += " TABLESPACE " + table_space.get();
+        if (table_options.tblsmain_data)
+            sql += " TABLESPACE " + table_options.tblsmain_data.get();
 
         //create the table
         pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, sql);
@@ -155,8 +157,8 @@ void table_t::start()
         //slim mode needs this to be able to apply diffs
         if (slim && !drop_temp) {
             sql = (fmt("CREATE INDEX %1%_pkey ON %1% USING BTREE (osm_id)") % name).str();
-            if (table_space_index)
-                sql += " TABLESPACE " + table_space_index.get();
+            if (table_options.tblsmain_index)
+                sql += " TABLESPACE " + table_options.tblsmain_index.get();
             pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, sql);
         }
 
@@ -193,11 +195,11 @@ void table_t::start()
         cols += (fmt("\"%1%\",") % column->first).str();
 
     //then with the hstore columns
-    for(hstores_t::const_iterator hcolumn = hstore_columns.begin(); hcolumn != hstore_columns.end(); ++hcolumn)
+    for(hstores_t::const_iterator hcolumn = table_options.hstore_columns.begin(); hcolumn != table_options.hstore_columns.end(); ++hcolumn)
         cols += (fmt("\"%1%\",") % (*hcolumn)).str();
 
     //add tags column and geom column
-    if (hstore_mode != HSTORE_NONE)
+    if (table_options.hstore_mode != HSTORE_NONE)
         cols += "tags,way";
     //or just the geom column
     else
@@ -221,7 +223,7 @@ void table_t::stop()
 
         // Special handling for empty geometries because geohash chokes on
         // empty geometries on postgis 1.5.
-        pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE TABLE %1%_tmp %2% AS SELECT * FROM %1% ORDER BY CASE WHEN ST_IsEmpty(way) THEN NULL ELSE ST_GeoHash(ST_Transform(ST_Envelope(way),4326),10) END") % name % (table_space ? "TABLESPACE " + table_space.get() : "")).str());
+        pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE TABLE %1%_tmp %2% AS SELECT * FROM %1% ORDER BY CASE WHEN ST_IsEmpty(way) THEN NULL ELSE ST_GeoHash(ST_Transform(ST_Envelope(way),4326),10) END") % name % (table_options.tblsmain_index ? "TABLESPACE " + table_options.tblsmain_index.get() : "")).str());
         pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("DROP TABLE %1%") % name).str());
         pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("ALTER TABLE %1%_tmp RENAME TO %1%") % name).str());
         // Re-add constraints if on 1.x. 2.0 has typemod, and they automatically come with CREATE TABLE AS
@@ -232,25 +234,25 @@ void table_t::stop()
         // Use fillfactor 100 for un-updatable imports
         pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE INDEX %1%_index ON %1% USING GIST (way) %2% %3%") % name %
             (slim && !drop_temp ? "" : "WITH (FILLFACTOR=100)") %
-            (table_space_index ? "TABLESPACE " + table_space_index.get() : "")).str());
+            (table_options.tblsmain_index ? "TABLESPACE " + table_options.tblsmain_index.get() : "")).str());
 
         /* slim mode needs this to be able to apply diffs */
         if (slim && !drop_temp)
         {
             fprintf(stderr, "Creating osm_id index on %s\n", name.c_str());
             pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE INDEX %1%_pkey ON %1% USING BTREE (osm_id) %2%") % name %
-                (table_space_index ? "TABLESPACE " + table_space_index.get() : "")).str());
+                (table_options.tblsmain_index ? "TABLESPACE " + table_options.tblsmain_index.get() : "")).str());
         }
         /* Create hstore index if selected */
-        if (enable_hstore_index) {
+        if (table_options.enable_hstore_index) {
             fprintf(stderr, "Creating hstore indexes on %s\n", name.c_str());
-            if (hstore_mode != HSTORE_NONE) {
+            if (table_options.hstore_mode != HSTORE_NONE) {
                 pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE INDEX %1%_tags_index ON %1% USING GIN (tags) %2%") % name %
-                    (table_space_index ? "TABLESPACE " + table_space_index.get() : "")).str());
+                    (table_options.tblsmain_index ? "TABLESPACE " + table_options.tblsmain_index.get() : "")).str());
             }
-            for(size_t i = 0; i < hstore_columns.size(); ++i) {
-                pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE INDEX %1%_hstore_%2%_index ON %1% USING GIN (\"%3%\") %4%") % name % i % hstore_columns[i] %
-                    (table_space_index ? "TABLESPACE " + table_space_index.get() : "")).str());
+            for(size_t i = 0; i < table_options.hstore_columns.size(); ++i) {
+                pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE INDEX %1%_hstore_%2%_index ON %1% USING GIN (\"%3%\") %4%") % name % i % table_options.hstore_columns[i] %
+                    (table_options.tblsmain_index ? "TABLESPACE " + table_options.tblsmain_index.get() : "")).str());
             }
         }
         fprintf(stderr, "Creating indexes on %s finished\n", name.c_str());
@@ -315,17 +317,17 @@ void table_t::write_wkt(const osmid_t id, const taglist_t &tags, const char *wkt
     // used to remember which columns have been written out already.
     std::vector<bool> used;
 
-    if (hstore_mode != HSTORE_NONE)
+    if (table_options.hstore_mode != HSTORE_NONE)
         used.assign(tags.size(), false);
 
     //get the regular columns' values
-    write_columns(tags, buffer, hstore_mode == HSTORE_NORM?&used:nullptr);
+    write_columns(tags, buffer, table_options.hstore_mode == HSTORE_NORM?&used:nullptr);
 
     //get the hstore columns' values
     write_hstore_columns(tags, buffer);
 
     //get the key value pairs for the tags column
-    if (hstore_mode != HSTORE_NONE)
+    if (table_options.hstore_mode != HSTORE_NONE)
         write_tags_column(tags, buffer, used);
 
     //give the wkt an srid
@@ -402,7 +404,7 @@ void table_t::write_tags_column(const taglist_t &tags, std::string& values,
 void table_t::write_hstore_columns(const taglist_t &tags, std::string& values)
 {
     //iterate over all configured hstore columns in the options
-    for(hstores_t::const_iterator hstore_column = hstore_columns.begin(); hstore_column != hstore_columns.end(); ++hstore_column)
+    for(hstores_t::const_iterator hstore_column = table_options.hstore_columns.begin(); hstore_column != table_options.hstore_columns.end(); ++hstore_column)
     {
         bool added = false;
 

--- a/table.hpp
+++ b/table.hpp
@@ -20,10 +20,14 @@ typedef std::vector<std::pair<std::string, std::string> > columns_t;
 class table_t
 {
     public:
+        /**
+         * Sets up a new table, creating it if in --create.
+         * It takes in both options and table_options because in the multi
+         * backend there can be differences
+         */
         table_t(const std::string& conninfo, const std::string& name,
                 const std::string& type, const columns_t& columns,
-                const table_options_t& table_options,
-                const int srid, const bool append, const bool slim, const bool droptemp);
+                const table_options_t& table_options, const options_t& options);
         table_t(const table_t& other);
         ~table_t();
 

--- a/table.hpp
+++ b/table.hpp
@@ -3,6 +3,7 @@
 
 #include "pgsql.hpp"
 #include "osmtypes.hpp"
+#include "options.hpp"
 
 #include <cstddef>
 #include <string>
@@ -19,9 +20,10 @@ typedef std::vector<std::pair<std::string, std::string> > columns_t;
 class table_t
 {
     public:
-        table_t(const std::string& conninfo, const std::string& name, const std::string& type, const columns_t& columns, const hstores_t& hstore_columns, const int srid,
-                const bool append, const bool slim, const bool droptemp, const int hstore_mode, const bool enable_hstore_index,
-                const boost::optional<std::string>& table_space, const boost::optional<std::string>& table_space_index);
+        table_t(const std::string& conninfo, const std::string& name,
+                const std::string& type, const columns_t& columns,
+                const table_options_t& table_options,
+                const int srid, const bool append, const bool slim, const bool droptemp);
         table_t(const table_t& other);
         ~table_t();
 
@@ -70,6 +72,7 @@ class table_t
         std::string conninfo;
         std::string name;
         std::string type;
+        table_options_t table_options;
         pg_conn *sql_conn;
         bool copyMode;
         std::string buffer;
@@ -77,13 +80,8 @@ class table_t
         bool append;
         bool slim;
         bool drop_temp;
-        int hstore_mode;
-        bool enable_hstore_index;
         columns_t columns;
-        hstores_t hstore_columns;
         std::string copystr;
-        boost::optional<std::string> table_space;
-        boost::optional<std::string> table_space_index;
 
         boost::format single_fmt, point_fmt, del_fmt;
 };

--- a/tagtransform.cpp
+++ b/tagtransform.cpp
@@ -621,27 +621,27 @@ unsigned int tagtransform::c_filter_basic_tags(OsmType type, const taglist_t &ta
         // if we didn't find any tags that we wanted to export
         // and we aren't strictly adhering to the list
         if (i == infos.size() && !strict) {
-            if (options->hstore_mode != HSTORE_NONE) {
+            if (options->global_table_options.hstore_mode != HSTORE_NONE) {
                 /* with hstore, copy all tags... */
                 out_tags.push_back(*item);
                 /* ... but if hstore_match_only is set then don't take this
                  as a reason for keeping the object */
-                if (!options->hstore_match_only && "osm_uid" != item->key
+                if (!options->global_table_options.hstore_match_only && "osm_uid" != item->key
                         && "osm_user" != item->key
                         && "osm_timestamp" != item->key
                         && "osm_version" != item->key
                         && "osm_changeset" != item->key)
                     filter = 0;
-            } else if (options->hstore_columns.size() > 0) {
+            } else if (options->global_table_options.hstore_columns.size() > 0) {
                 /* does this column match any of the hstore column prefixes? */
                 size_t j = 0;
-                for(; j < options->hstore_columns.size(); ++j) {
-                    size_t pos = item->key.find(options->hstore_columns[j]);
+                for(; j < options->global_table_options.hstore_columns.size(); ++j) {
+                    size_t pos = item->key.find(options->global_table_options.hstore_columns[j]);
                     if (pos == 0) {
                         out_tags.push_back(*item);
                         /* ... but if hstore_match_only is set then don't take this
                          as a reason for keeping the object */
-                        if (!options->hstore_match_only
+                        if (!options->global_table_options.hstore_match_only
                                 && "osm_uid" != item->key
                                 && "osm_user" != item->key
                                 && "osm_timestamp" != item->key

--- a/tests/test-hstore-match-only.cpp
+++ b/tests/test-hstore-match-only.cpp
@@ -48,8 +48,8 @@ int main(int argc, char *argv[]) {
         options.num_procs = 1;
         options.prefix = "osm2pgsql_test";
         options.style="tests/hstore-match-only.style";
-        options.hstore_match_only=1;
-        options.hstore_mode = HSTORE_NORM;
+        options.global_table_options.hstore_match_only=1;
+        options.global_table_options.hstore_mode = HSTORE_NORM;
         options.slim = 1;
 
         auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);

--- a/tests/test-options-parse.cpp
+++ b/tests/test-options-parse.cpp
@@ -227,7 +227,7 @@ void test_random_perms()
         //--hstore-match-only
         //--hstore-column   Add an additional hstore (key/value) column containing all tags that start with the specified string, eg --hstore-column "name:" will produce an extra hstore column that contains all name:xx tags
 
-        add_arg_or_not("--hstore-add-index", args, options.enable_hstore_index);
+        add_arg_or_not("--hstore-add-index", args, options.global_table_options.enable_hstore_index);
 
         //--tablespace-index    The name of the PostgreSQL tablespace where all indexes will be created. The following options allow more fine-grained control:
         //      --tablespace-main-data    tablespace for main tables


### PR DESCRIPTION
- Moves per-table options into their own class
- Make use of this class for the table_t constructor
- Get the few global options for table_t from the options_t object
- C++11 loop cleanup
