### PR TITLE
Fixes to restore MSVC compatibilty

### DIFF
--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -45,7 +45,7 @@ class elem_cache_t
         return id & (per_block()-1);
     }
 
-    typedef cache_block_t<T, per_block()> element_t;
+    typedef cache_block_t<T, 1 << BLOCK_SHIFT> element_t;
     std::vector<std::unique_ptr<element_t>> arr;
 public:
     elem_cache_t() : arr(num_blocks()) {}

--- a/tests/test-expire-tiles.cpp
+++ b/tests/test-expire-tiles.cpp
@@ -1,6 +1,7 @@
 #include "expire-tiles.hpp"
 #include "options.hpp"
 
+#include <iterator>
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>


### PR DESCRIPTION
Recompilng on Visual Studio 2015 on Windows 10 x64 resulted in several errors.
Most of them were from my cmake scripts (now fixed), but two problematic places were found in the code.