### PR TITLE
Increase dense block size from 1k to 8k nodes

### DIFF
--- a/node-ram-cache.cpp
+++ b/node-ram-cache.cpp
@@ -54,7 +54,7 @@
 
 
 
-#define BLOCK_SHIFT 10
+#define BLOCK_SHIFT 13
 #define PER_BLOCK  (((osmid_t)1) << BLOCK_SHIFT)
 #define NUM_BLOCKS (((osmid_t)1) << (36 - BLOCK_SHIFT))
 

--- a/tests/middle-tests.cpp
+++ b/tests/middle-tests.cpp
@@ -9,7 +9,7 @@
 #include "osmtypes.hpp"
 #include "tests/middle-tests.hpp"
 
-#define BLOCK_SHIFT 10
+#define BLOCK_SHIFT 13
 #define PER_BLOCK  (((osmid_t)1) << BLOCK_SHIFT)
 
 struct expected_node {


### PR DESCRIPTION
The dense cache has a fixed memory cost which is associated with the number of blocks needed. Increase the block size reduces the number of blocks, resulting in reduced memory usage. For this change on modern hardware it is a decrease from 1GB to 128MB. Large blocks are less efficient than small ones, but it turns out that this does not matter for planet imports, where the efficiency change is small and memory usage is actually slightly reduced, or for small imports, where the fixed cost change overwhelms anything else.

On large but not planet sized extracts (e.g. Europe) memory usage is slightly increased, by about 450MB, while the cache in total consumes about 18GB.

Changing the cache size did not have a measurable impact on performance in testing.

Fixes #439

----

I had considered other cache sizes, but

* Going larger is into diminishing returns
* The size chosen is close to minimum planet memory usage, and at a minimum for the Canada test
* Each increase of BLOCK_SHIFT beyond 13 increases memory usage by about 350MB for a Europe extract and about 100MB for the planet.
* 130MB cache overhead is sufficiently low for VMs I'd consider capable of running a rendering server, even on a very small extract

-----

### Data ###
![image](https://cloud.githubusercontent.com/assets/1190866/9321130/2eae9f72-4517-11e5-9f88-e0ca0f1d79d7.png)

![image](https://cloud.githubusercontent.com/assets/1190866/9321139/5a118904-4517-11e5-92fe-c099ae5ac040.png)

Memory usage includes queue overhead, which scales with cache size, but is only 3.3 MB for a 27GB cache and 8k node dense blocks, so can be mostly ignored.