### PR TITLE
Ignore nodes with invalid coordinates.

### DIFF
--- a/parse-osmium.cpp
+++ b/parse-osmium.cpp
@@ -67,7 +67,7 @@ void parse_osmium_t::node(osmium::Node& node)
     if (!node.location().valid()) {
       fprintf(stderr, "WARNING: Node %" PRIdOSMID " (version %ud) has an invalid "
               "location and has been ignored. This is not expected to happen with "
-              "recent planet files, so please check that your input is correct.",
+              "recent planet files, so please check that your input is correct.\n",
               node.id(), node.version());
 
       return;

--- a/parse-osmium.cpp
+++ b/parse-osmium.cpp
@@ -61,6 +61,11 @@ parse_osmium_t::stream_file(const std::string &filename, osmdata_t *osmdata)
 
 void parse_osmium_t::node(osmium::Node& node)
 {
+    // if the node is not valid, then node.location.lat/lon() can throw.
+    // we probably ought to treat invalid locations as if they were
+    // deleted and ignore them.
+    if (!node.location().valid()) { return; }
+
     double lat = node.location().lat();
     double lon = node.location().lon();
     if (bbox.inside(lat, lon)) {

--- a/parse-osmium.cpp
+++ b/parse-osmium.cpp
@@ -64,7 +64,14 @@ void parse_osmium_t::node(osmium::Node& node)
     // if the node is not valid, then node.location.lat/lon() can throw.
     // we probably ought to treat invalid locations as if they were
     // deleted and ignore them.
-    if (!node.location().valid()) { return; }
+    if (!node.location().valid()) {
+      fprintf(stderr, "WARNING: Node %" PRIdOSMID " (version %ud) has an invalid "
+              "location and has been ignored. This is not expected to happen with "
+              "recent planet files, so please check that your input is correct.",
+              node.id(), node.version());
+
+      return;
+    }
 
     double lat = node.location().lat_without_check();
     double lon = node.location().lon_without_check();

--- a/parse-osmium.cpp
+++ b/parse-osmium.cpp
@@ -66,8 +66,8 @@ void parse_osmium_t::node(osmium::Node& node)
     // deleted and ignore them.
     if (!node.location().valid()) { return; }
 
-    double lat = node.location().lat();
-    double lon = node.location().lon();
+    double lat = node.location().lat_without_check();
+    double lon = node.location().lon_without_check();
     if (bbox.inside(lat, lon)) {
         proj->reproject(&lat, &lon);
 


### PR DESCRIPTION
I hit this while processing a snapshot extracted from history which happened to contain [version 3 of node 7226378](http://www.openstreetmap.org/node/7226378/history), which has coordinates (83.4542914, 214.7483647). The API at the time didn't check this, and it has since been fixed, but it means that [the node parsing code](https://github.com/openstreetmap/osm2pgsql/blob/master/parse-osmium.cpp#L64-L65) will throw an exception.

(Notably, this doesn't kill the process, as it means the consumer thread waits on the Queue to finish processing, while the producer thread is waiting on the Queue to empty. But this is a separate issue.)

In this case it seems simple enough to just ignore any node which has an invalid location, which is effectively the same behaviour as setting the bbox to the world extent.