### PR TITLE
Include cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,8 +61,7 @@ int main(int argc, char *argv[])
 Names should use underscores, not camel case, with class/struct names ending in `_t`.
 
 Headers should be included in the order `config.h`, C++ standard library headers,
-C library headers, Boost headers, and last osm2pgsql files. If the file is a .cpp
-file, include its .hpp file before all other headers.
+C library headers, Boost headers, and last osm2pgsql files.
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,10 @@ int main(int argc, char *argv[])
 
 Names should use underscores, not camel case, with class/struct names ending in `_t`.
 
+Headers should be included in the order `config.h`, C++ standard library headers,
+C library headers, Boost headers, and last osm2pgsql files. If the file is a .cpp
+file, include its .hpp file before all other headers.
+
 ## Documentation
 
 User documentation is stored in `docs/`. Pages on the OpenStreetMap wiki are

--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -33,25 +33,27 @@ using namespace std;
 #define alloca _alloca
 #endif
 
-#include <libpq-fe.h>
-
-#include "osmtypes.hpp"
-#include "middle-pgsql.hpp"
-#include "output-pgsql.hpp"
-#include "options.hpp"
-#include "node-ram-cache.hpp"
-#include "node-persistent-cache.hpp"
-#include "pgsql.hpp"
-#include "util.hpp"
-
 #include <stdexcept>
+#include <unordered_map>
+
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
-#include <unordered_map>
+
 #include <boost/format.hpp>
+
+#include <libpq-fe.h>
+
+#include "middle-pgsql.hpp"
+#include "node-persistent-cache.hpp"
+#include "node-ram-cache.hpp"
+#include "options.hpp"
+#include "osmtypes.hpp"
+#include "output-pgsql.hpp"
+#include "pgsql.hpp"
+#include "util.hpp"
 
 enum table_id {
     t_node, t_way, t_rel

--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -45,7 +45,6 @@ using namespace std;
 #include "util.hpp"
 
 #include <stdexcept>
-#include <algorithm>
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>

--- a/middle-ram.cpp
+++ b/middle-ram.cpp
@@ -9,7 +9,6 @@
 
 #include <stdexcept>
 #include <cstdio>
-#include <cstring>
 #include <cassert>
 
 #include "middle-ram.hpp"

--- a/middle-ram.cpp
+++ b/middle-ram.cpp
@@ -8,13 +8,14 @@
 */
 
 #include <stdexcept>
-#include <cstdio>
-#include <cassert>
 
+#include <cassert>
+#include <cstdio>
+
+#include "id-tracker.hpp"
 #include "middle-ram.hpp"
 #include "node-ram-cache.hpp"
 #include "options.hpp"
-#include "id-tracker.hpp"
 
 /* Object storage now uses 2 levels of storage arrays.
  *

--- a/node-persistent-cache.cpp
+++ b/node-persistent-cache.cpp
@@ -2,16 +2,16 @@
 
 #include "config.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <unistd.h>
 #include <string.h>
-#include <errno.h>
-#include <limits.h>
+#include <cerrno>
+#include <climits>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <math.h>
+#include <cmath>
 
 #include "osmtypes.hpp"
 #include "output.hpp"

--- a/node-persistent-cache.cpp
+++ b/node-persistent-cache.cpp
@@ -2,25 +2,26 @@
 
 #include "config.h"
 
-#include <cstdio>
-#include <cstdlib>
-#include <unistd.h>
-#include <string.h>
+#include <algorithm>
+#include <stdexcept>
+
 #include <cerrno>
 #include <climits>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include <cmath>
+#include <cstdio>
+#include <cstdlib>
 
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "node-persistent-cache.hpp"
+#include "options.hpp"
 #include "osmtypes.hpp"
 #include "output.hpp"
-#include "options.hpp"
-#include "node-persistent-cache.hpp"
 #include "util.hpp"
-
-#include <stdexcept>
-#include <algorithm>
 
 #ifdef _WIN32
  #include "win_fsync.h"

--- a/node-ram-cache.cpp
+++ b/node-ram-cache.cpp
@@ -5,6 +5,9 @@
 
 #include "config.h"
 
+#include <new>
+#include <stdexcept>
+
 #include <cstdio>
 #include <cstdlib>
 

--- a/node-ram-cache.cpp
+++ b/node-ram-cache.cpp
@@ -7,7 +7,6 @@
 
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 
 #include <boost/format.hpp>
 

--- a/node-ram-cache.cpp
+++ b/node-ram-cache.cpp
@@ -13,8 +13,8 @@
 
 #include <boost/format.hpp>
 
-#include "osmtypes.hpp"
 #include "node-ram-cache.hpp"
+#include "osmtypes.hpp"
 #include "util.hpp"
 
 /* Here we use a similar storage structure as middle-ram, except we allow

--- a/node-ram-cache.hpp
+++ b/node-ram-cache.hpp
@@ -13,7 +13,7 @@
 
 #include <cstddef>
 #include <climits>
-#include <stdint.h>
+#include <cstdint>
 #include <boost/noncopyable.hpp>
 
 #define ALLOC_SPARSE 1

--- a/node-ram-cache.hpp
+++ b/node-ram-cache.hpp
@@ -10,8 +10,8 @@
 
 #include "config.h"
 
-#include <cstddef>
 #include <climits>
+#include <cstddef>
 #include <cstdint>
 
 #include <boost/noncopyable.hpp>

--- a/node-ram-cache.hpp
+++ b/node-ram-cache.hpp
@@ -9,12 +9,14 @@
 #define NODE_RAM_CACHE_H
 
 #include "config.h"
-#include "osmtypes.hpp"
 
 #include <cstddef>
 #include <climits>
 #include <cstdint>
+
 #include <boost/noncopyable.hpp>
+
+#include "osmtypes.hpp"
 
 #define ALLOC_SPARSE 1
 #define ALLOC_DENSE 2

--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -1,14 +1,14 @@
-#include "osmdata.hpp"
-#include "output.hpp"
-#include "middle.hpp"
-#include "node-ram-cache.hpp"
-
-#include <boost/thread/thread.hpp>
-#include <boost/thread.hpp>
-
 #include <stdexcept>
 #include <utility>
+
 #include <cstdio>
+
+#include <boost/thread.hpp>
+
+#include "middle.hpp"
+#include "node-ram-cache.hpp"
+#include "osmdata.hpp"
+#include "output.hpp"
 
 osmdata_t::osmdata_t(std::shared_ptr<middle_t> mid_, const std::shared_ptr<output_t>& out_): mid(mid_)
 {

--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -5,7 +5,6 @@
 
 #include <boost/thread/thread.hpp>
 #include <boost/thread.hpp>
-#include <boost/version.hpp>
 
 #include <stdexcept>
 #include <utility>

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -1,17 +1,17 @@
 #ifndef OUTPUT_GAZETTEER_H
 #define OUTPUT_GAZETTEER_H
 
+#include <memory>
+#include <string>
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/format.hpp>
+
+#include "geometry-builder.hpp"
 #include "osmtypes.hpp"
 #include "output.hpp"
-#include "geometry-builder.hpp"
 #include "pgsql.hpp"
 #include "util.hpp"
-
-#include <boost/format.hpp>
-#include <boost/algorithm/string/predicate.hpp>
-
-#include <string>
-#include <memory>
 
 /**
  * A private class to convert tags.

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -11,7 +11,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <string>
-#include <iostream>
 #include <memory>
 
 /**

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -8,39 +8,40 @@
 
 #include "config.h"
 
-#include <stdio.h>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <unistd.h>
-#include <stdlib.h>
-#include <string.h>
-#include <assert.h>
-#include <errno.h>
-#include <time.h>
 
 #ifdef HAVE_PTHREAD
 #include <pthread.h>
 #endif
 
-#include "osmtypes.hpp"
-#include "reprojection.hpp"
-#include "output-pgsql.hpp"
-#include "options.hpp"
-#include "middle.hpp"
-#include "pgsql.hpp"
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind.hpp>
+#include <boost/exception_ptr.hpp>
+#include <boost/format.hpp>
+
 #include "expire-tiles.hpp"
-#include "wildcmp.hpp"
+#include "middle.hpp"
 #include "node-ram-cache.hpp"
+#include "options.hpp"
+#include "osmtypes.hpp"
+#include "output-pgsql.hpp"
+#include "pgsql.hpp"
+#include "reprojection.hpp"
 #include "taginfo_impl.hpp"
 #include "tagtransform.hpp"
 #include "util.hpp"
-
-#include <boost/bind.hpp>
-#include <boost/format.hpp>
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/exception_ptr.hpp>
-#include <iostream>
-#include <limits>
-#include <stdexcept>
-#include <memory>
+#include "wildcmp.hpp"
 
 /* make the diagnostic information work with older versions of
  * boost - the function signature changed at version 1.54.

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -53,11 +53,6 @@
 
 #define SRID (reproj->project_getprojinfo()->srs)
 
-/* FIXME: Shouldn't malloc this all to begin with but call realloc()
-   as required. The program will most likely segfault if it reads a
-   style file with more styles than this */
-#define MAX_STYLES 1000
-
 #define NUM_TABLES (output_pgsql_t::t_MAX)
 
 /* example from: pg_dump -F p -t planet_osm gis

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -15,7 +15,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <time.h>
-#include <stdexcept>
 
 #ifdef HAVE_PTHREAD
 #include <pthread.h>

--- a/output.hpp
+++ b/output.hpp
@@ -11,14 +11,13 @@
 #define OUTPUT_H
 
 #include "options.hpp"
-#include "middle.hpp"
-#include "id-tracker.hpp"
-#include "expire-tiles.hpp"
 
 #include <boost/noncopyable.hpp>
-#include <boost/version.hpp>
-#include <utility>
 #include <stack>
+
+struct id_tracker;
+struct expire_tiles;
+struct middle_query_t;
 
 struct pending_job_t {
     osmid_t osm_id;

--- a/output.hpp
+++ b/output.hpp
@@ -10,13 +10,14 @@
 #ifndef OUTPUT_H
 #define OUTPUT_H
 
-#include "options.hpp"
-
-#include <boost/noncopyable.hpp>
 #include <stack>
 
-struct id_tracker;
+#include <boost/noncopyable.hpp>
+
+#include "options.hpp"
+
 struct expire_tiles;
+struct id_tracker;
 struct middle_query_t;
 
 struct pending_job_t {

--- a/parse-o5m.cpp
+++ b/parse-o5m.cpp
@@ -28,11 +28,17 @@
 // when __cplusplus is defined, we need to define this macro as well
 // to get the print format specifiers in the inttypes.h header.
 #define __STDC_FORMAT_MACROS
-#include <inttypes.h>
-#include <stdint.h>
+
+#include "parse-o5m.hpp"
+
+#include <stdexcept>
+#include <string>
+
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cstdio>
 #include <unistd.h>
 #include <time.h>
 #include <fcntl.h>
@@ -41,7 +47,6 @@
 #include <io.h>
 #endif
 
-#include "parse-o5m.hpp"
 #include "osmdata.hpp"
 #include "osmtypes.hpp"
 #include "reprojection.hpp"

--- a/parse-o5m.cpp
+++ b/parse-o5m.cpp
@@ -29,8 +29,6 @@
 // to get the print format specifiers in the inttypes.h header.
 #define __STDC_FORMAT_MACROS
 
-#include "parse-o5m.hpp"
-
 #include <stdexcept>
 #include <string>
 
@@ -39,9 +37,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <unistd.h>
-#include <time.h>
+#include <ctime>
 #include <fcntl.h>
+#include <unistd.h>
 
 #ifdef _WIN32
 #include <io.h>
@@ -49,6 +47,7 @@
 
 #include "osmdata.hpp"
 #include "osmtypes.hpp"
+#include "parse-o5m.hpp"
 #include "reprojection.hpp"
 
 #define inline

--- a/parse-o5m.hpp
+++ b/parse-o5m.hpp
@@ -25,9 +25,12 @@
 #ifndef PARSE_O5M_H
 #define PARSE_O5M_H
 
+#include <iosfwd>
+
 #include "parse.hpp"
 
 struct reprojection;
+class osmdata_t;
 
 class parse_o5m_t: public parse_t
 {

--- a/parse.cpp
+++ b/parse.cpp
@@ -6,11 +6,9 @@
 
 #include <cstdio>
 
-#include "parse.hpp"
 #include "parse-o5m.hpp"
 #include "parse-osmium.hpp"
-
-
+#include "parse.hpp"
 
 #define INIT_MAX_MEMBERS 64
 #define INIT_MAX_NODES  4096

--- a/parse.cpp
+++ b/parse.cpp
@@ -1,13 +1,15 @@
 #include "config.h"
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+
+#include <cstdio>
+
 #include "parse.hpp"
 #include "parse-o5m.hpp"
 #include "parse-osmium.hpp"
 
-#include <cstdlib>
-#include <cstdio>
-#include <cstring>
-#include <stdexcept>
-#include <algorithm>
 
 
 #define INIT_MAX_MEMBERS 64

--- a/parse.hpp
+++ b/parse.hpp
@@ -3,9 +3,11 @@
 
 #include "osmtypes.hpp"
 
-#include <time.h>
-#include <string>
+#include <iosfwd> // for string
 #include <memory>
+
+#include <ctime>
+
 #include <boost/optional.hpp>
 
 typedef enum { FILETYPE_NONE, FILETYPE_OSM, FILETYPE_OSMCHANGE, FILETYPE_PLANETDIFF } filetypes_t;

--- a/parse.hpp
+++ b/parse.hpp
@@ -3,8 +3,8 @@
 
 #include "osmtypes.hpp"
 
-#include <iosfwd> // for string
 #include <memory>
+#include <string>
 
 #include <ctime>
 
@@ -13,8 +13,8 @@
 typedef enum { FILETYPE_NONE, FILETYPE_OSM, FILETYPE_OSMCHANGE, FILETYPE_PLANETDIFF } filetypes_t;
 typedef enum { ACTION_NONE, ACTION_CREATE, ACTION_MODIFY, ACTION_DELETE } actions_t;
 
-class parse_t;
 class osmdata_t;
+class parse_t;
 struct reprojection;
 
 class bbox_t

--- a/reprojection.cpp
+++ b/reprojection.cpp
@@ -5,15 +5,17 @@
  * so Mapnik doesn't have to).
  */
 
+#include "reprojection.hpp"
+
 #include "config.h"
 
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
-#include <proj_api.h>
 #include <cmath>
 
-#include "reprojection.hpp"
+#include <proj_api.h>
+
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846

--- a/reprojection.cpp
+++ b/reprojection.cpp
@@ -5,17 +5,16 @@
  * so Mapnik doesn't have to).
  */
 
-#include "reprojection.hpp"
-
 #include "config.h"
 
-#include <cstdlib>
-#include <cstdio>
-#include <cstring>
 #include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include <proj_api.h>
 
+#include "reprojection.hpp"
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846

--- a/sprompt.cpp
+++ b/sprompt.cpp
@@ -54,13 +54,10 @@
 
 #define DEVTTY "/dev/tty"
 
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 #include <unistd.h>
-#include <stdlib.h>
 #include <string.h>
-#include <assert.h>
-
-#include <libpq-fe.h>
 
 #ifdef HAVE_TERMIOS_H
 #include <termios.h>

--- a/sprompt.cpp
+++ b/sprompt.cpp
@@ -54,10 +54,10 @@
 
 #define DEVTTY "/dev/tty"
 
-#include <cstdlib>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <unistd.h>
-#include <string.h>
 
 #ifdef HAVE_TERMIOS_H
 #include <termios.h>

--- a/tests/test-parse-xml2.cpp
+++ b/tests/test-parse-xml2.cpp
@@ -1,17 +1,17 @@
 #include <iostream>
 #include <memory>
 
-#include <cstdlib>
-#include <cstdio>
-#include <string.h>
 #include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include "middle.hpp"
-#include "osmtypes.hpp"
-#include "osmdata.hpp"
-#include "parse-osmium.hpp"
-#include "output.hpp"
 #include "options.hpp"
+#include "osmdata.hpp"
+#include "osmtypes.hpp"
+#include "output.hpp"
+#include "parse-osmium.hpp"
 
 void exit_nicely()
 {

--- a/tests/test-parse-xml2.cpp
+++ b/tests/test-parse-xml2.cpp
@@ -1,10 +1,12 @@
 #include <iostream>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <cassert>
 #include <memory>
 
+#include <cstdlib>
+#include <cstdio>
+#include <string.h>
+#include <cassert>
+
+#include "middle.hpp"
 #include "osmtypes.hpp"
 #include "osmdata.hpp"
 #include "parse-osmium.hpp"


### PR DESCRIPTION
This is not a complete cleanup, but what iwyu was reporting without errors on clang 3.4 and some earlier work with deheader.

Switching from `<stdio.h>` to <cstdio>` does apparently have some differences (include-what-you-use/include-what-you-use#226), but we weren't consistent about this before.