### PR TITLE
add missing include for std::cerr

### DIFF
--- a/output-gazetteer.cpp
+++ b/output-gazetteer.cpp
@@ -11,6 +11,7 @@
 #include "util.hpp"
 
 #include <algorithm>
+#include <iostream>
 #include <memory>
 
 #define SRID (reproj->project_getprojinfo()->srs)


### PR DESCRIPTION
After fixing include order, one include was missing for Visual Studio 2015. std::cerr needs explicit ``<iostream>``.

Could you please add it?