### PR TITLE
Use the polygon flag from the tagtransforms to change multi-backend 

### DIFF
--- a/docs/multi.md
+++ b/docs/multi.md
@@ -16,23 +16,25 @@ That is essentially why it was named `multi` because it's basically multiple
 ## Table Configuration ##
 As sample configuration may resemble the following:
 
-    [
-      {
-        "name": "building",
-        "type": "polygon",
-        "tagtransform": "building.lua",
-        "tagtransform-node-function": "nodes_proc",
-        "tagtransform-way-function": "ways_proc",
-        "tagtransform-relation-function": "rels_proc",
-        "tagtransform-relation-member-function": "rel_members_proc",
-        "tags": [
-          {"name": "building", "type": "text"},
-          {"name": "shop", "type": "text"},
-          {"name": "amenity", "type": "text"}
-        ]
-      },
-      ...
+```json
+[
+  {
+    "name": "building",
+    "type": "polygon",
+    "tagtransform": "building.lua",
+    "tagtransform-node-function": "nodes_proc",
+    "tagtransform-way-function": "ways_proc",
+    "tagtransform-relation-function": "rels_proc",
+    "tagtransform-relation-member-function": "rel_members_proc",
+    "tags": [
+      {"name": "building", "type": "text"},
+      {"name": "shop", "type": "text"},
+      {"name": "amenity", "type": "text"}
     ]
+  },
+  ...
+]
+```
 
 Note that each table has a `name` and can target a single type of geometry
 by setting the `type` to one of `point`, `line` or `polygon`. `tagtransform`
@@ -43,12 +45,24 @@ when processing various tags, these can be named via
 `tagtransform-relation-function`, and `tagtransform-relation-member-function`.
 As with the normal top level options within osm2pgsql you can specify any of the
 following: `tablespace-index`, `tablespace-data`, `enable-hstore`,
-`enable-hstore-index`, `enable-multi`, `hstore-match-only`. Hstore colum names
+`enable-hstore-index`, `enable-multi`, `hstore-match-only`. Hstore column names
 may be specified via an array of strings named `hstores`. Finally standard columns
 may be specified via an array of objects named `tags` with each object containing
 a `name` and a postgres `type`. Note you may also set `flags` on each tag as with
 the standard osm2pgsql style file. `flags` is formated exactly as in the style file
-as a string of flag names seprated by commas.
+as a string of flag names separated by commas.
+
+## Polygons ##
+
+Area handling differs slightly from the traditional osm2pgsql C and Lua transforms
+where if a way is added to the polygon or line table depends on if it is closed,
+not just its tagging. All tables with the multi-backend are independent.
+
+All ways in `line` tables are turned into linestrings and what the tag
+transform sets the polygon flag to does not matter.. In `polygon` tables ways
+that can be formed into polygons are, and if the polygon flag is not set by the
+tag transform then other ways become linestrings. If the polygon flag is set,
+then linestrings will not be added to the table.
 
 ## Example ##
 An example based on the above is in [multi.lua](../multi.lua) and

--- a/docs/multi.md
+++ b/docs/multi.md
@@ -59,7 +59,7 @@ where if a way is added to the polygon or line table depends on if it is closed,
 not just its tagging. All tables with the multi-backend are independent.
 
 All ways in `line` tables are turned into linestrings and what the tag
-transform sets the polygon flag to does not matter.. In `polygon` tables ways
+transform sets the polygon flag to does not matter. In `polygon` tables ways
 that can be formed into polygons are, and if the polygon flag is not set by the
 tag transform then other ways become linestrings. If the polygon flag is set,
 then linestrings will not be added to the table.

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -270,7 +270,7 @@ int output_multi_t::process_node(osmid_t id, double lat, double lon, const tagli
         geometry_builder::maybe_wkt_t wkt = m_processor->process_node(lat, lon);
         if (wkt) {
             m_expire->from_bbox(lon, lat, lon, lat);
-            copy_to_table(id, wkt->geom.c_str(), outtags);
+            copy_node_to_table(id, wkt->geom.c_str(), outtags);
         }
     }
     return 0;
@@ -297,21 +297,7 @@ int output_multi_t::reprocess_way(osmid_t id, const nodelist_t &nodes, const tag
         //grab its geom
         geometry_builder::maybe_wkt_t wkt = m_processor->process_way(nodes);
         if (wkt) {
-            if (polygon) {
-                // The way is required to be a polygon
-                if (boost::starts_with(wkt->geom, "POLYGON") || boost::starts_with(wkt->geom, "MULTIPOLYGON")) {
-                    m_expire->from_nodes_poly(nodes, id);
-                    copy_to_table(id, wkt->geom.c_str(), outtags);
-                }
-            } else {
-                // The way is not required to be a polygon
-                copy_to_table(id, wkt->geom.c_str(), outtags);
-                if (boost::starts_with(wkt->geom, "POLYGON") || boost::starts_with(wkt->geom, "MULTIPOLYGON")) {
-                    m_expire->from_nodes_poly(nodes, id);
-                } else {
-                    m_expire->from_nodes_line(nodes);
-                }
-            }
+            copy_to_table(id, wkt, outtags, polygon);
         }
     }
     return 0;
@@ -335,23 +321,10 @@ int output_multi_t::process_way(osmid_t id, const idlist_t &nodes, const taglist
             //this way pending just in case it shows up in one
             if (m_processor->interests(geometry_processor::interest_relation)) {
                 ways_pending_tracker->mark(id);
-            }//we aren't interested in relations so if it comes in on a relation later we wont keep it
-            else {
-                if (polygon) {
-                    // The way is required to be a polygon
-                    if (boost::starts_with(wkt->geom, "POLYGON") || boost::starts_with(wkt->geom, "MULTIPOLYGON")) {
-                        m_expire->from_nodes_poly(m_way_helper.node_cache, id);
-                        copy_to_table(id, wkt->geom.c_str(), outtags);
-                    }
-                } else {
-                    // The way is not required to be a polygon
-                    copy_to_table(id, wkt->geom.c_str(), outtags);
-                    if (boost::starts_with(wkt->geom, "POLYGON") || boost::starts_with(wkt->geom, "MULTIPOLYGON")) {
-                        m_expire->from_nodes_poly(m_way_helper.node_cache, id);
-                    } else {
-                        m_expire->from_nodes_line(m_way_helper.node_cache);
-                    }
-                }
+            } else {
+                // We wouldn't be interested in this as a relation, so no need to mark it pending.
+                // TODO: Does this imply anything for non-multipolygon relations?
+                copy_to_table(id, wkt, outtags, polygon);
             }
         }
     }
@@ -390,11 +363,11 @@ int output_multi_t::process_relation(osmid_t id, const memberlist_t &members,
         }
 
         //do the members of this relation have anything interesting to us
-        //NOTE: make_polygon is preset here this is to force the tag matching/superseeded stuff
+        //NOTE: make_polygon is preset here this is to force the tag matching/superseded stuff
         //normally this wouldnt work but we tell the tag transform to allow typeless relations
         //this is needed because the type can get stripped off by the rel_tag filter above
         //if the export list did not include the type tag.
-        //TODO: find a less hacky way to do the matching/superseeded and tag copying stuff without
+        //TODO: find a less hacky way to do the matching/superseded and tag copying stuff without
         //all this trickery
         int make_boundary, make_polygon = 1;
         taglist_t outtags;
@@ -406,17 +379,17 @@ int output_multi_t::process_relation(osmid_t id, const memberlist_t &members,
         {
             geometry_builder::maybe_wkts_t wkts = m_processor->process_relation(m_relation_helper.nodes);
             if (wkts) {
-                for (const auto& wkt: *wkts) {
+                for (const auto wkt: *wkts) {
                     //TODO: we actually have the nodes in the m_relation_helper and could use them
                     //instead of having to reparse the wkt in the expiry code
                     m_expire->from_wkt(wkt.geom.c_str(), -id);
                     //what part of the code relies on relation members getting negative ids?
-                    copy_to_table(-id, wkt.geom.c_str(), outtags);
+                    copy_to_table(-id, wkt, outtags, make_polygon);
                 }
             }
 
             //TODO: should this loop be inside the if above just in case?
-            //take a look at each member to see if its superseeded (tags on it matched the tags on the relation)
+            //take a look at each member to see if its superseded (tags on it matched the tags on the relation)
             for(size_t i = 0; i < m_relation_helper.ways.size(); ++i) {
                 //tags matched so we are keeping this one with this relation
                 if (m_relation_helper.superseeded[i]) {
@@ -434,8 +407,43 @@ int output_multi_t::process_relation(osmid_t id, const memberlist_t &members,
     return 0;
 }
 
-void output_multi_t::copy_to_table(osmid_t id, const char *wkt, const taglist_t &tags) {
+void output_multi_t::copy_node_to_table(osmid_t id, const char *wkt, const taglist_t &tags) {
     m_table->write_wkt(id, tags, wkt);
+}
+
+/**
+ * Copies a 2d object(line or polygon) to the table, adding a way_area tag if appropriate
+ * \param id OSM ID of the object
+ * \param wkt WKT string of the object
+ * \param tags List of tags
+ * \param polygon Polygon flag returned from the tag transform (polygon=1)
+ */
+void output_multi_t::copy_to_table(const osmid_t id, const geometry_builder::wkt_t &wkt, const taglist_t &tags, int polygon) {
+    if (boost::starts_with(wkt.geom, "POLYGON") || boost::starts_with(wkt.geom, "MULTIPOLYGON")) {
+        // It's a polygon table (implied by it turning into a poly), and it got formed into a polygon, so expire as a polygon and write the WKT
+        m_expire->from_nodes_poly(m_way_helper.node_cache, id);
+        m_table->write_wkt(id, tags, wkt.geom.c_str());
+    } else {
+        // Linestring
+        if (!polygon) {
+            // non-polygons are okay
+            m_expire->from_nodes_line(m_way_helper.node_cache);
+            m_table->write_wkt(id, tags, wkt.geom.c_str());
+        }
+    }
+}
+
+/**
+ * Copies a 2d object(line or polygon) to the table, adding a way_area tag if appropriate
+ * \param id OSM ID of the object
+ * \param wkt Maybe-WKT string of the object
+ * \param tags List of tags
+ * \param polygon Polygon flag returned from the tag transform (polygon=1)
+ */
+void output_multi_t::copy_to_table(const osmid_t id, const geometry_builder::maybe_wkt_t &wkt, const taglist_t &tags, int polygon) {
+    if (wkt) {
+        copy_to_table(id, *wkt, tags, polygon);
+    }
 }
 
 void output_multi_t::delete_from_output(osmid_t id) {

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -70,7 +70,9 @@ protected:
     int process_way(osmid_t id, const idlist_t &nodes, const taglist_t &tags);
     int reprocess_way(osmid_t id, const nodelist_t &nodes, const taglist_t &tags, bool exists);
     int process_relation(osmid_t id, const memberlist_t &members, const taglist_t &tags, bool exists, bool pending=false);
-    void copy_to_table(osmid_t id, const char *wkt, const taglist_t &tags);
+    void copy_node_to_table(osmid_t id, const char *wkt, const taglist_t &tags);
+    void copy_to_table(const osmid_t id, const geometry_builder::maybe_wkt_t &wkt, const taglist_t &tags, int polygon);
+    void copy_to_table(const osmid_t id, const geometry_builder::wkt_t &wkt, const taglist_t &tags, int polygon);
 
     std::unique_ptr<tagtransform> m_tagtransform;
     std::unique_ptr<export_list> m_export_list;


### PR DESCRIPTION
Fixes #270

This allows creation of polygon tables which consist of only polygons