### PR TITLE
Ignore osm2pgsql binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+osm2pgsql
 
 docs/html
 docs/latex


### PR DESCRIPTION
An osm2pgsql binary is frequently placed in the root dir of the repo,
so ignore it. The tests are probably doing this.

Partial revert of earlier gitignore cleanup.

Note: Hoping to test that CI works with this PR.