### PR TITLE
MSVC: add flag to skip warings about missing .pdbs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 
 if ( MSVC )
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -DNOMINMAX -wd4996)
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:30000000")
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ignore:4099 /STACK:30000000")
 else()
   add_definitions(-Wall)
   add_definitions(-std=c++11)


### PR DESCRIPTION
This small PR affects only Windows and reduces a log of Debug build greately, eliminating .pdb related warnings like the following ones:
```
proj.lib(PJ_chamb.obj) : warning LNK4099: PDB 'proj.pdb' was not found with 'proj.lib(PJ_chamb.obj)' or at 'D:\winbuilds\osm2pgsql\build\tests\proj.pdb'; linking object as if no debug info
proj.lib(PJ_collg.obj) : warning LNK4099: PDB 'proj.pdb' was not found with 'proj.lib(PJ_collg.obj)' or at 'D:\winbuilds\osm2pgsql\build\tests\proj.pdb'; linking object as if no debug info
proj.lib(PJ_crast.obj) : warning LNK4099: PDB 'proj.pdb' was not found with 'proj.lib(PJ_crast.obj)' or at 'D:\winbuilds\osm2pgsql\build\tests\proj.pdb'; linking object as if no debug info
proj.lib(PJ_denoy.obj) : warning LNK4099: PDB 'proj.pdb' was not found with 'proj.lib(PJ_denoy.obj)' or at 'D:\winbuilds\osm2pgsql\build\tests\proj.pdb'; linking object as if no debug info
..... (hundreds of lines)
```
http://stackoverflow.com/questions/661606/visual-c-how-to-disable-specific-linker-warnings

PDB files are needed only for interactive debug and they are not available in the most packages.