### PR TITLE
explicit type conversions to reduce MSVC warnings

### DIFF
--- a/node-ram-cache.hpp
+++ b/node-ram-cache.hpp
@@ -63,7 +63,7 @@ private:
     int _lon;
     int _lat;
 
-    int dbl2fix(const double x) const { return x * scale + 0.4; }
+    int dbl2fix(const double x) const { return (int) (x * scale + 0.4); }
     double fix2dbl(const int x) const { return (double)x / scale; }
 #else
 public:

--- a/pgsql.hpp
+++ b/pgsql.hpp
@@ -25,10 +25,10 @@ void escape(const std::string &src, std::string& dst);
 
 
 inline void pgsql_CopyData(const char *context, PGconn *sql_conn, const char *sql) {
-    pgsql_CopyData(context, sql_conn, sql, strlen(sql));
+    pgsql_CopyData(context, sql_conn, sql, (int) strlen(sql));
 }
 
 inline void pgsql_CopyData(const char *context, PGconn *sql_conn, const std::string &sql) {
-    pgsql_CopyData(context, sql_conn, sql.c_str(), sql.length());
+    pgsql_CopyData(context, sql_conn, sql.c_str(), (int) sql.length());
 }
 #endif


### PR DESCRIPTION
Here is the cosmetic fix that reduces the number of MSVC warnings
https://github.com/openstreetmap/osm2pgsql/issues/470
(all warnings in hpps)