### PR TITLE
fix Clang warnings about wrong format specifiers

### DIFF
--- a/node-ram-cache.cpp
+++ b/node-ram-cache.cpp
@@ -367,14 +367,14 @@ node_ram_cache::node_ram_cache( int strategy, int cacheSizeMB, int fixpointscale
     }
 
 #ifdef __MINGW_H
-    fprintf( stderr, "Node-cache: cache=%ldMB, maxblocks=%d*%d, allocation method=%i\n", (cacheSize >> 20), maxBlocks, PER_BLOCK*sizeof(ramNode), allocStrategy );
+    fprintf( stderr, "Node-cache: cache=%" PRId64 "MB, maxblocks=%d*%d, allocation method=%i\n", (cacheSize >> 20), maxBlocks, PER_BLOCK*sizeof(ramNode), allocStrategy );
 #else
-    fprintf( stderr, "Node-cache: cache=%ldMB, maxblocks=%d*%zd, allocation method=%i\n", (cacheSize >> 20), maxBlocks, PER_BLOCK*sizeof(ramNode), allocStrategy );
+    fprintf( stderr, "Node-cache: cache=%" PRId64 "MB, maxblocks=%d*%zd, allocation method=%i\n", (cacheSize >> 20), maxBlocks, PER_BLOCK*sizeof(ramNode), allocStrategy );
 #endif
 }
 
 node_ram_cache::~node_ram_cache() {
-  fprintf( stderr, "node cache: stored: %" PRIdOSMID "(%.2f%%), storage efficiency: %.2f%% (dense blocks: %i, sparse nodes: %li), hit rate: %.2f%%\n",
+  fprintf( stderr, "node cache: stored: %" PRIdOSMID "(%.2f%%), storage efficiency: %.2f%% (dense blocks: %i, sparse nodes: %" PRIi64 "), hit rate: %.2f%%\n",
            storedNodes, 100.0f*storedNodes/totalNodes, 100.0f*storedNodes*sizeof(ramNode)/cacheUsed,
            usedBlocks, sizeSparseTuples,
            100.0f*nodesCacheHits/nodesCacheLookups );


### PR DESCRIPTION
Use the proper format macros from inttypes.h instead.

Fixes these warnings:

```
/Users/travis/build/DerDakon/osm2pgsql/node-ram-cache.cpp:372:91: warning: format specifies type 'long' but the argument has type 'int64_t' (aka 'long long') [-Wformat]
    fprintf( stderr, "Node-cache: cache=%ldMB, maxblocks=%d*%zd, allocation method=%i\n", (cacheSize >> 20), maxBlocks, PER_BLOCK*sizeof(ramNode), allocStrategy );
                                        ~~~                                               ^~~~~~~~~~~~~~~~~
                                        %lld
/Users/travis/build/DerDakon/osm2pgsql/node-ram-cache.cpp:379:24: warning: format specifies type 'long' but the argument has type 'int64_t' (aka 'long long') [-Wformat]
           usedBlocks, sizeSparseTuples,
                       ^~~~~~~~~~~~~~~~
```