### PR TITLE
Fix three format warnings.

### DIFF
--- a/node-ram-cache.cpp
+++ b/node-ram-cache.cpp
@@ -369,12 +369,12 @@ node_ram_cache::node_ram_cache( int strategy, int cacheSizeMB, int fixpointscale
 #ifdef __MINGW_H
     fprintf( stderr, "Node-cache: cache=%ldMB, maxblocks=%d*%d, allocation method=%i\n", (cacheSize >> 20), maxBlocks, PER_BLOCK*sizeof(ramNode), allocStrategy );
 #else
-    fprintf( stderr, "Node-cache: cache=%ldMB, maxblocks=%d*%zd, allocation method=%i\n", (cacheSize >> 20), maxBlocks, PER_BLOCK*sizeof(ramNode), allocStrategy );
+    fprintf( stderr, "Node-cache: cache=%lldMB, maxblocks=%d*%llu, allocation method=%i\n", (cacheSize >> 20), maxBlocks, PER_BLOCK*sizeof(ramNode), allocStrategy );
 #endif
 }
 
 node_ram_cache::~node_ram_cache() {
-  fprintf( stderr, "node cache: stored: %" PRIdOSMID "(%.2f%%), storage efficiency: %.2f%% (dense blocks: %i, sparse nodes: %li), hit rate: %.2f%%\n",
+  fprintf( stderr, "node cache: stored: %" PRIdOSMID "(%.2f%%), storage efficiency: %.2f%% (dense blocks: %i, sparse nodes: %lli), hit rate: %.2f%%\n",
            storedNodes, 100.0f*storedNodes/totalNodes, 100.0f*storedNodes*sizeof(ramNode)/cacheUsed,
            usedBlocks, sizeSparseTuples,
            100.0f*nodesCacheHits/nodesCacheLookups );


### PR DESCRIPTION
node-ram-cache.cpp:372:162: warning: format '%ld' expects argument of type 'long int', but argument 3 has type 'int64_t {aka long long int}' [-Wformat=]
node-ram-cache.cpp:372:162: warning: format '%zd' expects argument of type 'signed size_t', but argument 5 has type 'long long unsigned int' [-Wformat=]
node-ram-cache.cpp:380:52: warning: format '%li' expects argument of type 'long int', but argument 7 has type 'int64_t {aka long long int}' [-Wformat=]


Found while porting/testing on OpenBSD by patrick keshishian