### PR TITLE
change directory for tests if TEST_DATA_DIR is present

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} ${ARGS})
 add_dependencies(check osm2pgsql)
 
-add_library(common-pg STATIC common-pg.cpp common-pg.hpp common-cleanup.cpp common-cleanup.hpp)
+add_library(common-pg STATIC common-pg.cpp common-pg.hpp common-cleanup.cpp common-cleanup.hpp common-chdir.hpp)
 add_library(middle-tests STATIC middle-tests.cpp middle-tests.hpp)
 
 set(TESTS

--- a/tests/common-chdir.hpp
+++ b/tests/common-chdir.hpp
@@ -1,0 +1,14 @@
+#ifndef COMMON_CHDIR_HPP
+#define COMMON_CHDIR_HPP
+
+#include <cstdlib>
+#include <boost/filesystem.hpp>
+
+static inline void auto_chdir() {
+  char* testDir = getenv ("TEST_DATA_DIR");
+  if (testDir!=nullptr) {
+      boost::filesystem::current_path(testDir);
+      fprintf(stderr, "Changed directory to %s\n", boost::filesystem::current_path().string().c_str());
+  }
+}
+#endif /* COMMON_CHDIR_HPP */

--- a/tests/test-hstore-match-only.cpp
+++ b/tests/test-hstore-match-only.cpp
@@ -14,6 +14,7 @@ The tags of inteest are specified in hstore-match-only.style
 #include <stdexcept>
 #include <memory>
 
+#include "common-chdir.hpp"
 #include "osmtypes.hpp"
 #include "osmdata.hpp"
 #include "middle.hpp"
@@ -32,6 +33,7 @@ The tags of inteest are specified in hstore-match-only.style
 #include "tests/common-pg.hpp"
 
 int main(int argc, char *argv[]) {
+    auto_chdir();
     std::unique_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-middle-flat.cpp
+++ b/tests/test-middle-flat.cpp
@@ -18,6 +18,7 @@
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
 #include "tests/common-cleanup.hpp"
+#include "tests/common-chdir.hpp"
 
 #define FLAT_NODES_FILE_NAME "tests/test_middle_flat.flat.nodes.bin"
 
@@ -73,6 +74,7 @@ void run_tests(options_t options, const std::string cache_type) {
   }*/
 }
 int main(int argc, char *argv[]) {
+  auto_chdir();
   std::unique_ptr<pg::tempdb> db;
 
   try {

--- a/tests/test-middle-pgsql.cpp
+++ b/tests/test-middle-pgsql.cpp
@@ -17,6 +17,7 @@
 
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
+#include "tests/common-chdir.hpp"
 
 void run_tests(options_t options, const std::string cache_type) {
   options.append = false;
@@ -61,6 +62,7 @@ void run_tests(options_t options, const std::string cache_type) {
   }
 }
 int main(int argc, char *argv[]) {
+  auto_chdir();
   std::unique_ptr<pg::tempdb> db;
 
   try {

--- a/tests/test-options-parse.cpp
+++ b/tests/test-options-parse.cpp
@@ -5,6 +5,8 @@
 #include "output-gazetteer.hpp"
 #include "output-null.hpp"
 
+#include "tests/common-chdir.hpp"
+
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
@@ -281,6 +283,7 @@ void test_random_perms()
 
 int main(int argc, char *argv[])
 {
+    auto_chdir();
     srand(0);
 
     //try each test if any fail we will exit

--- a/tests/test-output-multi-line-storage.cpp
+++ b/tests/test-output-multi-line-storage.cpp
@@ -22,8 +22,10 @@
 
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
+#include "tests/common-chdir.hpp"
 
 int main(int argc, char *argv[]) {
+    auto_chdir();
     std::unique_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-output-multi-line.cpp
+++ b/tests/test-output-multi-line.cpp
@@ -23,8 +23,10 @@
 
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
+#include "tests/common-chdir.hpp"
 
 int main(int argc, char *argv[]) {
+    auto_chdir();
     std::unique_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-output-multi-point-multi-table.cpp
+++ b/tests/test-output-multi-point-multi-table.cpp
@@ -22,8 +22,10 @@
 
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
+#include "tests/common-chdir.hpp"
 
 int main(int argc, char *argv[]) {
+    auto_chdir();
     std::unique_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-output-multi-point.cpp
+++ b/tests/test-output-multi-point.cpp
@@ -22,8 +22,10 @@
 
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
+#include "tests/common-chdir.hpp"
 
 int main(int argc, char *argv[]) {
+    auto_chdir();
     std::unique_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-output-multi-poly-trivial.cpp
+++ b/tests/test-output-multi-poly-trivial.cpp
@@ -22,6 +22,7 @@
 
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
+#include "tests/common-chdir.hpp"
 
 void run_osm2pgsql(options_t &options) {
   //setup the front (input)
@@ -84,6 +85,7 @@ void check_output_poly_trivial(bool enable_multi, std::shared_ptr<pg::tempdb> db
 }
 
 int main(int argc, char *argv[]) {
+    auto_chdir();
     std::shared_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-output-multi-polygon.cpp
+++ b/tests/test-output-multi-polygon.cpp
@@ -22,8 +22,10 @@
 
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
+#include "tests/common-chdir.hpp"
 
 int main(int argc, char *argv[]) {
+    auto_chdir();
     std::unique_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-output-multi-tags.cpp
+++ b/tests/test-output-multi-tags.cpp
@@ -22,8 +22,10 @@
 
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
+#include "tests/common-chdir.hpp"
 
 int main(int argc, char *argv[]) {
+    auto_chdir();
     std::unique_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-output-pgsql-schema.cpp
+++ b/tests/test-output-pgsql-schema.cpp
@@ -22,6 +22,7 @@
 #include <boost/lexical_cast.hpp>
 
 #include "tests/common-pg.hpp"
+#include "tests/common-chdir.hpp"
 
 namespace {
 
@@ -112,6 +113,7 @@ void test_other_output_schema() {
 } // anonymous namespace
 
 int main(int argc, char *argv[]) {
+    auto_chdir();
     RUN_TEST(test_other_output_schema);
 
     return 0;

--- a/tests/test-output-pgsql-tablespace.cpp
+++ b/tests/test-output-pgsql-tablespace.cpp
@@ -23,6 +23,7 @@
 
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
+#include "tests/common-chdir.hpp"
 
 namespace {
 
@@ -104,6 +105,7 @@ void test_regression_simple() {
 } // anonymous namespace
 
 int main(int argc, char *argv[]) {
+    auto_chdir();
     RUN_TEST(test_regression_simple);
 
     return 0;

--- a/tests/test-output-pgsql-z_order.cpp
+++ b/tests/test-output-pgsql-z_order.cpp
@@ -23,6 +23,8 @@
 
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
+#include "tests/common-chdir.hpp"
+
 
 namespace {
 
@@ -102,6 +104,7 @@ void test_z_order() {
 } // anonymous namespace
 
 int main(int argc, char *argv[]) {
+    auto_chdir();
     RUN_TEST(test_z_order);
 
     return 0;

--- a/tests/test-output-pgsql.cpp
+++ b/tests/test-output-pgsql.cpp
@@ -24,6 +24,7 @@
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
 #include "tests/common-cleanup.hpp"
+#include "tests/common-chdir.hpp"
 
 #define FLAT_NODES_FILE_NAME "tests/test_output_pgsql_area_way.flat.nodes.bin"
 
@@ -323,6 +324,7 @@ void test_clone() {
 int main(int argc, char *argv[]) {
     // remove flat nodes file  on exit - it's 20GB and bad manners to
     // leave that lying around on the filesystem.
+    auto_chdir();
     cleanup::file flat_nodes_file(FLAT_NODES_FILE_NAME);
 
     RUN_TEST(test_regression_simple);

--- a/tests/test-parse-xml2.cpp
+++ b/tests/test-parse-xml2.cpp
@@ -13,6 +13,9 @@
 #include "output.hpp"
 #include "parse-osmium.hpp"
 
+#include "tests/common-chdir.hpp"
+
+
 void exit_nicely()
 {
     fprintf(stderr, "Error occurred, cleaning up\n");
@@ -130,6 +133,7 @@ void assert_equal(uint64_t actual, uint64_t expected) {
 }
 
 int main(int argc, char *argv[]) {
+  auto_chdir();
 
   std::string inputfile = "tests/test_multipolygon.osm";
 


### PR DESCRIPTION
This patch solves the problem of missing files in tests.https://github.com/openstreetmap/osm2pgsql/issues/490

To run tests from any directory one need to add environment variable

```
export TEST_DATA_DIR=/path/to/osm2pgsql_sources
```

(if the variable is not present, the tests will get data from current directory)

ctest did not need it, it had WORKING_DIRECTORY in it.
If we want to just run executable without setting TEST_DATA_DIR, only auto-hardcoding in source can help. Will do it if really needed.
Python test also needs similar patching. Will do if solution is accepted.
