### PR TITLE
Add area reprojection facility

### DIFF
--- a/geometry-builder.hpp
+++ b/geometry-builder.hpp
@@ -35,13 +35,15 @@ class GeometryFactory;
 class CoordinateSequence;
 }}
 
+struct reprojection;
+
 class geometry_builder
 {
 public:
     struct wkt_t
     {
         wkt_t(const geos::geom::Geometry *geom, double area);
-        wkt_t(const geos::geom::Geometry *geom);
+        wkt_t(const geos::geom::Geometry *geom, reprojection *p);
 
         wkt_t(const std::string &geom_str, double geom_area = 0)
         : geom(geom_str), area(geom_area)
@@ -69,11 +71,19 @@ public:
         excludepoly = exclude;
     }
 
+    void set_reprojection(reprojection *r)
+    {
+        projection = r;
+    }
+
+
 private:
     std::unique_ptr<geos::geom::Geometry>
     create_simple_poly(geos::geom::GeometryFactory &gf,
                        std::unique_ptr<geos::geom::CoordinateSequence> coords) const;
+
     bool excludepoly = false;
+    reprojection *projection = nullptr;
 };
 
 #endif

--- a/options.cpp
+++ b/options.cpp
@@ -62,6 +62,7 @@ namespace
         {"flat-nodes",1,0,209},
         {"exclude-invalid-polygon",0,0,210},
         {"tag-transform-script",1,0,212},
+        {"reproject-area",0,0,213},
         {0, 0, 0, 0}
     };
 
@@ -201,6 +202,7 @@ namespace
                         By default natural=coastline tagged data will be discarded\n\
                         because renderers usually have shape files for them.\n\
           --exclude-invalid-polygon   do not import polygons with invalid geometries.\n\
+          --reproject-area   compute area column using spherical mercator coordinates.\n\
        -h|--help        Help information.\n\
        -v|--verbose     Verbose output.\n");
         }
@@ -267,7 +269,7 @@ options_t::options_t():
     #else
     alloc_chunkwise(ALLOC_SPARSE),
     #endif
-    droptemp(false),  unlogged(false), hstore_match_only(false), flat_node_cache_enabled(false), excludepoly(false), flat_node_file(boost::none),
+    droptemp(false),  unlogged(false), hstore_match_only(false), flat_node_cache_enabled(false), excludepoly(false), reproject_area(false), flat_node_file(boost::none),
     tag_transform_script(boost::none), tag_transform_node_func(boost::none), tag_transform_way_func(boost::none),
     tag_transform_rel_func(boost::none), tag_transform_rel_mem_func(boost::none),
     create(false), long_usage_bool(false), pass_prompt(false),  output_backend("pgsql"), input_reader("auto"), bbox(boost::none),
@@ -445,6 +447,9 @@ options_t::options_t(int argc, char *argv[]): options_t()
             break;
         case 212:
             tag_transform_script = optarg;
+            break;
+        case 213:
+            reproject_area = true;
             break;
         case 'V':
             exit (EXIT_SUCCESS);

--- a/options.hpp
+++ b/options.hpp
@@ -75,6 +75,7 @@ public:
     bool hstore_match_only; ///< only copy rows that match an explicitly listed key
     bool flat_node_cache_enabled;
     bool excludepoly;
+    bool reproject_area;
     boost::optional<std::string> flat_node_file;
     /**
      * these options allow you to control the name of the

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -613,6 +613,7 @@ output_pgsql_t::output_pgsql_t(const middle_query_t* mid_, const options_t &opti
 
     reproj = m_options.projection;
     builder.set_exclude_broken_polygon(m_options.excludepoly);
+    if (m_options.reproject_area) builder.set_reprojection(reproj.get());
 
     m_export_list.reset(new export_list());
 
@@ -682,6 +683,7 @@ output_pgsql_t::output_pgsql_t(const output_pgsql_t& other):
     ways_pending_tracker(new id_tracker()), ways_done_tracker(new id_tracker()), rels_pending_tracker(new id_tracker())
 {
     builder.set_exclude_broken_polygon(m_options.excludepoly);
+    if (m_options.reproject_area) builder.set_reprojection(reproj.get());
     for(std::vector<std::shared_ptr<table_t> >::const_iterator t = other.m_tables.begin(); t != other.m_tables.end(); ++t) {
         //copy constructor will just connect to the already there table
         m_tables.push_back(std::shared_ptr<table_t>(new table_t(**t)));

--- a/reprojection.cpp
+++ b/reprojection.cpp
@@ -200,6 +200,34 @@ void reprojection::coords_to_tile(double *tilex, double *tiley, double lon, doub
     *tiley = map_width * (0.5 - y[0] / EARTH_CIRCUMFERENCE);
 }
 
+
+/**
+ * Converts from (target) coordinates to coordinates in the tile projection (EPSG:3857)
+ *
+ * Do not confuse with coords_to_tile which does *not* calculate coordinates in the
+ * tile projection, but tile coordinates.
+ */
+void reprojection::target_to_tile(double *lat, double *lon) const
+{
+    if (Proj == PROJ_SPHERE_MERC)
+        return;
+
+    if (Proj == PROJ_LATLONG)
+    {
+        if (*lat > 85.07)
+            *lat = 85.07;
+        if (*lat < -85.07)
+            *lat = -85.07;
+
+        *lon = (*lon) * EARTH_CIRCUMFERENCE / 360.0;
+        *lat = log(tan(M_PI/4.0 + (*lat) * DEG_TO_RAD / 2.0)) * EARTH_CIRCUMFERENCE/(M_PI*2);
+        return;
+    }
+
+    double z = 0;
+    pj_transform(pj_target, pj_tile, 1, 1, lon, lat, &z);
+}
+
 int reprojection::get_proj_id() const
 {
 	return Proj;

--- a/reprojection.hpp
+++ b/reprojection.hpp
@@ -28,6 +28,7 @@ struct reprojection : public boost::noncopyable
 
     struct Projection_Info const* project_getprojinfo(void);
     void reproject(double *lat, double *lon) const;
+    void target_to_tile(double *lat, double *lon) const;
     void coords_to_tile(double *tilex, double *tiley, double lon, double lat, int map_width);
     int get_proj_id() const;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TESTS
   test-output-multi-poly-trivial.cpp
   test-output-multi-polygon.cpp
   test-output-multi-tags.cpp
+  test-output-pgsql-area.cpp
   test-output-pgsql-schema.cpp
   test-output-pgsql-tablespace.cpp
   test-output-pgsql-z_order.cpp

--- a/tests/test-output-pgsql-area.cpp
+++ b/tests/test-output-pgsql-area.cpp
@@ -1,0 +1,107 @@
+/**
+
+Test the area reprojection functionality of osm2pgsql 
+
+The idea behind that functionality is to populate the way_area
+column with the area that a polygoun would have in EPSG:3857, 
+rather than the area it actually has in the coordinate system
+used for importing.
+
+*/
+#include <iostream>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <cassert>
+#include <sstream>
+#include <stdexcept>
+#include <memory>
+
+#include "osmtypes.hpp"
+#include "osmdata.hpp"
+#include "middle.hpp"
+#include "output-pgsql.hpp"
+#include "options.hpp"
+#include "middle-pgsql.hpp"
+#include "middle-ram.hpp"
+#include "taginfo_impl.hpp"
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <boost/lexical_cast.hpp>
+
+#include "tests/common-pg.hpp"
+#include "tests/common.hpp"
+
+void run_test(const char* test_name, void (*testfunc)()) {
+    try {
+        fprintf(stderr, "%s\n", test_name);
+        testfunc();
+
+    } catch (const std::exception& e) {
+        fprintf(stderr, "%s\n", e.what());
+        fprintf(stderr, "FAIL\n");
+        exit(EXIT_FAILURE);
+    }
+
+    fprintf(stderr, "PASS\n");
+}
+#define RUN_TEST(x) run_test(#x, &(x))
+
+
+void test_area_base(bool latlon, bool reproj, double expect_area_poly, double expect_area_multi) {
+    std::unique_ptr<pg::tempdb> db;
+
+    try {
+        db.reset(new pg::tempdb);
+    } catch (const std::exception &e) {
+        std::cerr << "Unable to setup database: " << e.what() << "\n";
+        exit(77);
+    }
+
+    std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
+    options_t options;
+    options.database_options = db->database_options;
+    options.num_procs = 1;
+    options.style = "default.style";
+    options.prefix = "osm2pgsql_test";
+    if (latlon) {
+        options.projection.reset(new reprojection(PROJ_LATLONG));
+    }
+    if (reproj) {
+        options.reproject_area = true;
+    }
+    options.scale = latlon ? 10000000 : 100;
+
+    auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
+
+    osmdata_t osmdata(mid_pgsql, out_test);
+    testing::parse("tests/test_output_pgsql_area.osm", "xml",
+                   options, &osmdata);
+
+    db->check_count(2, "SELECT COUNT(*) FROM osm2pgsql_test_polygon");
+    db->check_number(expect_area_poly, "SELECT way_area FROM osm2pgsql_test_polygon WHERE name='poly'");
+    db->check_number(expect_area_multi, "SELECT way_area FROM osm2pgsql_test_polygon WHERE name='multi'");
+
+    return;
+}
+
+void test_area_classic() {
+    test_area_base(false, false, 1.23927e+10, 9.91828e+10);
+}
+
+void test_area_latlon() {
+    test_area_base(true, false, 1, 8);
+}
+
+void test_area_latlon_with_reprojection() {
+    test_area_base(true, true, 1.23927e+10, 9.91828e+10);
+}
+
+int main(int argc, char *argv[]) {
+    RUN_TEST(test_area_latlon);
+    RUN_TEST(test_area_classic);
+    RUN_TEST(test_area_latlon_with_reprojection);
+    return 0;
+}

--- a/tests/test_output_pgsql_area.osm
+++ b/tests/test_output_pgsql_area.osm
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Nodes:
+        7     8
+   3 4   11 12
+         9  10
+   1 2  5     6
+-->
+<osm version="0.6">
+  <node id="1" version="1" lat="0" lon="0"/>
+  <node id="2" version="1" lat="0" lon="1"/>
+  <node id="3" version="1" lat="1" lon="0"/>
+  <node id="4" version="1" lat="1" lon="1"/>
+
+  <node id="5" version="1" lat="0" lon="2"/>
+  <node id="6" version="1" lat="0" lon="5"/>
+  <node id="7" version="1" lat="3" lon="2"/>
+  <node id="8" version="1" lat="3" lon="5"/>
+
+  <node id="9" version="1" lat="1" lon="3"/>
+  <node id="10" version="1" lat="1" lon="4"/>
+  <node id="11" version="1" lat="2" lon="3"/>
+  <node id="12" version="1" lat="2" lon="4"/>
+
+  <way id="1" version="1">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="4"/>
+    <nd ref="3"/>
+    <nd ref="1"/>
+    <tag k="natural" v="water"/>
+    <tag k="name" v="poly"/>
+  </way>
+  <way id="2" version="1">
+    <nd ref="5"/>
+    <nd ref="6"/>
+    <nd ref="8"/>
+    <nd ref="7"/>
+    <nd ref="5"/>
+  </way>
+  <way id="3" version="1">
+    <nd ref="9"/>
+    <nd ref="10"/>
+    <nd ref="12"/>
+    <nd ref="11"/>
+    <nd ref="9"/>
+  </way>
+  <relation id='1' version='1'>
+    <member type="way" ref="2" role=""/>
+    <member type="way" ref="3" role=""/>
+    <tag k="type" v="multipolygon"/>
+    <tag k="natural" v="water"/>
+    <tag k="name" v="multi"/>
+  </relation>
+</osm>


### PR DESCRIPTION
Supersedes #454 which is no longer mergable because of cmake and geometry-builder refactoring.

@woodpeck could you check that it still works for you? I've done some minor cleanup especially wrt resource management but functionally it should be the same.