### PR TITLE
Convert geometries to WKB instead of WKT

### DIFF
--- a/expire-tiles.cpp
+++ b/expire-tiles.cpp
@@ -464,14 +464,14 @@ void expire_tiles::from_xnodes_line(const multinodelist_t &xnodes)
         from_nodes_line(*it);
 }
 
-void expire_tiles::from_wkt(const char * wkt, osmid_t osm_id)
+void expire_tiles::from_wkb(const char* wkb, osmid_t osm_id)
 {
     if (Options->expire_tiles_zoom < 0) return;
 
     multinodelist_t xnodes;
     bool polygon;
 
-    if (!geometry_builder::parse_wkt(wkt, xnodes, &polygon)) {
+    if (geometry_builder::parse_wkb(wkb, xnodes, &polygon) == 0) {
         if (polygon)
             from_xnodes_poly(xnodes, osm_id);
         else
@@ -495,15 +495,15 @@ int expire_tiles::from_db(table_t* table, osmid_t osm_id) {
         return -1;
 
     //grab the geom for this id
-    std::unique_ptr<table_t::wkt_reader> wkts = table->get_wkt_reader(osm_id);
+    auto wkbs = table->get_wkb_reader(osm_id);
 
     //dirty the stuff
-    const char* wkt = nullptr;
-    while((wkt = wkts->get_next()))
-        from_wkt(wkt, osm_id);
+    const char* wkb = nullptr;
+    while((wkb = wkbs.get_next()))
+        from_wkb(wkb, osm_id);
 
     //return how many rows were affected
-    return wkts->get_count();
+    return wkbs.get_count();
 }
 
 void expire_tiles::merge_and_destroy(expire_tiles &other) {

--- a/expire-tiles.hpp
+++ b/expire-tiles.hpp
@@ -17,7 +17,7 @@ struct expire_tiles : public boost::noncopyable {
     int from_bbox(double min_lon, double min_lat, double max_lon, double max_lat);
     void from_nodes_line(const nodelist_t &nodes);
     void from_nodes_poly(const nodelist_t &nodes, osmid_t osm_id);
-    void from_wkt(const char * wkt, osmid_t osm_id);
+    void from_wkb(const char* wkb, osmid_t osm_id);
     int from_db(table_t* table, osmid_t osm_id);
 
     struct tile {

--- a/geometry-builder.cpp
+++ b/geometry-builder.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <sstream>
 #include <stdexcept>
 #include <memory>
 #include <new>
@@ -47,7 +48,7 @@
 #include <geos/geom/Polygon.h>
 #include <geos/geom/MultiPolygon.h>
 #include <geos/io/WKTReader.h>
-#include <geos/io/WKTWriter.h>
+#include <geos/io/WKBWriter.h>
 #include <geos/util/GEOSException.h>
 #include <geos/opLinemerge.h>
 using namespace geos::geom;
@@ -192,8 +193,13 @@ geometry_builder::wkt_t::wkt_t(const geos::geom::Geometry *g, reprojection *p)
 {}
 
 geometry_builder::wkt_t::wkt_t(const geos::geom::Geometry *g, double a)
-: geom(geos::io::WKTWriter().write(g)), area(a)
-{}
+: area(a)
+{
+    geos::io::WKBWriter writer(2, getMachineByteOrder(), true);
+    std::stringstream stream(std::ios_base::out);
+    writer.writeHEX(*g, stream);
+    geom = stream.str();
+}
 
 geom_ptr geometry_builder::create_simple_poly(GeometryFactory &gf,
                                               std::unique_ptr<CoordinateSequence> coords) const

--- a/geometry-builder.cpp
+++ b/geometry-builder.cpp
@@ -47,7 +47,7 @@
 #include <geos/geom/MultiLineString.h>
 #include <geos/geom/Polygon.h>
 #include <geos/geom/MultiPolygon.h>
-#include <geos/io/WKTReader.h>
+#include <geos/io/WKBReader.h>
 #include <geos/io/WKBWriter.h>
 #include <geos/util/GEOSException.h>
 #include <geos/opLinemerge.h>
@@ -338,12 +338,13 @@ geometry_builder::maybe_wkts_t geometry_builder::get_wkt_split(const nodelist_t 
     return wkts;
 }
 
-int geometry_builder::parse_wkt(const char * wkt, multinodelist_t &nodes, bool *polygon) {
+int geometry_builder::parse_wkb(const char* wkb, multinodelist_t &nodes, bool *polygon) {
     GeometryFactory gf;
-    geos::io::WKTReader reader(&gf);
+    geos::io::WKBReader reader(gf);
 
     *polygon = false;
-    geom_ptr geometry(reader.read(wkt));
+    std::stringstream stream(wkb, std::ios_base::in);
+    geom_ptr geometry(reader.readHEX(stream));
     switch (geometry->getGeometryTypeId()) {
         // Single geometries
         case GEOS_POLYGON:

--- a/geometry-builder.hpp
+++ b/geometry-builder.hpp
@@ -49,6 +49,9 @@ public:
         : geom(geom_str), area(geom_area)
         {}
 
+        bool is_polygon() const
+        { return area > 0; }
+
         std::string geom;
         double area;
     };

--- a/geometry-builder.hpp
+++ b/geometry-builder.hpp
@@ -42,18 +42,18 @@ class geometry_builder
 public:
     struct wkt_t
     {
-        wkt_t(const geos::geom::Geometry *geom, double area);
-        wkt_t(const geos::geom::Geometry *geom, reprojection *p);
+        wkt_t(const geos::geom::Geometry *geom, bool poly, reprojection *p = nullptr);
 
-        wkt_t(const std::string &geom_str, double geom_area = 0)
-        : geom(geom_str), area(geom_area)
+        wkt_t(const std::string &geom_str, bool poly, double geom_area = 0)
+        : geom(geom_str), area(geom_area), polygon(poly)
         {}
 
         bool is_polygon() const
-        { return area > 0; }
+        { return polygon; }
 
         std::string geom;
         double area;
+        bool polygon;
     };
 
     // type to represent an optional return of WKT-encoded geometry

--- a/geometry-builder.hpp
+++ b/geometry-builder.hpp
@@ -60,7 +60,7 @@ public:
     typedef std::shared_ptr<geometry_builder::wkt_t> maybe_wkt_t;
     typedef std::shared_ptr<std::vector<geometry_builder::wkt_t> > maybe_wkts_t;
 
-    static int parse_wkt(const char *wkt, multinodelist_t &nodes, bool *polygon);
+    static int parse_wkb(const char *wkb, multinodelist_t &nodes, bool *polygon);
     maybe_wkt_t get_wkt_simple(const nodelist_t &nodes, int polygon) const;
     maybe_wkts_t get_wkt_split(const nodelist_t &nodes, int polygon, double split_at) const;
     maybe_wkts_t build_both(const multinodelist_t &xnodes, int make_polygon,

--- a/output-gazetteer.cpp
+++ b/output-gazetteer.cpp
@@ -755,8 +755,7 @@ int output_gazetteer_t::process_relation(osmid_t id, const memberlist_t &members
     if (cmp_waterway) {
         geometry_builder::maybe_wkts_t wkts = builder.build_both(xnodes, 1, 1, 1000000, id);
         for (const auto& wkt: *wkts) {
-            if (boost::starts_with(wkt.geom,  "POLYGON")
-                    || boost::starts_with(wkt.geom,  "MULTIPOLYGON")) {
+            if (wkt.is_polygon()) {
                 places.copy_out('R', id, wkt.geom, buffer);
                 flush_place_buffer();
             } else {

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -382,7 +382,7 @@ int output_multi_t::process_relation(osmid_t id, const memberlist_t &members,
                 for (const auto wkt: *wkts) {
                     //TODO: we actually have the nodes in the m_relation_helper and could use them
                     //instead of having to reparse the wkt in the expiry code
-                    m_expire->from_wkt(wkt.geom.c_str(), -id);
+                    m_expire->from_wkb(wkt.geom.c_str(), -id);
                     //what part of the code relies on relation members getting negative ids?
                     copy_to_table(-id, wkt, outtags, make_polygon);
                 }

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -419,7 +419,7 @@ void output_multi_t::copy_node_to_table(osmid_t id, const char *wkt, const tagli
  * \param polygon Polygon flag returned from the tag transform (polygon=1)
  */
 void output_multi_t::copy_to_table(const osmid_t id, const geometry_builder::wkt_t &wkt, const taglist_t &tags, int polygon) {
-    if (boost::starts_with(wkt.geom, "POLYGON") || boost::starts_with(wkt.geom, "MULTIPOLYGON")) {
+    if (wkt.is_polygon()) {
         // It's a polygon table (implied by it turning into a poly), and it got formed into a polygon, so expire as a polygon and write the WKT
         m_expire->from_nodes_poly(m_way_helper.node_cache, id);
         m_table->write_wkt(id, tags, wkt.geom.c_str());

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -115,7 +115,7 @@ int output_pgsql_t::pgsql_out_way(osmid_t id, const taglist_t &tags, const nodel
     geometry_builder::maybe_wkts_t wkts = builder.get_wkt_split(nodes, polygon, split_at);
     for (const auto& wkt: *wkts) {
         /* FIXME: there should be a better way to detect polygons */
-        if (boost::starts_with(wkt.geom, "POLYGON") || boost::starts_with(wkt.geom, "MULTIPOLYGON")) {
+        if (wkt.is_polygon()) {
             expire->from_nodes_poly(nodes, id);
             if ((wkt.area > 0.0) && m_enable_way_area) {
                 char tmp[32];
@@ -179,7 +179,7 @@ int output_pgsql_t::pgsql_out_relation(osmid_t id, const taglist_t &rel_tags,
     for (const auto& wkt: *wkts) {
         expire->from_wkt(wkt.geom.c_str(), -id);
         /* FIXME: there should be a better way to detect polygons */
-        if (boost::starts_with(wkt.geom, "POLYGON") || boost::starts_with(wkt.geom, "MULTIPOLYGON")) {
+        if (wkt.is_polygon()) {
             if ((wkt.area > 0.0) && m_enable_way_area) {
                 char tmp[32];
                 snprintf(tmp, sizeof(tmp), "%g", wkt.area);

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -177,7 +177,7 @@ int output_pgsql_t::pgsql_out_relation(osmid_t id, const taglist_t &rel_tags,
 
     tag_t *areatag = 0;
     for (const auto& wkt: *wkts) {
-        expire->from_wkt(wkt.geom.c_str(), -id);
+        expire->from_wkb(wkt.geom.c_str(), -id);
         /* FIXME: there should be a better way to detect polygons */
         if (wkt.is_polygon()) {
             if ((wkt.area > 0.0) && m_enable_way_area) {
@@ -219,7 +219,7 @@ int output_pgsql_t::pgsql_out_relation(osmid_t id, const taglist_t &rel_tags,
         tag_t *areatag = 0;
         wkts = builder.build_polygons(xnodes, m_options.enable_multi, id);
         for (const auto& wkt: *wkts) {
-            expire->from_wkt(wkt.geom.c_str(), -id);
+            expire->from_wkb(wkt.geom.c_str(), -id);
             if ((wkt.area > 0.0) && m_enable_way_area) {
                 char tmp[32];
                 snprintf(tmp, sizeof(tmp), "%g", wkt.area);

--- a/processor-point.cpp
+++ b/processor-point.cpp
@@ -15,5 +15,5 @@ processor_point::~processor_point() {
 geometry_builder::maybe_wkt_t processor_point::process_node(double lat, double lon)
 {
     using wkt_t = geometry_builder::wkt_t;
-    return std::make_shared<wkt_t>((boost::format("POINT(%.15g %.15g)") % lon % lat).str());
+    return std::make_shared<wkt_t>((boost::format("POINT(%.15g %.15g)") % lon % lat).str(), false);
 }


### PR DESCRIPTION
Changes geometry-builder to emit WKBs. Nodes are still built as WKTs at the moment.
Improves performance by 15-20%.

Planet import with `./osm2pgsql -d gis -S ../default.style --flat-nodes osm2pgsql.flatnodes -s -C 24000 --drop planet-150624.osm.pbf` on 32GB RAM all-SSD system with 6x2 CPUs yields:

master:
```
Node stats: total(2926993226), max(3610010794) in 1064s
Way stats: total(295111882), max(355378385) in 12100s
Relation stats: total(3493735), max(5307354) in 15387s
Pending ways took 9523s at a rate of 20389.88/s
Osm2pgsql took 55724s overall
```

use-wkb branch:
```
Node stats: total(2926993226), max(3610010794) in 1065s
Way stats: total(295111882), max(355378385) in 9093s
Relation stats: total(3493735), max(5307354) in 11710s
Pending ways took 8320s at a rate of 23338.07/s
Osm2pgsql took 48452s overall
```
