### PR TITLE
Fix build without FIXED_POINT

### DIFF
--- a/node-ram-cache.cpp
+++ b/node-ram-cache.cpp
@@ -62,7 +62,9 @@
 
 #define SAFETY_MARGIN 1024*PER_BLOCK*sizeof(ramNode)
 
+#ifdef FIXED_POINT
 int ramNode::scale;
+#endif
 
 static int32_t id2block(osmid_t id)
 {
@@ -305,8 +307,9 @@ node_ram_cache::node_ram_cache( int strategy, int cacheSizeMB, int fixpointscale
       maxSparseTuples(0), sizeSparseTuples(0), maxSparseId(0), cacheUsed(0),
       cacheSize(0), storedNodes(0), totalNodes(0), nodesCacheHits(0),
       nodesCacheLookups(0), warn_node_order(0) {
-
+#ifdef FIXED_POINT
     ramNode::scale = fixpointscale;
+#endif
     blockCache = 0;
     blockCachePos = 0;
     cacheUsed = 0;

--- a/node-ram-cache.hpp
+++ b/node-ram-cache.hpp
@@ -68,9 +68,9 @@ private:
 #else
 public:
     ramNode() : _lat(NAN), _lon(NAN) {}
-    ramNode(double _lon, double _lat) : _lon(lon), _lat(lat) {}
+    ramNode(double lon, double lat) : _lon(lon), _lat(lat) {}
 
-    bool is_valid() const ( return !std::isnan(_lon); }
+    bool is_valid() const { return !std::isnan(_lon); }
     double lon() const { return _lon; }
     double lat() const { return _lat; }
 private:


### PR DESCRIPTION
* fixed an error in `node-ram-cache.hpp`
* make the headers work with msvc on windows

These changes have only been tested on Windows x64 with Visual Studio 2015.