### PR TITLE
Rename and clean up wkt_t

### DIFF
--- a/expire-tiles.cpp
+++ b/expire-tiles.cpp
@@ -483,7 +483,7 @@ void expire_tiles::from_wkb(const char* wkb, osmid_t osm_id)
  * Expire tiles based on an osm element.
  * What type of element (node, line, polygon) osm_id refers to depends on
  * sql_conn. Each type of table has its own sql_conn and the prepared statement
- * get_wkt refers to the appropriate table.
+ * get_wkb refers to the appropriate table.
  *
  * The function returns -1 if expiry is not enabled. Otherwise it returns the number
  * of elements that refer to the osm_id.

--- a/geometry-processor.cpp
+++ b/geometry-processor.cpp
@@ -57,16 +57,16 @@ bool geometry_processor::interests(unsigned int interested) const {
     return (interested & m_interests) == interested;
 }
 
-geometry_builder::maybe_wkt_t geometry_processor::process_node(double lat, double lon) {
-    return geometry_builder::maybe_wkt_t();
+geometry_builder::pg_geom_t geometry_processor::process_node(double, double) {
+    return geometry_builder::pg_geom_t();
 }
 
-geometry_builder::maybe_wkt_t geometry_processor::process_way(const nodelist_t &nodes) {
-    return geometry_builder::maybe_wkt_t();
+geometry_builder::pg_geom_t geometry_processor::process_way(const nodelist_t &) {
+    return geometry_builder::pg_geom_t();
 }
 
-geometry_builder::maybe_wkts_t geometry_processor::process_relation(const multinodelist_t &nodes) {
-    return geometry_builder::maybe_wkts_t();
+geometry_builder::pg_geoms_t geometry_processor::process_relation(const multinodelist_t &) {
+    return geometry_builder::pg_geoms_t();
 }
 
 way_helper::way_helper()

--- a/geometry-processor.hpp
+++ b/geometry-processor.hpp
@@ -38,19 +38,19 @@ struct geometry_processor {
     // LINESTRING, etc...) that this processor outputs
     const std::string &column_type() const;
 
-    // process a node, optionally returning a WKT string describing
+    // process a node, optionally returning a WKB string describing
     // geometry to be inserted into the table.
-    virtual geometry_builder::maybe_wkt_t process_node(double lat, double lon);
+    virtual geometry_builder::pg_geom_t process_node(double lat, double lon);
 
     // process a way
-    // position data and optionally returning WKT-encoded geometry
+    // position data and optionally returning WKB-encoded geometry
     // for insertion into the table.
-    virtual geometry_builder::maybe_wkt_t process_way(const nodelist_t &nodes);
+    virtual geometry_builder::pg_geom_t process_way(const nodelist_t &nodes);
 
     // process a way, taking a middle query object to get way and
-    // node position data. optionally returns a WKT-encoded geometry
+    // node position data. optionally returns an array of WKB-encoded geometry
     // for insertion into the table.
-    virtual geometry_builder::maybe_wkts_t process_relation(const multinodelist_t &nodes);
+    virtual geometry_builder::pg_geoms_t process_relation(const multinodelist_t &nodes);
 
     // returns the SRID of the output geometry.
     int srid() const;

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -43,7 +43,7 @@ public:
         return false;
     }
 
-    void copy_out(char osm_type, osmid_t osm_id, const std::string &wkt,
+    void copy_out(char osm_type, osmid_t osm_id, const std::string &geom,
                   std::string &buffer);
 
     void clear();

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -70,9 +70,8 @@ protected:
     int process_way(osmid_t id, const idlist_t &nodes, const taglist_t &tags);
     int reprocess_way(osmid_t id, const nodelist_t &nodes, const taglist_t &tags, bool exists);
     int process_relation(osmid_t id, const memberlist_t &members, const taglist_t &tags, bool exists, bool pending=false);
-    void copy_node_to_table(osmid_t id, const char *wkt, const taglist_t &tags);
-    void copy_to_table(const osmid_t id, const geometry_builder::maybe_wkt_t &wkt, const taglist_t &tags, int polygon);
-    void copy_to_table(const osmid_t id, const geometry_builder::wkt_t &wkt, const taglist_t &tags, int polygon);
+    void copy_node_to_table(osmid_t id, const std::string &geom, const taglist_t &tags);
+    void copy_to_table(const osmid_t id, const geometry_builder::pg_geom_t &geom, const taglist_t &tags, int polygon);
 
     std::unique_ptr<tagtransform> m_tagtransform;
     std::unique_ptr<export_list> m_export_list;

--- a/processor-line.cpp
+++ b/processor-line.cpp
@@ -8,10 +8,7 @@ processor_line::~processor_line()
 {
 }
 
-geometry_builder::maybe_wkt_t processor_line::process_way(const nodelist_t &nodes)
+geometry_builder::pg_geom_t processor_line::process_way(const nodelist_t &nodes)
 {
-    //have the builder make the wkt
-    geometry_builder::maybe_wkt_t wkt = builder.get_wkt_simple(nodes, false);
-    //hand back the wkt
-    return wkt;
+    return builder.get_wkb_simple(nodes, false);
 }

--- a/processor-line.hpp
+++ b/processor-line.hpp
@@ -7,7 +7,7 @@ struct processor_line : public geometry_processor {
     processor_line(int srid);
     virtual ~processor_line();
 
-    geometry_builder::maybe_wkt_t process_way(const nodelist_t &nodes);
+    geometry_builder::pg_geom_t process_way(const nodelist_t &nodes);
 
 private:
     geometry_builder builder;

--- a/processor-point.cpp
+++ b/processor-point.cpp
@@ -12,8 +12,7 @@ processor_point::processor_point(int srid)
 processor_point::~processor_point() {
 }
 
-geometry_builder::maybe_wkt_t processor_point::process_node(double lat, double lon)
+geometry_builder::pg_geom_t processor_point::process_node(double lat, double lon)
 {
-    using wkt_t = geometry_builder::wkt_t;
-    return std::make_shared<wkt_t>((boost::format("POINT(%.15g %.15g)") % lon % lat).str(), false);
+    return geometry_builder::pg_geom_t((boost::format("POINT(%.15g %.15g)") % lon % lat).str(), false);
 }

--- a/processor-point.hpp
+++ b/processor-point.hpp
@@ -7,7 +7,7 @@ struct processor_point : public geometry_processor {
     processor_point(int srid);
     virtual ~processor_point();
 
-    geometry_builder::maybe_wkt_t process_node(double lat, double lon);
+    geometry_builder::pg_geom_t process_node(double lat, double lon);
 };
 
 #endif /* PROCESSOR_POINT_HPP */

--- a/processor-polygon.cpp
+++ b/processor-polygon.cpp
@@ -8,17 +8,12 @@ processor_polygon::~processor_polygon()
 {
 }
 
-geometry_builder::maybe_wkt_t processor_polygon::process_way(const nodelist_t &nodes)
+geometry_builder::pg_geom_t processor_polygon::process_way(const nodelist_t &nodes)
 {
-    //have the builder make the wkt
-    geometry_builder::maybe_wkt_t wkt = builder.get_wkt_simple(nodes, true);
-    //hand back the wkt
-    return wkt;
+    return builder.get_wkb_simple(nodes, true);
 }
 
-geometry_builder::maybe_wkts_t processor_polygon::process_relation(const multinodelist_t &nodes)
+geometry_builder::pg_geoms_t processor_polygon::process_relation(const multinodelist_t &nodes)
 {
-    //the hard word was already done for us in getting at the node data for each way. at this point just make the geom
-    geometry_builder::maybe_wkts_t wkts  = builder.build_polygons(nodes, enable_multi, -1);
-    return wkts;
+    return  builder.build_polygons(nodes, enable_multi, -1);
 }

--- a/processor-polygon.hpp
+++ b/processor-polygon.hpp
@@ -7,8 +7,8 @@ struct processor_polygon : public geometry_processor {
     processor_polygon(int srid, bool enable_multi);
     virtual ~processor_polygon();
 
-    geometry_builder::maybe_wkt_t process_way(const nodelist_t &nodes);
-    geometry_builder::maybe_wkts_t process_relation(const multinodelist_t &nodes);
+    geometry_builder::pg_geom_t process_way(const nodelist_t &nodes);
+    geometry_builder::pg_geoms_t process_relation(const multinodelist_t &nodes);
 
 private:
     bool enable_multi;

--- a/table.cpp
+++ b/table.cpp
@@ -297,7 +297,7 @@ void table_t::stop_copy()
 
 void table_t::write_node(const osmid_t id, const taglist_t &tags, double lat, double lon)
 {
-    write_wkt(id, tags, (point_fmt % lon % lat).str().c_str());
+    write_row(id, tags, (point_fmt % lon % lat).str());
 }
 
 void table_t::delete_row(const osmid_t id)
@@ -306,7 +306,7 @@ void table_t::delete_row(const osmid_t id)
     pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (del_fmt % name % id).str());
 }
 
-void table_t::write_wkt(const osmid_t id, const taglist_t &tags, const char *wkt)
+void table_t::write_row(const osmid_t id, const taglist_t &tags, const std::string &geom)
 {
     //add the osm id
     buffer.append((single_fmt % id).str());
@@ -328,12 +328,12 @@ void table_t::write_wkt(const osmid_t id, const taglist_t &tags, const char *wkt
     if (hstore_mode != HSTORE_NONE)
         write_tags_column(tags, buffer, used);
 
-    //give the wkt an srid
+    //give the geometry an srid
     buffer.append("SRID=");
     buffer.append(srid);
     buffer.push_back(';');
-    //add the wkt
-    buffer.append(wkt);
+    //add the geometry
+    buffer.append(geom);
     //we need \n because we are copying from stdin
     buffer.push_back('\n');
 

--- a/table.hpp
+++ b/table.hpp
@@ -31,7 +31,7 @@ class table_t
         void begin();
         void commit();
 
-        void write_wkt(const osmid_t id, const taglist_t &tags, const char *wkt);
+        void write_row(const osmid_t id, const taglist_t &tags, const std::string &geom);
         void write_node(const osmid_t id, const taglist_t &tags, double lat, double lon);
         void delete_row(const osmid_t id);
 


### PR DESCRIPTION
Renames wkt_t to the more neutral pg_geom_t and gets rid of the shared_ptr wrapper for it.