### PR TITLE
avoid double-filtering tags on ways in pgsql output

### DIFF
--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -61,7 +61,8 @@ public:
 protected:
 
     int pgsql_out_node(osmid_t id, const taglist_t &tags, double node_lat, double node_lon);
-    int pgsql_out_way(osmid_t id, const taglist_t &tags, const nodelist_t &nodes, int exists);
+    int pgsql_out_way(osmid_t id, taglist_t &tags, const nodelist_t &nodes,
+                      int polygons, int roads);
     int pgsql_out_relation(osmid_t id, const taglist_t &rel_tags,
                            const multinodelist_t &xnodes, const multitaglist_t & xtags,
                            const idlist_t &xid, const rolelist_t &xrole,


### PR DESCRIPTION
In way_add() tags have been filtered and then forwarded to pgsql_out_way() where they will filtered again. Moved filtering code out of pgsql_out_way() to avoid filtering twice altogether.