### PR TITLE
Use long ints for tracking cache hits

### DIFF
--- a/node-ram-cache.hpp
+++ b/node-ram-cache.hpp
@@ -138,7 +138,7 @@ private:
 
     int64_t cacheUsed, cacheSize;
     osmid_t storedNodes, totalNodes;
-    int nodesCacheHits, nodesCacheLookups;
+    long nodesCacheHits, nodesCacheLookups;
 
     int warn_node_order;
 };


### PR DESCRIPTION
This should fix #521, but I haven't tested with a full planet.