### PR TITLE
Use UNLOGGED for non-permanant tables

### DIFF
--- a/table.cpp
+++ b/table.cpp
@@ -120,7 +120,7 @@ void table_t::start()
     if (!append)
     {
         //define the new table
-        string sql = (fmt("CREATE TABLE %1% (osm_id %2%,") % name % POSTGRES_OSMID_TYPE).str();
+        string sql = (fmt("CREATE UNLOGGED TABLE %1% (osm_id %2%,") % name % POSTGRES_OSMID_TYPE).str();
 
         //first with the regular columns
         for(columns_t::const_iterator column = columns.begin(); column != columns.end(); ++column)


### PR DESCRIPTION
This breaks compatibility with PostgreSQL 9.0, which has been EOL for months.

This increases pending ways speed by 5.2% (5m of 1h34m)