### PR TITLE
Change the section about `--flat-nodes`

### DIFF
--- a/docs/osm2pgsql.1
+++ b/docs/osm2pgsql.1
@@ -228,7 +228,8 @@ planet requires about 100GB in PostgreSQL, the same data is stored in only ~16GB
 the flat\-nodes mode. This can also increase the speed of applying diff files. This option
 activates the flat\-nodes mode and specifies the location of the database file. It is a
 single large > 16GB file. This mode is only recommended for full planet imports
-as it doesn't work well with small extracts. The default is disabled.
+as it doesn't work well with small imports (even from big extracts, like while using the
+\-\-bbox option). The default is disabled.
 .TP
 \fB\-h\fR|\-\-help
 Help information.


### PR DESCRIPTION
The original paragraph mentions that `--flat-nodes` in unsuitable for "small extracts", but a few test on my own show that it's actually unsuitable for small _imports_. For instance, I'm importing a 5x3 degrees bbox from a whole Europe extract (~80x51 degrees bbox) and it's _way_ faster without `--flat-nodes`.
