### PR TITLE
Remove remove shared_ptr wrappers around private class members

### DIFF
--- a/id-tracker.cpp
+++ b/id-tracker.cpp
@@ -169,7 +169,7 @@ osmid_t id_tracker::pop_mark() {
     return id;
 }
 
-size_t id_tracker::size() { return impl->count; }
+size_t id_tracker::size() const { return impl->count; }
 
 osmid_t id_tracker::last_returned() const { return impl->old_id; }
 

--- a/id-tracker.hpp
+++ b/id-tracker.hpp
@@ -29,7 +29,7 @@ struct id_tracker : public boost::noncopyable {
      * Finds an osmid_t that is marked
      */
     osmid_t pop_mark();
-    size_t size();
+    size_t size() const;
     osmid_t last_returned() const;
 
     static bool is_valid(osmid_t);

--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -285,7 +285,7 @@ struct pending_threaded_processor : public middle_t::pending_processor {
                 //done copying ways for now
                 clone_output->get()->commit();
                 //merge the pending from this threads copy of output back
-                original_output->get()->merge_pending_relations(*clone_output);
+                original_output->get()->merge_pending_relations(clone_output->get());
             }
         }
     }
@@ -344,7 +344,7 @@ struct pending_threaded_processor : public middle_t::pending_processor {
                 //done copying rels for now
                 clone_output->get()->commit();
                 //merge the expire tree from this threads copy of output back
-                original_output->get()->merge_expire_trees(*clone_output);
+                original_output->get()->merge_expire_trees(clone_output->get());
             }
         }
     }

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -28,8 +28,8 @@ output_multi_t::output_multi_t(const std::string &name,
                           m_options.hstore_mode, m_options.enable_hstore_index,
                           m_options.tblsmain_data, m_options.tblsmain_index)),
       ways_done_tracker(new id_tracker()),
-      m_expire(&m_options) {
-}
+      m_expire(&m_options)
+{}
 
 output_multi_t::output_multi_t(const output_multi_t& other):
     output_t(other.m_mid, other.m_options), m_tagtransform(new tagtransform(&m_options)), m_export_list(new export_list(*other.m_export_list)),
@@ -37,18 +37,17 @@ output_multi_t::output_multi_t(const output_multi_t& other):
     //NOTE: we need to know which ways were used by relations so each thread
     //must have a copy of the original marked done ways, its read only so its ok
     ways_done_tracker(other.ways_done_tracker),
-    m_expire(&m_options) {
-}
+    m_expire(&m_options)
+{}
 
 
-output_multi_t::~output_multi_t() {
-}
+output_multi_t::~output_multi_t() = default;
 
 std::shared_ptr<output_t> output_multi_t::clone(const middle_query_t* cloned_middle) const
 {
-    auto clone = std::make_shared<output_multi_t>(*this);
+    auto *clone = new output_multi_t(*this);
     clone->m_mid = cloned_middle;
-    return clone;
+    return std::shared_ptr<output_t>(clone);
 }
 
 int output_multi_t::start() {

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -7,6 +7,7 @@
 #ifndef OUTPUT_MULTI_HPP
 #define OUTPUT_MULTI_HPP
 
+#include "expire-tiles.hpp"
 #include "osmtypes.hpp"
 #include "output.hpp"
 #include "geometry-processor.hpp"
@@ -17,7 +18,6 @@
 
 class table_t;
 class tagtransform;
-struct expire_tiles;
 struct export_list;
 struct id_tracker;
 struct middle_query_t;
@@ -58,10 +58,8 @@ public:
 
     size_t pending_count() const;
 
-    void merge_pending_relations(std::shared_ptr<output_t> other);
-    void merge_expire_trees(std::shared_ptr<output_t> other);
-    virtual std::shared_ptr<id_tracker> get_pending_relations();
-    virtual std::shared_ptr<expire_tiles> get_expire_tree();
+    void merge_pending_relations(output_t *other);
+    void merge_expire_trees(output_t *other);
 
 protected:
 
@@ -79,7 +77,7 @@ protected:
     const OsmType m_osm_type;
     std::unique_ptr<table_t> m_table;
     std::shared_ptr<id_tracker> ways_pending_tracker, ways_done_tracker, rels_pending_tracker;
-    std::shared_ptr<expire_tiles> m_expire;
+    expire_tiles m_expire;
     way_helper m_way_helper;
     relation_helper m_relation_helper;
 };

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -8,6 +8,7 @@
 #define OUTPUT_MULTI_HPP
 
 #include "expire-tiles.hpp"
+#include "id-tracker.hpp"
 #include "osmtypes.hpp"
 #include "output.hpp"
 #include "geometry-processor.hpp"
@@ -19,7 +20,6 @@
 class table_t;
 class tagtransform;
 struct export_list;
-struct id_tracker;
 struct middle_query_t;
 struct options_t;
 
@@ -76,7 +76,8 @@ protected:
     std::shared_ptr<geometry_processor> m_processor;
     const OsmType m_osm_type;
     std::unique_ptr<table_t> m_table;
-    std::shared_ptr<id_tracker> ways_pending_tracker, ways_done_tracker, rels_pending_tracker;
+    id_tracker ways_pending_tracker, rels_pending_tracker;
+    std::shared_ptr<id_tracker> ways_done_tracker;
     expire_tiles m_expire;
     way_helper m_way_helper;
     relation_helper m_relation_helper;

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -53,10 +53,8 @@ public:
 
     size_t pending_count() const;
 
-    void merge_pending_relations(std::shared_ptr<output_t> other);
-    void merge_expire_trees(std::shared_ptr<output_t> other);
-    virtual std::shared_ptr<id_tracker> get_pending_relations();
-    virtual std::shared_ptr<expire_tiles> get_expire_tree();
+    void merge_pending_relations(output_t *other);
+    void merge_expire_trees(output_t *other);
 
 protected:
 
@@ -81,9 +79,9 @@ protected:
     std::unique_ptr<export_list> m_export_list;
 
     geometry_builder builder;
+    expire_tiles expire;
 
     std::shared_ptr<reprojection> reproj;
-    std::shared_ptr<expire_tiles> expire;
 
     std::shared_ptr<id_tracker> ways_pending_tracker, ways_done_tracker, rels_pending_tracker;
 };

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -83,7 +83,8 @@ protected:
 
     std::shared_ptr<reprojection> reproj;
 
-    std::shared_ptr<id_tracker> ways_pending_tracker, ways_done_tracker, rels_pending_tracker;
+    id_tracker ways_pending_tracker, rels_pending_tracker;
+    std::shared_ptr<id_tracker> ways_done_tracker;
 };
 
 #endif

--- a/output.cpp
+++ b/output.cpp
@@ -130,30 +130,23 @@ std::vector<std::shared_ptr<output_t> > output_t::create_outputs(const middle_qu
     return outputs;
 }
 
-output_t::output_t(const middle_query_t *mid_, const options_t &options_): m_mid(mid_), m_options(options_) {
+output_t::output_t(const middle_query_t *mid_, const options_t &options_)
+: m_mid(mid_), m_options(options_)
+{}
 
-}
+output_t::~output_t() = default;
 
-output_t::~output_t() {
-
-}
-
-size_t output_t::pending_count() const{
+size_t output_t::pending_count() const
+{
     return 0;
 }
 
-const options_t *output_t::get_options()const {
-	return &m_options;
+const options_t *output_t::get_options() const
+{
+    return &m_options;
 }
 
-void output_t::merge_pending_relations(std::shared_ptr<output_t> other) {
-}
-void output_t::merge_expire_trees(std::shared_ptr<output_t> other) {
-}
+void output_t::merge_pending_relations(output_t*) {}
 
-std::shared_ptr<id_tracker> output_t::get_pending_relations() {
-    return std::shared_ptr<id_tracker>();
-}
-std::shared_ptr<expire_tiles> output_t::get_expire_tree() {
-    return std::shared_ptr<expire_tiles>();
-}
+void output_t::merge_expire_trees(output_t*) {}
+

--- a/output.hpp
+++ b/output.hpp
@@ -65,10 +65,8 @@ public:
 
     const options_t *get_options() const;
 
-    virtual void merge_pending_relations(std::shared_ptr<output_t> other);
-    virtual void merge_expire_trees(std::shared_ptr<output_t> other);
-    virtual std::shared_ptr<id_tracker> get_pending_relations();
-    virtual std::shared_ptr<expire_tiles> get_expire_tree();
+    virtual void merge_pending_relations(output_t *other);
+    virtual void merge_expire_trees(output_t *other);
 
 protected:
 


### PR DESCRIPTION
This PR is essentially more cleanup. Not having a shared pointer also allows the compiler to optimize a bit more but in the grand schema of things the speedup is marginal.