### PR TITLE
pgsql_execPrepared: check for null pointers when printing error message

### DIFF
--- a/pgsql.cpp
+++ b/pgsql.cpp
@@ -127,7 +127,7 @@ PGresult *pgsql_execPrepared( PGconn *sql_conn, const char *stmtName, const int 
              message += "Arguments were: ";
             for(int i = 0; i < nParams; i++)
             {
-                message += paramValues[i];
+                message += paramValues[i]?paramValues[i]:"<NULL>";
                 message += ", ";
             }
         }


### PR DESCRIPTION
fixes #564