### PR TITLE
Remove entirely unused POI tag

### DIFF
--- a/default.style
+++ b/default.style
@@ -126,7 +126,6 @@ node,way   office       text         polygon
 node,way   oneway       text         linear
 node,way   operator     text         linear
 node,way   place        text         polygon
-node       poi          text         linear
 node,way   population   text         linear
 node,way   power        text         polygon
 node,way   power_source text         linear

--- a/style.lua
+++ b/style.lua
@@ -10,7 +10,7 @@ polygon_keys = { 'building', 'landuse', 'amenity', 'harbour', 'historic', 'leisu
 generic_keys = {'access','addr:housename','addr:housenumber','addr:interpolation','admin_level','aerialway','aeroway','amenity','area','barrier',
    'bicycle','brand','bridge','boundary','building','capital','construction','covered','culvert','cutting','denomination','disused','ele',
    'embarkment','foot','generation:source','harbour','highway','historic','hours','intermittent','junction','landuse','layer','leisure','lock',
-   'man_made','military','motor_car','name','natural','office','oneway','operator','place','poi','population','power','power_source','public_transport',
+   'man_made','military','motor_car','name','natural','office','oneway','operator','place','population','power','power_source','public_transport',
    'railway','ref','religion','route','service','shop','sport','surface','toll','tourism','tower:type', 'tracktype','tunnel','water','waterway',
    'wetland','width','wood','type'}
 


### PR DESCRIPTION
Removing a tag from default.style is backwards compatible for osm2pgsql, as the column will just no longer be updated.

There are only 41 nodes with this tag, and all seem to be tagging errors.