### PR TITLE
add command line option for EXPIRE_TILES_MAX_BBOX instead of hard coded value of 20000

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON
 
 ## Usage ##
 
-Osm2pgsql has one program, the executable itself, which has **43** command line
+Osm2pgsql has one program, the executable itself, which has **44** command line
 options.
 
 Before loading into a database, the database must be created and the PostGIS

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,6 @@
 # Command-line usage #
 
-Osm2pgsql has one program, the executable itself, which has **43** command line
+Osm2pgsql has one program, the executable itself, which has **44** command line
 options. A full list of options can be obtained with ``osm2pgsql -h -v``. This
 document provides an overview of options, and more importantly, why you might
 use them.

--- a/expire-tiles.cpp
+++ b/expire-tiles.cpp
@@ -23,7 +23,6 @@
 #define EARTH_CIRCUMFERENCE		40075016.68
 #define HALF_EARTH_CIRCUMFERENCE	(EARTH_CIRCUMFERENCE / 2)
 #define TILE_EXPIRY_LEEWAY		0.1		/* How many tiles worth of space to leave either side of a changed feature */
-#define EXPIRE_TILES_MAX_BBOX		20000		/* Maximum width or height of a bounding box (metres) */
 
 namespace {
 /*
@@ -388,8 +387,8 @@ int expire_tiles::from_bbox(double min_lon, double min_lat, double max_lon, doub
 		return ret;
 	}
 
-	if (width > EXPIRE_TILES_MAX_BBOX) return -1;
-	if (height > EXPIRE_TILES_MAX_BBOX) return -1;
+	if (width > Options->expire_tiles_max_bbox) return -1;
+	if (height > Options->expire_tiles_max_bbox) return -1;
 
 
 	/* Convert the box's Mercator coordinates into tile coordinates */

--- a/options.cpp
+++ b/options.cpp
@@ -16,7 +16,7 @@
 
 namespace
 {
-    const char * short_options = "ab:cd:KhlmMp:suvU:WH:P:i:IE:C:S:e:o:O:xkjGz:r:V";
+    const char * short_options = "ab:cd:KhlmMp:suvU:WH:P:i:IE:C:S:e:o:B:O:xkjGz:r:V";
     const struct option long_options[] =
     {
         {"append",   0, 0, 'a'},
@@ -43,6 +43,7 @@ namespace
         {"style",    1, 0, 'S'},
         {"expire-tiles", 1, 0, 'e'},
         {"expire-output", 1, 0, 'o'},
+        {"expire-bbox-size", 1, 0, 'B'},
         {"output",   1, 0, 'O'},
         {"extra-attributes", 0, 0, 'x'},
         {"hstore", 0, 0, 'k'},
@@ -168,6 +169,8 @@ namespace
     Expiry options:\n\
        -e|--expire-tiles [min_zoom-]max_zoom    Create a tile expiry list.\n\
        -o|--expire-output filename  Output filename for expired tiles list.\n\
+       -B|--expire-bbox-size Max size for a polygon to expire the whole polygon,\n\
+                             not just the boundary.\n\
     \n\
     Other options:\n\
        -b|--bbox        Apply a bounding box filter on the imported data\n\
@@ -262,7 +265,8 @@ std::string database_options_t::conninfo() const
 options_t::options_t():
     prefix("planet_osm"), scale(DEFAULT_SCALE), projection(reprojection::create_projection(PROJ_SPHERE_MERC)), append(false), slim(false),
     cache(800), tblsmain_index(boost::none), tblsslim_index(boost::none), tblsmain_data(boost::none), tblsslim_data(boost::none), style(OSM2PGSQL_DATADIR "/default.style"),
-    expire_tiles_zoom(-1), expire_tiles_zoom_min(-1), expire_tiles_filename("dirty_tiles"), hstore_mode(HSTORE_NONE), enable_hstore_index(false),
+    expire_tiles_zoom(-1), expire_tiles_zoom_min(-1), expire_tiles_max_bbox(20000), expire_tiles_filename("dirty_tiles"),
+    hstore_mode(HSTORE_NONE), enable_hstore_index(false),
     enable_multi(false), hstore_columns(), keep_coastlines(false), parallel_indexing(true),
     #ifdef __amd64__
     alloc_chunkwise(ALLOC_SPARSE | ALLOC_DENSE),
@@ -376,6 +380,9 @@ options_t::options_t(int argc, char *argv[]): options_t()
             break;
         case 'o':
             expire_tiles_filename = optarg;
+            break;
+        case 'B':
+            expire_tiles_max_bbox = atoi(optarg);
             break;
         case 'O':
             output_backend = optarg;

--- a/options.cpp
+++ b/options.cpp
@@ -43,7 +43,7 @@ namespace
         {"style",    1, 0, 'S'},
         {"expire-tiles", 1, 0, 'e'},
         {"expire-output", 1, 0, 'o'},
-        {"expire-bbox-size", 1, 0, 'B'},
+        {"expire-bbox-size", 1, 0, 214},
         {"output",   1, 0, 'O'},
         {"extra-attributes", 0, 0, 'x'},
         {"hstore", 0, 0, 'k'},
@@ -381,7 +381,7 @@ options_t::options_t(int argc, char *argv[]): options_t()
         case 'o':
             expire_tiles_filename = optarg;
             break;
-        case 'B':
+        case 214:
             expire_tiles_max_bbox = atoi(optarg);
             break;
         case 'O':

--- a/options.cpp
+++ b/options.cpp
@@ -169,7 +169,7 @@ namespace
     Expiry options:\n\
        -e|--expire-tiles [min_zoom-]max_zoom    Create a tile expiry list.\n\
        -o|--expire-output filename  Output filename for expired tiles list.\n\
-       -B|--expire-bbox-size Max size for a polygon to expire the whole polygon,\n\
+          --expire-bbox-size Max size for a polygon to expire the whole polygon,\n\
                              not just the boundary.\n\
     \n\
     Other options:\n\

--- a/options.hpp
+++ b/options.hpp
@@ -61,6 +61,7 @@ public:
     std::string style; ///< style file to use
     int expire_tiles_zoom; ///< Zoom level for tile expiry list
     int expire_tiles_zoom_min; ///< Minimum zoom level for tile expiry list
+    int expire_tiles_max_bbox; ///< Max bbox size in either dimension to expire full bbox for a polygon
     std::string expire_tiles_filename; ///< File name to output expired tiles list to
     int hstore_mode; ///< add an additional hstore column with objects key/value pairs, and what type of hstore column
     bool enable_hstore_index; ///< add an index on the hstore column


### PR DESCRIPTION
Default value is still 20000

new lines in --help --verbose output"
```
       -B|--expire-bbox-size Max size for a polygon to expire the whole polygon,
                             not just the boundary.
```