### PR TITLE
add flag to process new-style polygons only

### DIFF
--- a/options.cpp
+++ b/options.cpp
@@ -64,6 +64,7 @@ namespace
         {"exclude-invalid-polygon",0,0,210},
         {"tag-transform-script",1,0,212},
         {"reproject-area",0,0,213},
+        {"ignore-oldstyle-polygons", 0, 0, 215},
         {0, 0, 0, 0}
     };
 
@@ -206,6 +207,11 @@ namespace
                         because renderers usually have shape files for them.\n\
           --exclude-invalid-polygon   do not import polygons with invalid geometries.\n\
           --reproject-area   compute area column using spherical mercator coordinates.\n\
+          --ignore-oldstyle-polygons\n\
+                        Process all multipolygons as new-style-multipolygons:\n\
+                        tags for multipolygons are only taken from the relation\n\
+                        and way polygons are always processed separately, even\n\
+                        when they are part of a multipolygon with the same tags.\n\
        -h|--help        Help information.\n\
        -v|--verbose     Verbose output.\n");
         }
@@ -273,7 +279,9 @@ options_t::options_t():
     #else
     alloc_chunkwise(ALLOC_SPARSE),
     #endif
-    droptemp(false),  unlogged(false), hstore_match_only(false), flat_node_cache_enabled(false), excludepoly(false), reproject_area(false), flat_node_file(boost::none),
+    droptemp(false),  unlogged(false), hstore_match_only(false),
+    flat_node_cache_enabled(false), excludepoly(false), reproject_area(false),
+    ignore_oldstyle_polygons(false), flat_node_file(boost::none),
     tag_transform_script(boost::none), tag_transform_node_func(boost::none), tag_transform_way_func(boost::none),
     tag_transform_rel_func(boost::none), tag_transform_rel_mem_func(boost::none),
     create(false), long_usage_bool(false), pass_prompt(false),  output_backend("pgsql"), input_reader("auto"), bbox(boost::none),
@@ -457,6 +465,9 @@ options_t::options_t(int argc, char *argv[]): options_t()
             break;
         case 213:
             reproject_area = true;
+            break;
+        case 215:
+            ignore_oldstyle_polygons = true;
             break;
         case 'V':
             exit (EXIT_SUCCESS);

--- a/options.hpp
+++ b/options.hpp
@@ -77,6 +77,7 @@ public:
     bool flat_node_cache_enabled;
     bool excludepoly;
     bool reproject_area;
+    bool ignore_oldstyle_polygons;
     boost::optional<std::string> flat_node_file;
     /**
      * these options allow you to control the name of the

--- a/tagtransform.cpp
+++ b/tagtransform.cpp
@@ -100,8 +100,9 @@ void add_z_order(taglist_t &tags, int *roads)
     snprintf(z, sizeof(z), "%d", z_order);
     tags.push_back(tag_t("z_order", z));
 }
+} // anonymous namespace
 
-unsigned int c_filter_rel_member_tags(const taglist_t &rel_tags,
+unsigned int tagtransform::c_filter_rel_member_tags(const taglist_t &rel_tags,
         const multitaglist_t &member_tags, const rolelist_t &member_roles,
         int *member_superseeded, int *make_boundary, int *make_polygon, int *roads,
         const export_list &exlist, taglist_t &out_tags, bool allow_typeless)
@@ -231,6 +232,10 @@ unsigned int c_filter_rel_member_tags(const taglist_t &rel_tags,
         /* Copy the tags from the outer way(s) if the relation is untagged (with
          * respect to tags that influence its polygon nature. Tags like name or fixme should be fine*/
         if (poly_tags.empty()) {
+            if (options->ignore_oldstyle_polygons) {
+                // no polygon tags on relation, so not a newstyle multipolygon
+                return 1;
+            }
             int first_outerway = 1;
             for (size_t i = 0; i < member_tags.size(); i++) {
                 if (member_roles[i] && *(member_roles[i]) == "inner")
@@ -318,7 +323,6 @@ unsigned int c_filter_rel_member_tags(const taglist_t &rel_tags,
 
     return 0;
 }
-} // anonymous namespace
 
 #ifdef HAVE_LUA
 unsigned tagtransform::lua_filter_rel_member_tags(const taglist_t &rel_tags,

--- a/tagtransform.hpp
+++ b/tagtransform.hpp
@@ -44,6 +44,10 @@ private:
         const multitaglist_t &members_tags, const rolelist_t &member_roles,
         int *member_superseeded, int *make_boundary, int *make_polygon, int *roads,
         taglist_t &out_tags);
+    unsigned int c_filter_rel_member_tags(const taglist_t &rel_tags,
+        const multitaglist_t &member_tags, const rolelist_t &member_roles,
+        int *member_superseeded, int *make_boundary, int *make_polygon, int *roads,
+        const export_list &exlist, taglist_t &out_tags, bool allow_typeless);
     void check_lua_function_exists(const std::string &func_name);
 
 


### PR DESCRIPTION
With this flag set, the logic that checks for tags of outer
rings on multipolygons is disabled and such ways also cannot
be superseded and will always be rendered. Note that for
efficiency reasons we still process polygon ways in the
second stage where we can make use of multiple threads.

This is an experimental change for exploring the effects of old-style multipolygons in the OSM database. I haven't extensively tested yet if it does what it says.
