### PR TITLE
Process relations for line tables

### DIFF
--- a/processor-line.cpp
+++ b/processor-line.cpp
@@ -1,6 +1,6 @@
 #include "processor-line.hpp"
 
-processor_line::processor_line(int srid) : geometry_processor(srid, "LINESTRING", interest_way)
+processor_line::processor_line(int srid) : geometry_processor(srid, "LINESTRING", interest_way | interest_relation )
 {
 }
 
@@ -11,4 +11,9 @@ processor_line::~processor_line()
 geometry_builder::pg_geom_t processor_line::process_way(const nodelist_t &nodes)
 {
     return builder.get_wkb_simple(nodes, false);
+}
+
+geometry_builder::pg_geoms_t processor_line::process_relation(const multinodelist_t &nodes)
+{
+    return builder.build_both(nodes, false, false, 1000000);
 }

--- a/processor-line.hpp
+++ b/processor-line.hpp
@@ -8,6 +8,7 @@ struct processor_line : public geometry_processor {
     virtual ~processor_line();
 
     geometry_builder::pg_geom_t process_way(const nodelist_t &nodes);
+    geometry_builder::pg_geoms_t process_relation(const multinodelist_t &nodes);
 
 private:
     geometry_builder builder;


### PR DESCRIPTION
A line table needs to be "interested" in relations to handle route relations, admin as lines, and potentially other relations.

Fixes #593, although by a slightly different route