### PR TITLE
Guard against segfaults on expiry of empty diff

### DIFF
--- a/expire-tiles.cpp
+++ b/expire-tiles.cpp
@@ -157,6 +157,9 @@ int tile::merge(tile *other)
 
 void expire_tiles::output_and_destroy(tile_output *output)
 {
+    if (!dirty)
+        return;
+
     dirty->output_and_destroy(output, 0, 0, 0);
     dirty.reset();
 }


### PR DESCRIPTION
When applying an empty diff, the dirty pointer was empty and would segfault when trying to output_and_destroy.