### PR TITLE
Add link to readme to find OSM data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # osm2pgsql #
 
-osm2pgsql is a tool for loading OpenStreetMap data into a PostgreSQL / PostGIS
+osm2pgsql is a tool for loading [OpenStreetMap data](http://planet.openstreetmap.org/) into a PostgreSQL / PostGIS
 database suitable for applications like rendering into a map, geocoding with
 Nominatim, or general analysis.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # osm2pgsql #
 
-osm2pgsql is a tool for loading [OpenStreetMap data](http://planet.openstreetmap.org/) into a PostgreSQL / PostGIS
+osm2pgsql is a tool for loading OpenStreetMap data into a PostgreSQL / PostGIS
 database suitable for applications like rendering into a map, geocoding with
 Nominatim, or general analysis.
 
@@ -142,6 +142,8 @@ osm2pgsql -c -d gis --slim -C <cache size> \
 where
 * ``<cache size>`` is about 75% of memory in MiB, to a maximum of about 30000. Additional RAM will not be used.
 * ``<flat nodes>`` is a location where a 24GiB file can be saved.
+
+Many different data files (e.g., .pbf) can be found at [planet.osm.org](http://planet.osm.org/).
 
 The databases from either of these commands can be used immediately by
 [Mapnik](http://mapnik.org/) for rendering maps with standard tools like


### PR DESCRIPTION
As a newbie, I went looking for the OSM data to load. This seems to be canonical place. I could be wrong. I _think_ a link would be helpful.