### PR TITLE
Schema support

### DIFF
--- a/docs/osm2pgsql.1
+++ b/docs/osm2pgsql.1
@@ -83,6 +83,7 @@ Use projection EPSG:num
 .TP
 \fB\-p\fR|\-\-prefix prefix_string
 Prefix for table names (default: planet_osm).
+The prefix may also contain a schema like in "geodata.osm".
 .TP
 \fB\-r\fR|\-\-input\-reader format
 Select format of the input file. Available choices are \fBauto\fR

--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -1203,7 +1203,7 @@ middle_pgsql_t::middle_pgsql_t()
             /*copy*/ "COPY %p_ways FROM STDIN;\n",
          /*analyze*/ "ANALYZE %p_ways;\n",
             /*stop*/  "COMMIT;\n",
-   /*array_indexes*/ "CREATE INDEX %p_ways_nodes ON %p_ways USING gin (nodes) WITH (FASTUPDATE=OFF) {TABLESPACE %i};\n"
+   /*array_indexes*/ "CREATE INDEX %P_ways_nodes ON %p_ways USING gin (nodes) WITH (FASTUPDATE=OFF) {TABLESPACE %i};\n"
                          ));
     tables.push_back(table_desc(
         /*table = t_rel,*/
@@ -1223,7 +1223,7 @@ middle_pgsql_t::middle_pgsql_t()
             /*copy*/ "COPY %p_rels FROM STDIN;\n",
          /*analyze*/ "ANALYZE %p_rels;\n",
             /*stop*/  "COMMIT;\n",
-   /*array_indexes*/ "CREATE INDEX %p_rels_parts ON %p_rels USING gin (parts) WITH (FASTUPDATE=OFF) {TABLESPACE %i};\n"
+   /*array_indexes*/ "CREATE INDEX %P_rels_parts ON %p_rels USING gin (parts) WITH (FASTUPDATE=OFF) {TABLESPACE %i};\n"
                          ));
 
     // set up the rest of the variables from the tables.

--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -905,13 +905,14 @@ void middle_pgsql_t::end(void)
  *
  * The input string is mangled as follows:
  * %p replaced by the content of the "prefix" option
+ * %P replaced by the content of the table part of the "prefix" option
  * %i replaced by the content of the "tblsslim_data" option
  * %t replaced by the content of the "tblssslim_index" option
  * %m replaced by "UNLOGGED" if the "unlogged" option is set
  * other occurrences of the "%" char are treated normally.
  * any occurrence of { or } will be ignored (not copied to output string);
  * anything inside {} is only copied if it contained at least one of
- * %p, %i, %t, %m that was not NULL.
+ * %p, %P, %i, %t, %m that was not NULL.
  *
  * So, the input string
  *    Hello{ dear %i}!
@@ -951,6 +952,14 @@ static void set_prefix_and_tbls(const struct options_t *options, const char **st
                 if (!options->prefix.empty()) {
                     strcpy(dest, options->prefix.c_str());
                     dest += strlen(options->prefix.c_str());
+                    copied = 1;
+                }
+                source+=2;
+                continue;
+            } else if (*(source+1) == 'P') {
+                if (!options->prefix.empty()) {
+                    strcpy(dest, options->prefix_table.c_str());
+                    dest += strlen(options->prefix_table.c_str());
                     copied = 1;
                 }
                 source+=2;

--- a/options.cpp
+++ b/options.cpp
@@ -500,6 +500,17 @@ options_t::options_t(int argc, char *argv[]): options_t()
     //NOTE: this is hugely important if you set it inappropriately and are are caching nodes
     //you could get overflow when working with larger coordinates (mercator) and larger scales
     scale = (projection->target_latlon()) ? 10000000 : 100;
+
+    // handle schema in prefix
+    size_t offset;
+    offset = prefix.find(".");
+    if (offset == std::string::npos) {
+        prefix_schema = ""; // we don't assume any schema
+        prefix_table = prefix;
+    } else {
+        prefix_schema = prefix.substr(0, offset);;
+        prefix_table = prefix.substr(offset+1);
+    }
 }
 
 void options_t::check_options()

--- a/options.cpp
+++ b/options.cpp
@@ -177,6 +177,7 @@ namespace
                         Must be specified as: minlon,minlat,maxlon,maxlat\n\
                         e.g. --bbox -0.5,51.25,0.5,51.75\n\
        -p|--prefix      Prefix for table names (default planet_osm)\n\
+                        The prefix may also contain a schema like in \"geodata.osm\".\n\
        -r|--input-reader    Input format.\n\
                         auto      - Detect file format. (default)\n\
                         o5m       - Parse as o5m format.\n\

--- a/options.hpp
+++ b/options.hpp
@@ -49,6 +49,8 @@ public:
     virtual ~options_t();
 
     std::string prefix; ///< prefix for table names
+    std::string prefix_schema; ///< prefix for table names (schema part)
+    std::string prefix_table; ///< prefix for table names (table part)
     int scale; ///< scale for converting coordinates to fixed point
     std::shared_ptr<reprojection> projection; ///< SRS of projection
     bool append; ///< Append to existing data

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -21,7 +21,7 @@ output_multi_t::output_multi_t(const std::string &name,
       m_processor(processor_),
       //TODO: we could in fact have something that is interested in nodes and ways..
       m_osm_type(m_processor->interests(geometry_processor::interest_node) ? OSMTYPE_NODE : OSMTYPE_WAY),
-      m_table(new table_t(m_options.database_options.conninfo(), name, m_processor->column_type(),
+      m_table(new table_t(m_options.database_options.conninfo(), m_options.prefix_schema, name, m_processor->column_type(),
                           m_export_list->normal_columns(m_osm_type),
                           m_options.hstore_columns, m_processor->srid(),
                           m_options.append, m_options.slim, m_options.droptemp,

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -647,8 +647,8 @@ output_pgsql_t::output_pgsql_t(const middle_query_t* mid, const options_t &o)
         //have a different tablespace/hstores/etc per table
         m_tables.push_back(std::shared_ptr<table_t>(
             new table_t(
-                m_options.database_options.conninfo(), name, type, columns, m_options.hstore_columns,
-                reproj->target_srs(),
+                m_options.database_options.conninfo(), m_options.prefix_schema, name, type, columns,
+                m_options.hstore_columns, reproj->target_srs(),
                 m_options.append, m_options.slim, m_options.droptemp, m_options.hstore_mode,
                 m_options.enable_hstore_index, m_options.tblsmain_data, m_options.tblsmain_index
             )

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -617,24 +617,24 @@ output_pgsql_t::output_pgsql_t(const middle_query_t* mid, const options_t &o)
         columns_t columns = m_export_list->normal_columns((i == t_point)?OSMTYPE_NODE:OSMTYPE_WAY);
 
         //figure out what name we are using for this and what type
-        std::string name = m_options.prefix;
+        std::string table_name = m_options.prefix_table;
         std::string type;
         switch(i)
         {
             case t_point:
-                name += "_point";
+                table_name += "_point";
                 type = "POINT";
                 break;
             case t_line:
-                name += "_line";
+                table_name += "_line";
                 type = "LINESTRING";
                 break;
             case t_poly:
-                name += "_polygon";
+                table_name += "_polygon";
                 type = "GEOMETRY"; // Actually POLGYON & MULTIPOLYGON but no way to limit to just these two
                 break;
             case t_roads:
-                name += "_roads";
+                table_name += "_roads";
                 type = "LINESTRING";
                 break;
             default:
@@ -647,7 +647,7 @@ output_pgsql_t::output_pgsql_t(const middle_query_t* mid, const options_t &o)
         //have a different tablespace/hstores/etc per table
         m_tables.push_back(std::shared_ptr<table_t>(
             new table_t(
-                m_options.database_options.conninfo(), m_options.prefix_schema, name, type, columns,
+                m_options.database_options.conninfo(), m_options.prefix_schema, table_name, type, columns,
                 m_options.hstore_columns, reproj->target_srs(),
                 m_options.append, m_options.slim, m_options.droptemp, m_options.hstore_mode,
                 m_options.enable_hstore_index, m_options.tblsmain_data, m_options.tblsmain_index

--- a/table.cpp
+++ b/table.cpp
@@ -35,7 +35,12 @@ table_t::table_t(const string& conninfo, const string& schema_name, const string
     single_fmt = fmt("%1%");
     point_fmt = fmt("POINT(%.15g %.15g)");
     del_fmt = fmt("DELETE FROM %1% WHERE osm_id = %2%");
-    name = table_name;
+
+    if (schema_name.empty()) {
+	    name = table_name;
+    } else {
+	    name = (fmt("%s.%s") % schema_name % table_name).str();
+    }
 }
 
 table_t::table_t(const table_t& other):

--- a/table.cpp
+++ b/table.cpp
@@ -226,7 +226,7 @@ void table_t::stop()
 
         pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE TABLE %1%_tmp %2% AS SELECT * FROM %1% ORDER BY ST_GeoHash(ST_Transform(ST_Envelope(way),4326),10) COLLATE \"C\"") % name % (table_space ? "TABLESPACE " + table_space.get() : "")).str());
         pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("DROP TABLE %1%") % name).str());
-        pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("ALTER TABLE %1%_tmp RENAME TO %1%") % name).str());
+        pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("ALTER TABLE %1%_tmp RENAME TO %2%") % name % table_name).str());
         fprintf(stderr, "Copying %s to cluster by geometry finished\n", name.c_str());
         fprintf(stderr, "Creating geometry index on %s\n", name.c_str());
 

--- a/table.cpp
+++ b/table.cpp
@@ -159,7 +159,7 @@ void table_t::start()
 
         //slim mode needs this to be able to delete from tables in pending
         if (slim && !drop_temp) {
-            sql = (fmt("CREATE INDEX %1%_pkey ON %1% USING BTREE (osm_id)") % name).str();
+            sql = (fmt("CREATE INDEX %1%_pkey ON %2% USING BTREE (osm_id)") % table_name % name).str();
             if (table_space_index)
                 sql += " TABLESPACE " + table_space_index.get();
             pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, sql);
@@ -231,7 +231,7 @@ void table_t::stop()
         fprintf(stderr, "Creating geometry index on %s\n", name.c_str());
 
         // Use fillfactor 100 for un-updatable imports
-        pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE INDEX %1%_index ON %1% USING GIST (way) %2% %3%") % name %
+        pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE INDEX %1%_index ON %2% USING GIST (way) %3% %4%") % table_name % name %
             (slim && !drop_temp ? "" : "WITH (FILLFACTOR=100)") %
             (table_space_index ? "TABLESPACE " + table_space_index.get() : "")).str());
 
@@ -239,18 +239,18 @@ void table_t::stop()
         if (slim && !drop_temp)
         {
             fprintf(stderr, "Creating osm_id index on %s\n", name.c_str());
-            pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE INDEX %1%_pkey ON %1% USING BTREE (osm_id) %2%") % name %
+            pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE INDEX %1%_pkey ON %2% USING BTREE (osm_id) %3%") % table_name % name %
                 (table_space_index ? "TABLESPACE " + table_space_index.get() : "")).str());
         }
         /* Create hstore index if selected */
         if (enable_hstore_index) {
             fprintf(stderr, "Creating hstore indexes on %s\n", name.c_str());
             if (hstore_mode != HSTORE_NONE) {
-                pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE INDEX %1%_tags_index ON %1% USING GIN (tags) %2%") % name %
+                pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE INDEX %1%_tags_index ON %2% USING GIN (tags) %3%") % table_name % name %
                     (table_space_index ? "TABLESPACE " + table_space_index.get() : "")).str());
             }
             for(size_t i = 0; i < hstore_columns.size(); ++i) {
-                pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE INDEX %1%_hstore_%2%_index ON %1% USING GIN (\"%3%\") %4%") % name % i % hstore_columns[i] %
+                pgsql_exec_simple(sql_conn, PGRES_COMMAND_OK, (fmt("CREATE INDEX %1%_hstore_%2%_index ON %3% USING GIN (\"%4%\") %5%") % table_name % i % name % hstore_columns[i] %
                     (table_space_index ? "TABLESPACE " + table_space_index.get() : "")).str());
             }
         }

--- a/table.cpp
+++ b/table.cpp
@@ -15,10 +15,12 @@ typedef boost::format fmt;
 #define BUFFER_SEND_SIZE 1024
 
 
-table_t::table_t(const string& conninfo, const string& name, const string& type, const columns_t& columns, const hstores_t& hstore_columns,
+table_t::table_t(const string& conninfo, const string& schema_name, const string& table_name,
+    const string& type, const columns_t& columns, const hstores_t& hstore_columns,
     const int srid, const bool append, const bool slim, const bool drop_temp, const int hstore_mode,
     const bool enable_hstore_index, const boost::optional<string>& table_space, const boost::optional<string>& table_space_index) :
-    conninfo(conninfo), name(name), type(type), sql_conn(nullptr), copyMode(false), srid((fmt("%1%") % srid).str()),
+    conninfo(conninfo), schema_name(schema_name), table_name(table_name), type(type),
+    sql_conn(nullptr), copyMode(false), srid((fmt("%1%") % srid).str()),
     append(append), slim(slim), drop_temp(drop_temp), hstore_mode(hstore_mode), enable_hstore_index(enable_hstore_index),
     columns(columns), hstore_columns(hstore_columns), table_space(table_space), table_space_index(table_space_index)
 {
@@ -33,10 +35,12 @@ table_t::table_t(const string& conninfo, const string& name, const string& type,
     single_fmt = fmt("%1%");
     point_fmt = fmt("POINT(%.15g %.15g)");
     del_fmt = fmt("DELETE FROM %1% WHERE osm_id = %2%");
+    name = table_name;
 }
 
 table_t::table_t(const table_t& other):
-    conninfo(other.conninfo), name(other.name), type(other.type), sql_conn(nullptr), copyMode(false), buffer(), srid(other.srid),
+    conninfo(other.conninfo), name(other.name), schema_name(other.schema_name), table_name(other.table_name),
+    type(other.type), sql_conn(nullptr), copyMode(false), buffer(), srid(other.srid),
     append(other.append), slim(other.slim), drop_temp(other.drop_temp), hstore_mode(other.hstore_mode), enable_hstore_index(other.enable_hstore_index),
     columns(other.columns), hstore_columns(other.hstore_columns), copystr(other.copystr), table_space(other.table_space),
     table_space_index(other.table_space_index), single_fmt(other.single_fmt), point_fmt(other.point_fmt), del_fmt(other.del_fmt)

--- a/table.hpp
+++ b/table.hpp
@@ -19,7 +19,8 @@ typedef std::vector<std::pair<std::string, std::string> > columns_t;
 class table_t
 {
     public:
-        table_t(const std::string& conninfo, const std::string& name, const std::string& type, const columns_t& columns, const hstores_t& hstore_columns, const int srid,
+        table_t(const std::string& conninfo, const std::string& schema_name, const std::string& table_name,
+                const std::string& type, const columns_t& columns, const hstores_t& hstore_columns, const int srid,
                 const bool append, const bool slim, const bool droptemp, const int hstore_mode, const bool enable_hstore_index,
                 const boost::optional<std::string>& table_space, const boost::optional<std::string>& table_space_index);
         table_t(const table_t& other);
@@ -92,6 +93,8 @@ class table_t
 
         std::string conninfo;
         std::string name;
+        std::string schema_name;
+        std::string table_name;
         std::string type;
         pg_conn *sql_conn;
         bool copyMode;


### PR DESCRIPTION
This series adds schema support to the prefix option eg. "gisdata.osm_". Default behavior is
preserved thus placing the tables in in the default public schema.
