### PR TITLE
allow more numeric datatypes for table columns in C tagtransform

### DIFF
--- a/table.hpp
+++ b/table.hpp
@@ -3,6 +3,7 @@
 
 #include "pgsql.hpp"
 #include "osmtypes.hpp"
+#include "taginfo.hpp"
 
 #include <cstddef>
 #include <string>
@@ -14,7 +15,6 @@
 #include <boost/format.hpp>
 
 typedef std::vector<std::string> hstores_t;
-typedef std::vector<std::pair<std::string, std::string> > columns_t;
 
 class table_t
 {
@@ -88,7 +88,7 @@ class table_t
         void write_hstore_columns(const taglist_t &tags, std::string& values);
 
         void escape4hstore(const char *src, std::string& dst);
-        void escape_type(const std::string &value, const std::string &type, std::string& dst);
+        void escape_type(const std::string &value, ColumnType flags, std::string& dst);
 
         std::string conninfo;
         std::string name;

--- a/taginfo.hpp
+++ b/taginfo.hpp
@@ -1,6 +1,27 @@
 #ifndef TAGINFO_HPP
 #define TAGINFO_HPP
 
+#include <string>
+#include <vector>
+
+enum ColumnType {
+    COLUMN_TYPE_INT,
+    COLUMN_TYPE_REAL,
+    COLUMN_TYPE_TEXT
+};
+
+struct Column
+{
+    Column(std::string const &n, std::string const &tn, ColumnType t)
+        : name(n), type_name(tn), type(t) {}
+
+    std::string name;
+    std::string type_name;
+    ColumnType type;
+};
+
+typedef std::vector<Column> columns_t;
+
 /* Table columns, representing key= tags */
 struct taginfo;
 

--- a/taginfo_impl.hpp
+++ b/taginfo_impl.hpp
@@ -13,15 +13,27 @@ enum column_flags {
   FLAG_NOCACHE = 4,   /* Optimisation: don't bother remembering this one */
   FLAG_DELETE = 8,    /* These tags should be simply deleted on sight */
   FLAG_NOCOLUMN = 16, /* objects without column but should be listed in database hstore column */
-  FLAG_PHSTORE = 17   /* same as FLAG_NOCOLUMN & FLAG_POLYGON to maintain compatibility */
+  FLAG_PHSTORE = 17,  /* same as FLAG_NOCOLUMN & FLAG_POLYGON to maintain compatibility */
+  FLAG_INT_TYPE = 32, /* column value should be converted to integer */
+  FLAG_REAL_TYPE = 64 /* column value should be converted to double */
 };
 
 struct taginfo {
     taginfo();
     taginfo(const taginfo &);
 
+    ColumnType column_type() const {
+        if (flags & FLAG_INT_TYPE) {
+            return COLUMN_TYPE_INT;
+        }
+        if (flags & FLAG_REAL_TYPE) {
+            return COLUMN_TYPE_REAL;
+        }
+        return COLUMN_TYPE_TEXT;
+    }
+
     std::string name, type;
-    int flags;
+    unsigned flags;
 };
 
 struct export_list {
@@ -31,7 +43,7 @@ struct export_list {
     std::vector<taginfo> &get(enum OsmType id);
     const std::vector<taginfo> &get(enum OsmType id) const;
 
-    std::vector<std::pair<std::string, std::string> > normal_columns(enum OsmType id) const;
+    columns_t normal_columns(OsmType id) const;
 
     int num_tables;
     std::vector<std::vector<taginfo> > exportList; /* Indexed by enum OsmType */


### PR DESCRIPTION
Scans the style file for additional int and real data types
and mappes them all to the existing int and real conversion
routines.

Fixes #621.
