### PR TITLE
Use a global buffer for middle-pgsql

### DIFF
--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -87,7 +87,7 @@ private:
      * Sets up sql_conn for the table
      */
     void connect(table_desc& table);
-    void local_nodes_set(const osmid_t& id, const double& lat, const double& lon, const taglist_t &tags);
+    void local_nodes_set(osmid_t id, double lat, double lon, const taglist_t &tags);
     size_t local_nodes_get_list(nodelist_t &out, const idlist_t nds) const;
     void local_nodes_delete(osmid_t osm_id);
 
@@ -103,7 +103,14 @@ private:
 
     std::shared_ptr<id_tracker> ways_pending_tracker, rels_pending_tracker;
 
+    void buffer_store_nodes(idlist_t const &nodes);
+    void buffer_store_string(std::string const &in, bool escape);
+    void buffer_store_tags(taglist_t const &tags, bool escape);
+
+    void buffer_correct_params(char const **param, size_t size);
+
     bool build_indexes;
+    std::string copy_buffer;
 };
 
 #endif

--- a/pgsql.cpp
+++ b/pgsql.cpp
@@ -92,12 +92,12 @@ int pgsql_exec(PGconn *sql_conn, const ExecStatusType expect, const char *fmt, .
     return 0;
 }
 
-void pgsql_CopyData(const char *context, PGconn *sql_conn, const char *sql, int len)
+void pgsql_CopyData(const char *context, PGconn *sql_conn, std::string const &sql)
 {
 #ifdef DEBUG_PGSQL
-    fprintf(stderr, "%s>>> %s\n", context, sql );
+    fprintf(stderr, "%s>>> %s\n", context, sql.c_str());
 #endif
-    int r = PQputCopyData(sql_conn, sql, len);
+    int r = PQputCopyData(sql_conn, sql.c_str(), sql.size());
     switch(r)
     {
         //need to wait for write ready

--- a/pgsql.hpp
+++ b/pgsql.hpp
@@ -12,7 +12,7 @@
 #include <memory>
 
 PGresult *pgsql_execPrepared( PGconn *sql_conn, const char *stmtName, const int nParams, const char *const * paramValues, const ExecStatusType expect);
-void pgsql_CopyData(const char *context, PGconn *sql_conn, const char *sql, int len);
+void pgsql_CopyData(const char *context, PGconn *sql_conn, std::string const &sql);
 std::shared_ptr<PGresult> pgsql_exec_simple(PGconn *sql_conn, const ExecStatusType expect, const std::string& sql);
 std::shared_ptr<PGresult> pgsql_exec_simple(PGconn *sql_conn, const ExecStatusType expect, const char *sql);
 int pgsql_exec(PGconn *sql_conn, const ExecStatusType expect, const char *fmt, ...)
@@ -22,13 +22,4 @@ int pgsql_exec(PGconn *sql_conn, const ExecStatusType expect, const char *fmt, .
 ;
 
 void escape(const std::string &src, std::string& dst);
-
-
-inline void pgsql_CopyData(const char *context, PGconn *sql_conn, const char *sql) {
-    pgsql_CopyData(context, sql_conn, sql, (int) strlen(sql));
-}
-
-inline void pgsql_CopyData(const char *context, PGconn *sql_conn, const std::string &sql) {
-    pgsql_CopyData(context, sql_conn, sql.c_str(), (int) sql.length());
-}
 #endif


### PR DESCRIPTION
Replaces the different static and malloc'd buffers for psql input with one global buffer. The same buffer is now used for copy mode and insert mode. We just track the beginning of each item for insert mode in the paramValues array.

This is more for cleanup, the gain in processing time is minimal.