### PR TITLE
Geos36

### DIFF
--- a/geometry-builder.cpp
+++ b/geometry-builder.cpp
@@ -558,7 +558,8 @@ geometry_builder::pg_geoms_t geometry_builder::build_both(const multinodelist_t 
     try
     {
         // geos36 - auto-allocation no longer supported in GEOS 3.6+
-	GeometryFactory *gf = GeometryFactory::getDefaultInstance();
+	GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
+	GeometryFactory& gf = *gf_p;
 	
         geom_ptr mline = create_multi_line(gf, xnodes);
         //geom_ptr noded (segment->Union(mline.get()));

--- a/geometry-builder.cpp
+++ b/geometry-builder.cpp
@@ -557,7 +557,9 @@ geometry_builder::pg_geoms_t geometry_builder::build_both(const multinodelist_t 
 
     try
     {
-        GeometryFactory gf;
+        // geos36 - auto-allocation no longer supported in GEOS 3.6+
+	GeometryFactory &gf = *GeometryFactory::getDefaultInstance();
+	
         geom_ptr mline = create_multi_line(gf, xnodes);
         //geom_ptr noded (segment->Union(mline.get()));
         LineMerger merger;

--- a/geometry-builder.cpp
+++ b/geometry-builder.cpp
@@ -228,8 +228,8 @@ geometry_builder::pg_geom_t geometry_builder::get_wkb_simple(const nodelist_t &n
     try
     {
         // geos36 - auto-allocation no longer supported in GEOS 3.6+
-	const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
-	const GeometryFactory& gf = *gf_p;
+        const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
+        const GeometryFactory& gf = *gf_p;
 
         auto coords = nodes2coords(gf, nodes);
         if (polygon && is_polygon_line(coords.get())) {
@@ -267,8 +267,8 @@ geometry_builder::pg_geoms_t geometry_builder::get_wkb_split(const nodelist_t &n
     try
     {
         // geos36 - auto-allocation no longer supported in GEOS 3.6+
-	const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
-	const GeometryFactory& gf = *gf_p;
+        const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
+        const GeometryFactory& gf = *gf_p;
 
         auto coords = nodes2coords(gf, nodes);
 
@@ -405,8 +405,8 @@ geometry_builder::pg_geoms_t geometry_builder::build_polygons(const multinodelis
     try
     {
         // geos36 - auto-allocation no longer supported in GEOS 3.6+
-	const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
-	const GeometryFactory& gf = *gf_p;
+        const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
+        const GeometryFactory& gf = *gf_p;
 
         geom_ptr mline = create_multi_line(gf, xnodes);
 
@@ -546,8 +546,8 @@ geometry_builder::pg_geom_t geometry_builder::build_multilines(const multinodeli
     try
     {
         // geos36 - auto-allocation no longer supported in GEOS 3.6+
-	const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
-	const GeometryFactory& gf = *gf_p;
+        const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
+        const GeometryFactory& gf = *gf_p;
 
         geom_ptr mline = create_multi_line(gf, xnodes);
 
@@ -573,9 +573,9 @@ geometry_builder::pg_geoms_t geometry_builder::build_both(const multinodelist_t 
     try
     {
         // geos36 - auto-allocation no longer supported in GEOS 3.6+
-	const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
-	const GeometryFactory& gf = *gf_p;
-	
+        const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
+        const GeometryFactory& gf = *gf_p;
+
         geom_ptr mline = create_multi_line(gf, xnodes);
         //geom_ptr noded (segment->Union(mline.get()));
         LineMerger merger;

--- a/geometry-builder.cpp
+++ b/geometry-builder.cpp
@@ -558,7 +558,7 @@ geometry_builder::pg_geoms_t geometry_builder::build_both(const multinodelist_t 
     try
     {
         // geos36 - auto-allocation no longer supported in GEOS 3.6+
-	GeometryFactory &gf = *GeometryFactory::getDefaultInstance();
+	GeometryFactory *gf = GeometryFactory::getDefaultInstance();
 	
         geom_ptr mline = create_multi_line(gf, xnodes);
         //geom_ptr noded (segment->Union(mline.get()));

--- a/geometry-builder.cpp
+++ b/geometry-builder.cpp
@@ -559,7 +559,7 @@ geometry_builder::pg_geoms_t geometry_builder::build_both(const multinodelist_t 
     {
         // geos36 - auto-allocation no longer supported in GEOS 3.6+
 	GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
-	GeometryFactory& gf = *gf_p;
+	const GeometryFactory& gf = *gf_p;
 	
         geom_ptr mline = create_multi_line(gf, xnodes);
         //geom_ptr noded (segment->Union(mline.get()));

--- a/geometry-builder.cpp
+++ b/geometry-builder.cpp
@@ -558,8 +558,8 @@ geometry_builder::pg_geoms_t geometry_builder::build_both(const multinodelist_t 
     try
     {
         // geos36 - auto-allocation no longer supported in GEOS 3.6+
-	GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
-	const GeometryFactory& gf = *gf_p;
+	const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
+	GeometryFactory& gf = *gf_p;
 	
         geom_ptr mline = create_multi_line(gf, xnodes);
         //geom_ptr noded (segment->Union(mline.get()));

--- a/geometry-builder.cpp
+++ b/geometry-builder.cpp
@@ -74,7 +74,7 @@ void coords2nodes(CoordinateSequence * coords, nodelist_t &nodes)
     }
 }
 
-coord_ptr nodes2coords(GeometryFactory &gf, const nodelist_t &nodes)
+coord_ptr nodes2coords(const GeometryFactory &gf, const nodelist_t &nodes)
 {
     coord_ptr coords(gf.getCoordinateSequenceFactory()->create(size_t(0), size_t(2)));
 
@@ -85,7 +85,7 @@ coord_ptr nodes2coords(GeometryFactory &gf, const nodelist_t &nodes)
     return coords;
 }
 
-geom_ptr create_multi_line(GeometryFactory &gf, const multinodelist_t &xnodes)
+geom_ptr create_multi_line(const GeometryFactory &gf, const multinodelist_t &xnodes)
 {
     // XXX leaks memory if an exception is thrown
     std::unique_ptr<std::vector<Geometry*> > lines(new std::vector<Geometry*>);
@@ -202,7 +202,7 @@ void geometry_builder::pg_geom_t::set(const geos::geom::Geometry *g, bool poly,
     }
 }
 
-geom_ptr geometry_builder::create_simple_poly(GeometryFactory &gf,
+geom_ptr geometry_builder::create_simple_poly(const GeometryFactory &gf,
                                               std::unique_ptr<CoordinateSequence> coords) const
 {
     std::unique_ptr<LinearRing> shell(gf.createLinearRing(coords.release()));
@@ -227,7 +227,10 @@ geometry_builder::pg_geom_t geometry_builder::get_wkb_simple(const nodelist_t &n
 
     try
     {
-        GeometryFactory gf;
+        // geos36 - auto-allocation no longer supported in GEOS 3.6+
+	const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
+	const GeometryFactory& gf = *gf_p;
+
         auto coords = nodes2coords(gf, nodes);
         if (polygon && is_polygon_line(coords.get())) {
             auto geom = create_simple_poly(gf, std::move(coords));
@@ -263,7 +266,10 @@ geometry_builder::pg_geoms_t geometry_builder::get_wkb_split(const nodelist_t &n
 
     try
     {
-        GeometryFactory gf;
+        // geos36 - auto-allocation no longer supported in GEOS 3.6+
+	const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
+	const GeometryFactory& gf = *gf_p;
+
         auto coords = nodes2coords(gf, nodes);
 
         if (polygon && is_polygon_line(coords.get())) {
@@ -340,7 +346,10 @@ geometry_builder::pg_geoms_t geometry_builder::get_wkb_split(const nodelist_t &n
 }
 
 int geometry_builder::parse_wkb(const char* wkb, multinodelist_t &nodes, bool *polygon) {
-    GeometryFactory gf;
+    // geos36 - auto-allocation no longer supported in GEOS 3.6+
+    const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
+    const GeometryFactory& gf = *gf_p;
+
     geos::io::WKBReader reader(gf);
 
     *polygon = false;
@@ -395,7 +404,10 @@ geometry_builder::pg_geoms_t geometry_builder::build_polygons(const multinodelis
 
     try
     {
-        GeometryFactory gf;
+        // geos36 - auto-allocation no longer supported in GEOS 3.6+
+	const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
+	const GeometryFactory& gf = *gf_p;
+
         geom_ptr mline = create_multi_line(gf, xnodes);
 
         //geom_ptr noded (segment->Union(mline.get()));
@@ -533,7 +545,10 @@ geometry_builder::pg_geom_t geometry_builder::build_multilines(const multinodeli
 
     try
     {
-        GeometryFactory gf;
+        // geos36 - auto-allocation no longer supported in GEOS 3.6+
+	const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
+	const GeometryFactory& gf = *gf_p;
+
         geom_ptr mline = create_multi_line(gf, xnodes);
 
         wkb.set(mline.get(), false);
@@ -559,7 +574,7 @@ geometry_builder::pg_geoms_t geometry_builder::build_both(const multinodelist_t 
     {
         // geos36 - auto-allocation no longer supported in GEOS 3.6+
 	const GeometryFactory *gf_p = GeometryFactory::getDefaultInstance();
-	GeometryFactory& gf = *gf_p;
+	const GeometryFactory& gf = *gf_p;
 	
         geom_ptr mline = create_multi_line(gf, xnodes);
         //geom_ptr noded (segment->Union(mline.get()));

--- a/geometry-builder.hpp
+++ b/geometry-builder.hpp
@@ -104,7 +104,7 @@ public:
 
 private:
     std::unique_ptr<geos::geom::Geometry>
-    create_simple_poly(geos::geom::GeometryFactory &gf,
+    create_simple_poly(const geos::geom::GeometryFactory &gf,
                        std::unique_ptr<geos::geom::CoordinateSequence> coords) const;
 
     bool excludepoly = false;


### PR DESCRIPTION
this built and tests passed, with the following Ubuntu 1404 Trusty config  : 

```
osm2pgsql_geos36/build$ cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON
-- The C compiler identification is GNU 4.8.4
-- The CXX compiler identification is GNU 4.8.4
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Building osm2pgsql 0.91.0-dev
-- Looking for include file termios.h
-- Looking for include file termios.h - found
-- Looking for include file libgen.h
-- Looking for include file libgen.h - found
-- Looking for include file unistd.h
-- Looking for include file unistd.h - found
-- Looking for lseek64
-- Looking for lseek64 - found
-- Looking for posix_fallocate
-- Looking for posix_fallocate - found
-- Looking for posix_fadvise
-- Looking for posix_fadvise - found
-- Looking for sync_file_range
-- Looking for sync_file_range - found
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of off_t
-- Check size of off_t - done
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.8") 
-- Looking for include file pthread.h
-- Looking for include file pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found EXPAT: /usr/lib/x86_64-linux-gnu/libexpat.so (found version "2.1.0") 
-- Found BZip2: /usr/lib/x86_64-linux-gnu/libbz2.so (found version "1.0.6") 
-- Looking for BZ2_bzCompressInit in /usr/lib/x86_64-linux-gnu/libbz2.so
-- Looking for BZ2_bzCompressInit in /usr/lib/x86_64-linux-gnu/libbz2.so - found
-- Found Osmium: /home/shared/srcs_i7d/osm2pgsql_geos36/contrib/libosmium  
-- Found Lua: /usr/lib/x86_64-linux-gnu/liblua5.2.so;/usr/lib/x86_64-linux-gnu/libm.so (found version "5.2.3") 
-- Boost version: 1.55.0
-- Found the following Boost libraries:
--   system
--   filesystem
-- Found PostgreSQL: /usr/lib/x86_64-linux-gnu/libpq.so (found version "9.6.1") 
Libraries used to build: /usr/lib/x86_64-linux-gnu/libboost_system.so/usr/lib/x86_64-linux-gnu/libboost_filesystem.so/usr/lib/x86_64-linux-gnu/libpq.so/usr/lib/x86_64-linux-gnu/libz.so-lpthread/usr/lib/x86_64-linux-gnu/libexpat.so/usr/lib/x86_64-linux-gnu/libbz2.so/usr/local/lib/libgeos.so/usr/lib/libproj.so/usr/lib/x86_64-linux-gnu/liblua5.2.so/usr/lib/x86_64-linux-gnu/libm.so
```
