### PR TITLE
Refer to small imports, not extracts

### DIFF
--- a/docs/osm2pgsql.1
+++ b/docs/osm2pgsql.1
@@ -1,4 +1,4 @@
-.TH OSM2PGSQL 1 "February 27, 2016"
+.TH OSM2PGSQL 1 "October 31, 2016"
 .\" Please adjust this date whenever revising the manpage.
 .SH NAME
 osm2pgsql \- Openstreetmap data to PostgreSQL converter.
@@ -228,7 +228,7 @@ planet requires about 100GB in PostgreSQL, the same data is stored in only ~16GB
 the flat\-nodes mode. This can also increase the speed of applying diff files. This option
 activates the flat\-nodes mode and specifies the location of the database file. It is a
 single large > 16GB file. This mode is only recommended for full planet imports
-as it doesn't work well with small extracts. The default is disabled.
+as it doesn't work well with small imports. The default is disabled.
 .TP
 \fB\-h\fR|\-\-help
 Help information.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -29,7 +29,7 @@ that only impact performance.
   ``--slim`` mode, this is just node positions while in non-slim it has to
   store information about ways and relations too. The maximum RAM it is useful
   to set this to in slim mode is 8 bytes * number of nodes / efficiency, where
-  efficiency ranges from 50% on small extracts to 80% for a planet.
+  efficiency ranges from 50% on small imports to 80% for a planet.
 
 * ``--number-processes`` sets the number of processes to use. This should
   typically be set to the number of CPU threads, but gains in speed are minimal

--- a/options.cpp
+++ b/options.cpp
@@ -147,7 +147,7 @@ namespace
                         dense: caching strategy optimised for full planet import\n\
                         chunk: caching strategy optimised for non-contiguous \n\
                             memory allocation\n\
-                        sparse: caching strategy optimised for small extracts\n\
+                        sparse: caching strategy optimised for small imports\n\
                         optimized: automatically combines dense and sparse \n\
                             strategies for optimal storage efficiency. This may\n\
                             us twice as much virtual memory, but no more physical \n\


### PR DESCRIPTION
Cache options depend on the number of nodes that make it past the bounding box filter, so it's better to speak of import size, not extract size.


Replaces #551