### PR TITLE
fix error for failed format dectection and format in usage example

### DIFF
--- a/options.cpp
+++ b/options.cpp
@@ -222,7 +222,7 @@ namespace
             printf("\n");
             printf("A typical command to update a database imported with the above command is\n");
             printf("    osmosis --rri workingDirectory=<osmosis dir> --simc --wxc - \\\n");
-            printf("      | %s -a -d gis --slim -k --flat-nodes <flat nodes> -\n", name);
+            printf("      | %s -a -d gis --slim -k --flat-nodes <flat nodes> -r xml -\n", name);
             printf("where\n");
             printf("    <flat nodes> is the same location as above.\n");
             printf("    <osmosis dir> is the location osmosis replication was initialized to.\n");

--- a/parse-osmium.cpp
+++ b/parse-osmium.cpp
@@ -112,7 +112,7 @@ void parse_osmium_t::stream_file(const std::string &filename, const std::string 
     osmium::io::File infile(filename, osmium_format);
 
     if (infile.format() == osmium::io::file_format::unknown)
-        throw std::runtime_error(fmt.empty()
+        throw std::runtime_error(fmt == "auto"
                                    ?"Cannot detect file format. Try using -r."
                                    : ((boost::format("Unknown file format '%1%'.")
                                                     % fmt).str()));


### PR DESCRIPTION
When throwing an exception because libosmium cannot detect the
file format, the check for auto detection was wrong and thus
a confusing message was printed.

Also adds an explicit format switch for the usage example for
updating the database because libosmium cannot autodetect formats
when reading from stdin.