### PR TITLE
remove comments in json configuration files

### DIFF
--- a/multi.style.json
+++ b/multi.style.json
@@ -1,10 +1,3 @@
-/* This is an example multi-backend style file that comes with osm2pgsql.
- *
- * It contains comments so is invalid JSON but the parser doesn't complain.
- *
- * To use this file, pass it in as a style file with the --style switch, e.g.
- * with osm2pgsql --output multi --style multi.style.json
- */
 [
   {
     "name": "stops",
@@ -15,15 +8,12 @@
     "tagtransform-relation-function": "drop_all",
     "tagtransform-relation-member-function": "drop_all",
     "tags": [
-      /* We don't need a column for highway, since it's always highway=bus_stop */
       {"name": "name", "type": "text"},
-      /* multi-lingual names can be generated at import time */
       {"name": "name_en", "type": "text"},
       {"name": "name_fr", "type": "text"},
       {"name": "name_de", "type": "text"},
       {"name": "ref", "type": "text"},
       {"name": "operator", "type": "text"},
-      /* By using boolean columns stylesheet processing can be simplified */
       {"name": "shelter", "type": "boolean"},
       {"name": "bench", "type": "boolean"},
       {"name": "wheelchair", "type": "boolean"}

--- a/tests/test_output_multi_tags.json
+++ b/tests/test_output_multi_tags.json
@@ -1,9 +1,3 @@
-/*
-These tables provide a test that tag processing works, and that one tag
-processing does not clobber another. They are not exhaustive,
-particularly with regards to interactions between way/area detection and
-relations.
-*/
 [
   {
     "name": "test_points_1",
@@ -11,28 +5,25 @@ relations.
     "tagtransform": "tests/test_output_multi_tags.lua",
     "tagtransform-node-function": "test_nodes_1",
     "tagtransform-way-function": "drop_all",
-    /* No relations in the file */
     "tagtransform-relation-function": "drop_all",
     "tagtransform-relation-member-function": "drop_all",
     "tags": [
       {"name": "foo", "type": "text"},
       {"name": "bar", "type": "text"},
-      {"name": "baz", "type": "text"} /* left empty by the transform */
+      {"name": "baz", "type": "text"}
     ]
   },
   {
-    /* This second table will process the same data, but resulting in different tags */
     "name": "test_points_2",
     "type": "point",
     "tagtransform": "tests/test_output_multi_tags.lua",
     "tagtransform-node-function": "test_nodes_2",
     "tagtransform-way-function": "drop_all",
-    /* No relations in the file */
     "tagtransform-relation-function": "drop_all",
     "tagtransform-relation-member-function": "drop_all",
     "tags": [
       {"name": "foo", "type": "text"},
-      {"name": "bar", "type": "text"}, /* left empty by the transform */
+      {"name": "bar", "type": "text"},
       {"name": "baz", "type": "text"}
     ]
   },
@@ -42,13 +33,12 @@ relations.
     "tagtransform": "tests/test_output_multi_tags.lua",
     "tagtransform-node-function": "drop_all",
     "tagtransform-way-function": "test_line_1",
-    /* No relations in the file */
     "tagtransform-relation-function": "drop_all",
     "tagtransform-relation-member-function": "drop_all",
     "tags": [
       {"name": "foo", "type": "text"},
       {"name": "bar", "type": "text"},
-      {"name": "baz", "type": "text"} /* left empty by the transform */
+      {"name": "baz", "type": "text"}
     ]
   },
   {
@@ -57,12 +47,11 @@ relations.
     "tagtransform": "tests/test_output_multi_tags.lua",
     "tagtransform-node-function": "drop_all",
     "tagtransform-way-function": "test_line_2",
-    /* No relations in the file */
     "tagtransform-relation-function": "drop_all",
     "tagtransform-relation-member-function": "drop_all",
     "tags": [
       {"name": "foo", "type": "text"},
-      {"name": "bar", "type": "text"}, /* left empty by the transform */
+      {"name": "bar", "type": "text"},
       {"name": "baz", "type": "text"}
     ]
   },
@@ -72,13 +61,12 @@ relations.
     "tagtransform": "tests/test_output_multi_tags.lua",
     "tagtransform-node-function": "drop_all",
     "tagtransform-way-function": "test_polygon_1",
-    /* No relations in the file */
     "tagtransform-relation-function": "drop_all",
     "tagtransform-relation-member-function": "drop_all",
     "tags": [
       {"name": "foo", "type": "text"},
       {"name": "bar", "type": "text"},
-      {"name": "baz", "type": "text"} /* left empty by the transform */
+      {"name": "baz", "type": "text"}
     ]
   },
   {
@@ -87,13 +75,12 @@ relations.
     "tagtransform": "tests/test_output_multi_tags.lua",
     "tagtransform-node-function": "drop_all",
     "tagtransform-way-function": "test_polygon_2",
-    /* No relations in the file */
     "tagtransform-relation-function": "drop_all",
     "tagtransform-relation-member-function": "drop_all",
     "tags": [
       {"name": "foo", "type": "text"},
       {"name": "bar", "type": "text"},
-      {"name": "baz", "type": "text"} /* left empty by the transform */
+      {"name": "baz", "type": "text"}
     ]
   }
 ]


### PR DESCRIPTION
Json does not allow for comments and starting with version
1.59.0 boost is no longer able to parse them.

Fixes #647