### PR TITLE
Use osmium types for all incomming data

### DIFF
--- a/geometry-processor.cpp
+++ b/geometry-processor.cpp
@@ -124,7 +124,7 @@ size_t relation_helper::set(const memberlist_t *member_list, const middle_t* mid
     for (idlist_t::const_iterator it = ways.begin(); it != ways.end(); ++it) {
         while (memberpos < members->size()) {
             if (members->at(memberpos).id == *it) {
-                roles.push_back(&(members->at(memberpos).role));
+                roles.push_back(members->at(memberpos).role.c_str());
                 memberpos++;
                 break;
             }

--- a/geometry-processor.cpp
+++ b/geometry-processor.cpp
@@ -107,7 +107,7 @@ size_t relation_helper::set(const memberlist_t *member_list, const middle_t* mid
     //grab the way members' ids
     input_way_ids.reserve(member_list->size());
     for (memberlist_t::const_iterator it = members->begin(); it != members->end(); ++it) {
-        if(it->type == OSMTYPE_WAY)
+        if(it->type == osmium::item_type::way)
             input_way_ids.push_back(it->id);
     }
 

--- a/geometry-processor.cpp
+++ b/geometry-processor.cpp
@@ -75,7 +75,8 @@ way_helper::way_helper()
 way_helper::~way_helper()
 {
 }
-size_t way_helper::set(const idlist_t &node_ids, const middle_query_t *mid)
+size_t way_helper::set(osmium::WayNodeList const &node_ids,
+                       const middle_query_t *mid)
 {
     node_cache.clear();
     mid->nodes_get_list(node_cache, node_ids);

--- a/geometry-processor.cpp
+++ b/geometry-processor.cpp
@@ -146,7 +146,7 @@ multitaglist_t relation_helper::get_filtered_tags(tagtransform *transform, expor
 
     size_t i = 0;
     for (auto const &w : data.select<osmium::Way>()) {
-        transform->filter_tags(w, false, 0, 0, el, filtered[i++]);
+        transform->filter_tags(w, nullptr, nullptr, el, filtered[i++]);
     }
 
     return filtered;

--- a/geometry-processor.hpp
+++ b/geometry-processor.hpp
@@ -75,7 +75,7 @@ struct way_helper
 {
     way_helper();
     ~way_helper();
-    size_t set(const idlist_t &node_ids, const middle_query_t *mid);
+    size_t set(osmium::WayNodeList const &node_ids, const middle_query_t *mid);
 
     nodelist_t node_cache;
 };

--- a/geometry-processor.hpp
+++ b/geometry-processor.hpp
@@ -5,8 +5,12 @@
 #include <string>
 #include <vector>
 #include <memory>
+
+#include <osmium/memory/buffer.hpp>
+
 #include "geometry-builder.hpp"
 #include "osmtypes.hpp"
+#include "tagtransform.hpp"
 
 struct middle_query_t;
 struct middle_t;
@@ -85,14 +89,16 @@ struct relation_helper
 {
     relation_helper();
     ~relation_helper();
-    size_t set(const memberlist_t *member_list, const middle_t *mid);
+    size_t set(osmium::RelationMemberList const &member_list, middle_t const *mid);
+    multitaglist_t get_filtered_tags(tagtransform *transform, export_list const &el) const;
+    multinodelist_t get_nodes(middle_t const *mid) const;
 
-    const memberlist_t *members;
-    multitaglist_t tags;
-    multinodelist_t nodes;
-    idlist_t ways;
+    osmium::memory::ItemIteratorRange<const osmium::Way> way_iterator() const
+    { return data.select<osmium::Way>(); }
+
     rolelist_t roles;
     std::vector<int> superseeded;
+    osmium::memory::Buffer data;
 
 private:
     idlist_t input_way_ids;

--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -257,7 +257,7 @@ void middle_pgsql_t::buffer_correct_params(char const **param, size_t size)
 }
 
 void middle_pgsql_t::local_nodes_set(osmium::Node const &node,
-                                     double lat, double lon, bool extra_tags)
+                                     double lat, double lon)
 {
     copy_buffer.reserve(node.tags().byte_size() + 100);
 
@@ -287,12 +287,12 @@ void middle_pgsql_t::local_nodes_set(osmium::Node const &node,
     copy_buffer += delim;
 #endif
 
-    if (node.tags().empty() && !extra_tags) {
+    if (node.tags().empty() && !out_options->extra_attributes) {
         paramValues[3] = nullptr;
         copy_buffer += "\\N";
     } else {
         paramValues[3] = paramValues[0] + copy_buffer.size();
-        buffer_store_tags(node, extra_tags, copy);
+        buffer_store_tags(node, out_options->extra_attributes, copy);
     }
 
     if (copy) {
@@ -395,15 +395,14 @@ size_t middle_pgsql_t::local_nodes_get_list(nodelist_t &out, osmium::WayNodeList
 }
 
 
-void middle_pgsql_t::nodes_set(osmium::Node const &node,
-                               double lat, double lon, bool extra_tags)
+void middle_pgsql_t::nodes_set(osmium::Node const &node, double lat, double lon)
 {
     cache->set(node.id(), lat, lon);
 
     if (out_options->flat_node_cache_enabled) {
         persistent_cache->set(node.id(), lat, lon);
     } else {
-        local_nodes_set(node, lat, lon, extra_tags);
+        local_nodes_set(node, lat, lon);
     }
 }
 
@@ -472,7 +471,7 @@ void middle_pgsql_t::node_changed(osmid_t osm_id)
     PQclear(res);
 }
 
-void middle_pgsql_t::ways_set(osmium::Way const &way, bool extra_tags)
+void middle_pgsql_t::ways_set(osmium::Way const &way)
 {
     copy_buffer.reserve(way.nodes().size() * 10 + way.tags().byte_size() + 100);
     bool copy = way_table->copyMode;
@@ -496,12 +495,12 @@ void middle_pgsql_t::ways_set(osmium::Way const &way, bool extra_tags)
     }
     copy_buffer += delim;
 
-    if (way.tags().empty() && !extra_tags) {
+    if (way.tags().empty() && !out_options->extra_attributes) {
         paramValues[2] = nullptr;
         copy_buffer += "\\N";
     } else {
         paramValues[2] = paramValues[0] + copy_buffer.size();
-        buffer_store_tags(way, extra_tags, copy);
+        buffer_store_tags(way, out_options->extra_attributes, copy);
     }
 
     if (copy) {
@@ -661,7 +660,7 @@ void middle_pgsql_t::way_changed(osmid_t osm_id)
     PQclear(res);
 }
 
-void middle_pgsql_t::relations_set(osmium::Relation const &rel, bool extra_tags)
+void middle_pgsql_t::relations_set(osmium::Relation const &rel)
 {
     idlist_t parts[3];
 
@@ -720,12 +719,12 @@ void middle_pgsql_t::relations_set(osmium::Relation const &rel, bool extra_tags)
     }
     copy_buffer+= delim;
 
-    if (rel.tags().empty() && ! extra_tags) {
+    if (rel.tags().empty() && !out_options->extra_attributes) {
         paramValues[5] = nullptr;
         copy_buffer += "\\N";
     } else {
         paramValues[5] = paramValues[0] + copy_buffer.size();
-        buffer_store_tags(rel, extra_tags, copy);
+        buffer_store_tags(rel, out_options->extra_attributes, copy);
     }
 
     if (copy) {

--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -319,6 +319,7 @@ size_t middle_pgsql_t::local_nodes_get_list(nodelist_t &out, osmium::WayNodeList
     // create a list of ids in tmp2 to query the database  */
     sprintf(tmp2, "{");
     int countDB = 0;
+    out.reserve(nds.size());
     for (auto const &n : nds) {
         // Check cache first */
         osmNode loc;
@@ -582,6 +583,7 @@ size_t middle_pgsql_t::ways_get_list(const idlist_t &ids, osmium::memory::Buffer
 
     // Match the list of ways coming from postgres in a different order
     //   back to the list of ways given by the caller */
+    int outres = 0;
     for (auto id : ids) {
         for (int j = 0; j < countPG; j++) {
             if (id == wayidspg[j]) {
@@ -594,6 +596,7 @@ size_t middle_pgsql_t::ways_get_list(const idlist_t &ids, osmium::memory::Buffer
                 }
 
                 buffer.commit();
+                outres++;
                 break;
             }
         }
@@ -601,7 +604,7 @@ size_t middle_pgsql_t::ways_get_list(const idlist_t &ids, osmium::memory::Buffer
 
     PQclear(res);
 
-    return wayidspg.size();
+    return outres;
 }
 
 

--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -837,7 +837,8 @@ idlist_t middle_pgsql_t::relations_using_way(osmid_t way_id) const
     PGresult *result = pgsql_execPrepared(rel_table->sql_conn, "rels_using_way",
                                           1, paramValues, PGRES_TUPLES_OK );
     const int ntuples = PQntuples(result);
-    idlist_t rel_ids(ntuples);
+    idlist_t rel_ids;
+    rel_ids.resize((size_t) ntuples);
     for (int i = 0; i < ntuples; ++i) {
         rel_ids[i] = strtoosmid(PQgetvalue(result, i, 0), nullptr, 10);
     }

--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -534,8 +534,7 @@ bool middle_pgsql_t::ways_get(osmid_t id, osmium::memory::Buffer &buffer) const
 
     {
         osmium::builder::WayBuilder builder(buffer);
-        builder.object().set_id(id);
-        builder.add_user("", 0);
+        builder.set_id(id);
 
         pgsql_parse_nodes(PQgetvalue(res, 0, 0), buffer, builder);
         pgsql_parse_tags(PQgetvalue(res, 0, 1), buffer, builder);
@@ -588,8 +587,7 @@ size_t middle_pgsql_t::ways_get_list(const idlist_t &ids, osmium::memory::Buffer
             if (id == wayidspg[j]) {
                 {
                     osmium::builder::WayBuilder builder(buffer);
-                    builder.object().set_id(id);
-                    builder.add_user("", 0);
+                    builder.set_id(id);
 
                     pgsql_parse_nodes(PQgetvalue(res, j, 1), buffer, builder);
                     pgsql_parse_tags(PQgetvalue(res, j, 2), buffer, builder);
@@ -748,7 +746,7 @@ bool middle_pgsql_t::relations_get(osmid_t id, osmium::memory::Buffer &buffer) c
     taglist_t member_temp;
 
     // Make sure we're out of copy mode */
-    pgsql_endCopy( rel_table );
+    pgsql_endCopy(rel_table);
 
     snprintf(tmp, sizeof(tmp), "%" PRIdOSMID, id);
     paramValues[0] = tmp;
@@ -763,13 +761,13 @@ bool middle_pgsql_t::relations_get(osmid_t id, osmium::memory::Buffer &buffer) c
 
     {
         osmium::builder::RelationBuilder builder(buffer);
-        builder.object().set_id(id);
-        builder.add_user("", 0);
+        builder.set_id(id);
 
         pgsql_parse_members(PQgetvalue(res, 0, 0), buffer, builder);
         pgsql_parse_tags(PQgetvalue(res, 0, 1), buffer, builder);
     }
 
+    PQclear(res);
     buffer.commit();
 
     return true;

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -40,7 +40,7 @@ struct middle_pgsql_t : public slim_middle_t {
     void ways_delete(osmid_t id);
     void way_changed(osmid_t id);
 
-    bool relations_get(osmid_t id, memberlist_t &members, taglist_t &tags) const;
+    bool relations_get(osmid_t id, osmium::memory::Buffer &buffer) const override;
     void relations_set(osmium::Relation const &rel, bool extra_tags) override;
     void relations_delete(osmid_t id);
     void relation_changed(osmid_t id);

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -49,7 +49,7 @@ struct middle_pgsql_t : public slim_middle_t {
 
     size_t pending_count() const;
 
-    std::vector<osmid_t> relations_using_way(osmid_t way_id) const;
+    idlist_t relations_using_way(osmid_t way_id) const;
 
     struct table_desc {
         table_desc(const char *name_ = NULL,

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -26,13 +26,12 @@ struct middle_pgsql_t : public slim_middle_t {
     void end(void);
     void commit(void);
 
-    void nodes_set(osmium::Node const &node, double lat, double lon,
-                   bool extra_tags) override;
+    void nodes_set(osmium::Node const &node, double lat, double lon) override;
     size_t nodes_get_list(nodelist_t &out, osmium::WayNodeList const &nds) const override;
     void nodes_delete(osmid_t id);
     void node_changed(osmid_t id);
 
-    void ways_set(osmium::Way const &way, bool extra_tags) override;
+    void ways_set(osmium::Way const &way) override;
     bool ways_get(osmid_t id, osmium::memory::Buffer &buffer) const override;
     size_t ways_get_list(const idlist_t &ids, osmium::memory::Buffer &buffer) const override;
 
@@ -40,7 +39,7 @@ struct middle_pgsql_t : public slim_middle_t {
     void way_changed(osmid_t id);
 
     bool relations_get(osmid_t id, osmium::memory::Buffer &buffer) const override;
-    void relations_set(osmium::Relation const &rel, bool extra_tags) override;
+    void relations_set(osmium::Relation const &rel) override;
     void relations_delete(osmid_t id);
     void relation_changed(osmid_t id);
 
@@ -87,8 +86,7 @@ private:
      * Sets up sql_conn for the table
      */
     void connect(table_desc& table);
-    void local_nodes_set(osmium::Node const &node,
-                         double lat, double lon, bool extra_tags);
+    void local_nodes_set(osmium::Node const &node, double lat, double lon);
     size_t local_nodes_get_list(nodelist_t &out, osmium::WayNodeList const &nds) const;
     void local_nodes_delete(osmid_t osm_id);
 

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -26,12 +26,13 @@ struct middle_pgsql_t : public slim_middle_t {
     void end(void);
     void commit(void);
 
-    void nodes_set(osmid_t id, double lat, double lon, const taglist_t &tags);
+    void nodes_set(osmium::Node const &node, double lat, double lon,
+                   bool extra_tags) override;
     size_t nodes_get_list(nodelist_t &out, const idlist_t nds) const;
     void nodes_delete(osmid_t id);
     void node_changed(osmid_t id);
 
-    void ways_set(osmid_t id, const idlist_t &nds, const taglist_t &tags);
+    void ways_set(osmium::Way const &way, bool extra_tags) override;
     bool ways_get(osmid_t id, taglist_t &tags, nodelist_t &nodes) const;
     size_t ways_get_list(const idlist_t &ids, idlist_t &way_ids,
                       multitaglist_t &tags, multinodelist_t &nodes) const;
@@ -40,7 +41,7 @@ struct middle_pgsql_t : public slim_middle_t {
     void way_changed(osmid_t id);
 
     bool relations_get(osmid_t id, memberlist_t &members, taglist_t &tags) const;
-    void relations_set(osmid_t id, const memberlist_t &members, const taglist_t &tags);
+    void relations_set(osmium::Relation const &rel, bool extra_tags) override;
     void relations_delete(osmid_t id);
     void relation_changed(osmid_t id);
 
@@ -87,7 +88,8 @@ private:
      * Sets up sql_conn for the table
      */
     void connect(table_desc& table);
-    void local_nodes_set(osmid_t id, double lat, double lon, const taglist_t &tags);
+    void local_nodes_set(osmium::Node const &node,
+                         double lat, double lon, bool extra_tags);
     size_t local_nodes_get_list(nodelist_t &out, const idlist_t nds) const;
     void local_nodes_delete(osmid_t osm_id);
 
@@ -104,7 +106,7 @@ private:
     std::shared_ptr<id_tracker> ways_pending_tracker, rels_pending_tracker;
 
     void buffer_store_string(std::string const &in, bool escape);
-    void buffer_store_tags(taglist_t const &tags, bool escape);
+    void buffer_store_tags(osmium::OSMObject const &obj, bool attrs, bool escape);
 
     void buffer_correct_params(char const **param, size_t size);
 

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -28,7 +28,7 @@ struct middle_pgsql_t : public slim_middle_t {
 
     void nodes_set(osmium::Node const &node, double lat, double lon,
                    bool extra_tags) override;
-    size_t nodes_get_list(nodelist_t &out, const idlist_t nds) const;
+    size_t nodes_get_list(nodelist_t &out, osmium::WayNodeList const &nds) const override;
     void nodes_delete(osmid_t id);
     void node_changed(osmid_t id);
 
@@ -90,7 +90,7 @@ private:
     void connect(table_desc& table);
     void local_nodes_set(osmium::Node const &node,
                          double lat, double lon, bool extra_tags);
-    size_t local_nodes_get_list(nodelist_t &out, const idlist_t nds) const;
+    size_t local_nodes_get_list(nodelist_t &out, osmium::WayNodeList const &nds) const;
     void local_nodes_delete(osmid_t osm_id);
 
     std::vector<table_desc> tables;

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -103,7 +103,6 @@ private:
 
     std::shared_ptr<id_tracker> ways_pending_tracker, rels_pending_tracker;
 
-    void buffer_store_nodes(idlist_t const &nodes);
     void buffer_store_string(std::string const &in, bool escape);
     void buffer_store_tags(taglist_t const &tags, bool escape);
 

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -33,9 +33,8 @@ struct middle_pgsql_t : public slim_middle_t {
     void node_changed(osmid_t id);
 
     void ways_set(osmium::Way const &way, bool extra_tags) override;
-    bool ways_get(osmid_t id, taglist_t &tags, nodelist_t &nodes) const;
-    size_t ways_get_list(const idlist_t &ids, idlist_t &way_ids,
-                      multitaglist_t &tags, multinodelist_t &nodes) const;
+    bool ways_get(osmid_t id, osmium::memory::Buffer &buffer) const override;
+    size_t ways_get_list(const idlist_t &ids, osmium::memory::Buffer &buffer) const override;
 
     void ways_delete(osmid_t id);
     void way_changed(osmid_t id);

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -20,35 +20,35 @@ struct middle_pgsql_t : public slim_middle_t {
     middle_pgsql_t();
     virtual ~middle_pgsql_t();
 
-    void start(const options_t *out_options_);
-    void stop(void);
-    void analyze(void);
-    void end(void);
-    void commit(void);
+    void start(const options_t *out_options_) override;
+    void stop(void) override;
+    void analyze(void) override;
+    void end(void) override;
+    void commit(void) override;
 
     void nodes_set(osmium::Node const &node, double lat, double lon) override;
     size_t nodes_get_list(nodelist_t &out, osmium::WayNodeList const &nds) const override;
-    void nodes_delete(osmid_t id);
-    void node_changed(osmid_t id);
+    void nodes_delete(osmid_t id) override;
+    void node_changed(osmid_t id) override;
 
     void ways_set(osmium::Way const &way) override;
     bool ways_get(osmid_t id, osmium::memory::Buffer &buffer) const override;
     size_t ways_get_list(const idlist_t &ids, osmium::memory::Buffer &buffer) const override;
 
-    void ways_delete(osmid_t id);
-    void way_changed(osmid_t id);
+    void ways_delete(osmid_t id) override;
+    void way_changed(osmid_t id) override;
 
     bool relations_get(osmid_t id, osmium::memory::Buffer &buffer) const override;
     void relations_set(osmium::Relation const &rel) override;
-    void relations_delete(osmid_t id);
-    void relation_changed(osmid_t id);
+    void relations_delete(osmid_t id) override;
+    void relation_changed(osmid_t id) override;
 
-    void iterate_ways(middle_t::pending_processor& pf);
-    void iterate_relations(pending_processor& pf);
+    void iterate_ways(middle_t::pending_processor& pf) override;
+    void iterate_relations(pending_processor& pf) override;
 
-    size_t pending_count() const;
+    size_t pending_count() const override;
 
-    idlist_t relations_using_way(osmid_t way_id) const;
+    idlist_t relations_using_way(osmid_t way_id) const override;
 
     struct table_desc {
         table_desc(const char *name_ = NULL,
@@ -78,7 +78,7 @@ struct middle_pgsql_t : public slim_middle_t {
         struct pg_conn *sql_conn;
     };
 
-    virtual std::shared_ptr<const middle_query_t> get_instance() const;
+    std::shared_ptr<const middle_query_t> get_instance() const override;
 private:
     void pgsql_stop_one(table_desc *table);
 

--- a/middle-ram.cpp
+++ b/middle-ram.cpp
@@ -198,7 +198,7 @@ middle_ram_t::~middle_ram_t() {
     //instance.reset();
 }
 
-std::vector<osmid_t> middle_ram_t::relations_using_way(osmid_t way_id) const
+idlist_t middle_ram_t::relations_using_way(osmid_t way_id) const
 {
     // this function shouldn't be called - relations_using_way is only used in
     // slim mode, and a middle_ram_t shouldn't be constructed if the slim mode

--- a/middle-ram.cpp
+++ b/middle-ram.cpp
@@ -12,7 +12,6 @@
 #include <cassert>
 #include <cstdio>
 
-#include <osmium/memory/buffer.hpp>
 #include <osmium/builder/attr.hpp>
 
 #include "id-tracker.hpp"
@@ -151,7 +150,7 @@ size_t middle_ram_t::ways_get_list(const idlist_t &ids, idlist_t &way_ids,
     return count;
 }
 
-bool middle_ram_t::relations_get(osmid_t id, memberlist_t &members, taglist_t &tags) const
+bool middle_ram_t::relations_get(osmid_t id, osmium::memory::Buffer &buffer) const
 {
     auto const *ele = rels.get(id);
 
@@ -159,8 +158,9 @@ bool middle_ram_t::relations_get(osmid_t id, memberlist_t &members, taglist_t &t
         return false;
     }
 
-    tags = ele->tags;
-    members = ele->members;
+    using namespace osmium::builder::attr;
+    osmium::builder::add_relation(buffer, _id(id), _members(ele->members.for_builder()),
+                                  _tags(ele->tags));
 
     return true;
 }

--- a/middle-ram.cpp
+++ b/middle-ram.cpp
@@ -32,18 +32,19 @@
  */
 
 
-void middle_ram_t::nodes_set(osmid_t id, double lat, double lon, const taglist_t &tags) {
-    cache->set(id, lat, lon, tags);
+void middle_ram_t::nodes_set(osmium::Node const &node, double lat, double lon, bool)
+{
+    cache->set(node.id(), lat, lon);
 }
 
-void middle_ram_t::ways_set(osmid_t id, const idlist_t &nds, const taglist_t &tags)
+void middle_ram_t::ways_set(osmium::Way const &way, bool extra_tags)
 {
-    ways.set(id, new ramWay(tags, nds));
+    ways.set(way.id(), new ramWay(way, extra_tags));
 }
 
-void middle_ram_t::relations_set(osmid_t id, const memberlist_t &members, const taglist_t &tags)
+void middle_ram_t::relations_set(osmium::Relation const &rel, bool extra_tags)
 {
-    rels.set(id, new ramRel(tags, members));
+    rels.set(rel.id(), new ramRel(rel, extra_tags));
 }
 
 size_t middle_ram_t::nodes_get_list(nodelist_t &out, const idlist_t nds) const
@@ -54,7 +55,7 @@ size_t middle_ram_t::nodes_get_list(nodelist_t &out, const idlist_t nds) const
             out.push_back(n);
     }
 
-    return int(out.size());
+    return out.size();
 }
 
 void middle_ram_t::iterate_relations(pending_processor& pf)
@@ -140,7 +141,7 @@ size_t middle_ram_t::ways_get_list(const idlist_t &ids, idlist_t &way_ids,
         nodes.resize(count);
     }
 
-    return int(count);
+    return count;
 }
 
 bool middle_ram_t::relations_get(osmid_t id, memberlist_t &members, taglist_t &tags) const

--- a/middle-ram.cpp
+++ b/middle-ram.cpp
@@ -34,19 +34,19 @@
  */
 
 
-void middle_ram_t::nodes_set(osmium::Node const &node, double lat, double lon, bool)
+void middle_ram_t::nodes_set(osmium::Node const &node, double lat, double lon)
 {
     cache->set(node.id(), lat, lon);
 }
 
-void middle_ram_t::ways_set(osmium::Way const &way, bool extra_tags)
+void middle_ram_t::ways_set(osmium::Way const &way)
 {
-    ways.set(way.id(), new ramWay(way, extra_tags));
+    ways.set(way.id(), new ramWay(way, out_options->extra_attributes));
 }
 
-void middle_ram_t::relations_set(osmium::Relation const &rel, bool extra_tags)
+void middle_ram_t::relations_set(osmium::Relation const &rel)
 {
-    rels.set(rel.id(), new ramRel(rel, extra_tags));
+    rels.set(rel.id(), new ramRel(rel, out_options->extra_attributes));
 }
 
 size_t middle_ram_t::nodes_get_list(nodelist_t &out, osmium::WayNodeList const &nds) const

--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -103,7 +103,7 @@ struct middle_ram_t : public middle_t {
     int ways_delete(osmid_t id);
     int way_changed(osmid_t id);
 
-    bool relations_get(osmid_t id, memberlist_t &members, taglist_t &tags) const;
+    bool relations_get(osmid_t id, osmium::memory::Buffer &buffer) const override;
     void relations_set(osmium::Relation const &rel, bool extra_tags) override;
     int relations_delete(osmid_t id);
     int relation_changed(osmid_t id);

--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -84,11 +84,11 @@ struct middle_ram_t : public middle_t {
     middle_ram_t();
     virtual ~middle_ram_t();
 
-    void start(const options_t *out_options_);
-    void stop(void);
-    void analyze(void);
-    void end(void);
-    void commit(void);
+    void start(const options_t *out_options_) override;
+    void stop(void) override;
+    void analyze(void) override;
+    void end(void) override;
+    void commit(void) override;
 
     void nodes_set(osmium::Node const &node, double lat, double lon) override;
     size_t nodes_get_list(nodelist_t &out, osmium::WayNodeList const &nds) const override;
@@ -107,14 +107,14 @@ struct middle_ram_t : public middle_t {
     int relations_delete(osmid_t id);
     int relation_changed(osmid_t id);
 
-    idlist_t relations_using_way(osmid_t way_id) const;
+    idlist_t relations_using_way(osmid_t way_id) const override;
 
-    void iterate_ways(middle_t::pending_processor& pf);
-    void iterate_relations(pending_processor& pf);
+    void iterate_ways(middle_t::pending_processor& pf) override;
+    void iterate_relations(pending_processor& pf) override;
 
-    size_t pending_count() const;
+    size_t pending_count() const override;
 
-    virtual std::shared_ptr<const middle_query_t> get_instance() const;
+    std::shared_ptr<const middle_query_t> get_instance() const override;
 private:
 
     void release_ways();

--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -90,12 +90,12 @@ struct middle_ram_t : public middle_t {
     void end(void);
     void commit(void);
 
-    void nodes_set(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
+    void nodes_set(osmium::Node const &node, double lat, double lon) override;
     size_t nodes_get_list(nodelist_t &out, osmium::WayNodeList const &nds) const override;
     int nodes_delete(osmid_t id);
     int node_changed(osmid_t id);
 
-    void ways_set(osmium::Way const &way, bool extra_tags) override;
+    void ways_set(osmium::Way const &way) override;
     bool ways_get(osmid_t id, osmium::memory::Buffer &buffer) const override;
     size_t ways_get_list(idlist_t const &ids, osmium::memory::Buffer &buffer) const override;
 
@@ -103,7 +103,7 @@ struct middle_ram_t : public middle_t {
     int way_changed(osmid_t id);
 
     bool relations_get(osmid_t id, osmium::memory::Buffer &buffer) const override;
-    void relations_set(osmium::Relation const &rel, bool extra_tags) override;
+    void relations_set(osmium::Relation const &rel) override;
     int relations_delete(osmid_t id);
     int relation_changed(osmid_t id);
 

--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -96,9 +96,8 @@ struct middle_ram_t : public middle_t {
     int node_changed(osmid_t id);
 
     void ways_set(osmium::Way const &way, bool extra_tags) override;
-    bool ways_get(osmid_t id, taglist_t &tags, nodelist_t &nodes) const;
-    size_t ways_get_list(const idlist_t &ids, idlist_t &way_ids,
-                      multitaglist_t &tags, multinodelist_t &nodes) const;
+    bool ways_get(osmid_t id, osmium::memory::Buffer &buffer) const override;
+    size_t ways_get_list(idlist_t const &ids, osmium::memory::Buffer &buffer) const override;
 
     int ways_delete(osmid_t id);
     int way_changed(osmid_t id);

--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -91,7 +91,7 @@ struct middle_ram_t : public middle_t {
     void commit(void);
 
     void nodes_set(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
-    size_t nodes_get_list(nodelist_t &out, const idlist_t nds) const;
+    size_t nodes_get_list(nodelist_t &out, osmium::WayNodeList const &nds) const override;
     int nodes_delete(osmid_t id);
     int node_changed(osmid_t id);
 

--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -108,7 +108,7 @@ struct middle_ram_t : public middle_t {
     int relations_delete(osmid_t id);
     int relation_changed(osmid_t id);
 
-    std::vector<osmid_t> relations_using_way(osmid_t way_id) const;
+    idlist_t relations_using_way(osmid_t way_id) const;
 
     void iterate_ways(middle_t::pending_processor& pf);
     void iterate_relations(pending_processor& pf);

--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -90,12 +90,12 @@ struct middle_ram_t : public middle_t {
     void end(void);
     void commit(void);
 
-    void nodes_set(osmid_t id, double lat, double lon, const taglist_t &tags);
+    void nodes_set(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
     size_t nodes_get_list(nodelist_t &out, const idlist_t nds) const;
     int nodes_delete(osmid_t id);
     int node_changed(osmid_t id);
 
-    void ways_set(osmid_t id, const idlist_t &nds, const taglist_t &tags);
+    void ways_set(osmium::Way const &way, bool extra_tags) override;
     bool ways_get(osmid_t id, taglist_t &tags, nodelist_t &nodes) const;
     size_t ways_get_list(const idlist_t &ids, idlist_t &way_ids,
                       multitaglist_t &tags, multinodelist_t &nodes) const;
@@ -104,7 +104,7 @@ struct middle_ram_t : public middle_t {
     int way_changed(osmid_t id);
 
     bool relations_get(osmid_t id, memberlist_t &members, taglist_t &tags) const;
-    void relations_set(osmid_t id, const memberlist_t &members, const taglist_t &tags);
+    void relations_set(osmium::Relation const &rel, bool extra_tags) override;
     int relations_delete(osmid_t id);
     int relation_changed(osmid_t id);
 
@@ -125,14 +125,24 @@ private:
         taglist_t tags;
         idlist_t ndids;
 
-        ramWay(const taglist_t &t, const idlist_t &n) : tags(t), ndids(n) {}
+        ramWay(osmium::Way const &way, bool add_attributes)
+        : tags(way.tags()), ndids(way.nodes())
+        {
+            if (add_attributes)
+                tags.add_attributes(way);
+        }
     };
 
     struct ramRel {
         taglist_t tags;
         memberlist_t members;
 
-        ramRel(const taglist_t &t, const memberlist_t &m) : tags(t), members(m) {}
+        ramRel(osmium::Relation const &rel, bool add_attributes)
+        : tags(rel.tags()), members(rel.members())
+        {
+            if (add_attributes)
+                tags.add_attributes(rel);
+        }
     };
 
     elem_cache_t<ramWay, 10> ways;

--- a/middle.hpp
+++ b/middle.hpp
@@ -9,6 +9,8 @@
 
 #include "osmtypes.hpp"
 
+#include <osmium/memory/buffer.hpp>
+
 #include <cstddef>
 #include <memory>
 
@@ -34,11 +36,16 @@ struct middle_query_t {
                               multinodelist_t &nodes) const = 0;
 
     /**
-     * Retrives a single relation from the relation storage.
+     * Retrives a single relation from the relation storage
+     * and stores it in the given osmium buffer.
+     *
+     * \param id     id of the relation to retrive
+     * \param buffer osmium buffer where to put the relation
+     *
+     *
      * \return true if the relation was retrieved
-     * \param id id of the relation to retrive
      */
-    virtual bool relations_get(osmid_t id, memberlist_t &members, taglist_t &tags) const = 0;
+    virtual bool relations_get(osmid_t id, osmium::memory::Buffer &buffer) const = 0;
 
     /*
      * Retrieve a list of relations with a particular way as a member

--- a/middle.hpp
+++ b/middle.hpp
@@ -20,7 +20,7 @@ struct options_t;
 struct middle_query_t {
     virtual ~middle_query_t() {}
 
-    virtual size_t nodes_get_list(nodelist_t &out, const idlist_t nds) const = 0;
+    virtual size_t nodes_get_list(nodelist_t &out, osmium::WayNodeList const &nds) const = 0;
 
     /**
      * Retrives a single way from the ways storage.

--- a/middle.hpp
+++ b/middle.hpp
@@ -73,9 +73,9 @@ struct middle_t : public middle_query_t {
     virtual void end(void) = 0;
     virtual void commit(void) = 0;
 
-    virtual void nodes_set(osmium::Node const &node, double lat, double lon, bool extra_tags) = 0;
-    virtual void ways_set(osmium::Way const &way, bool extra_tags) = 0;
-    virtual void relations_set(osmium::Relation const &rel, bool extra_tags) = 0;
+    virtual void nodes_set(osmium::Node const &node, double lat, double lon) = 0;
+    virtual void ways_set(osmium::Way const &way) = 0;
+    virtual void relations_set(osmium::Relation const &rel) = 0;
 
     struct pending_processor {
         virtual ~pending_processor() {}

--- a/middle.hpp
+++ b/middle.hpp
@@ -63,9 +63,9 @@ struct middle_t : public middle_query_t {
     virtual void end(void) = 0;
     virtual void commit(void) = 0;
 
-    virtual void nodes_set(osmid_t id, double lat, double lon, const taglist_t &tags) = 0;
-    virtual void ways_set(osmid_t id, const idlist_t &nds, const taglist_t &tags) = 0;
-    virtual void relations_set(osmid_t id, const memberlist_t &members, const taglist_t &tags) = 0;
+    virtual void nodes_set(osmium::Node const &node, double lat, double lon, bool extra_tags) = 0;
+    virtual void ways_set(osmium::Way const &way, bool extra_tags) = 0;
+    virtual void relations_set(osmium::Relation const &rel, bool extra_tags) = 0;
 
     struct pending_processor {
         virtual ~pending_processor() {}

--- a/middle.hpp
+++ b/middle.hpp
@@ -25,15 +25,19 @@ struct middle_query_t {
     virtual size_t nodes_get_list(nodelist_t &out, osmium::WayNodeList const &nds) const = 0;
 
     /**
-     * Retrives a single way from the ways storage.
+     * Retrives a single way from the ways storage
+     * and stores it in the given osmium buffer.
+     *
+     * \param id     id of the way to retrive
+     * \param buffer osmium buffer where to put the way
+     *
+     * The function does not retrieve the node locations.
+     *
      * \return true if the way was retrieved
-     * \param id id of the way to retrive
      */
-    virtual bool ways_get(osmid_t id, taglist_t &tags, nodelist_t &nodes) const = 0;
+    virtual bool ways_get(osmid_t id, osmium::memory::Buffer &buffer) const = 0;
 
-    virtual size_t ways_get_list(const idlist_t &ids, idlist_t &way_ids,
-                              multitaglist_t &tags,
-                              multinodelist_t &nodes) const = 0;
+    virtual size_t ways_get_list(idlist_t const &ids, osmium::memory::Buffer &buffer) const = 0;
 
     /**
      * Retrives a single relation from the relation storage
@@ -41,7 +45,6 @@ struct middle_query_t {
      *
      * \param id     id of the relation to retrive
      * \param buffer osmium buffer where to put the relation
-     *
      *
      * \return true if the relation was retrieved
      */

--- a/node-persistent-cache.cpp
+++ b/node-persistent-cache.cpp
@@ -417,7 +417,7 @@ int node_persistent_cache::get(osmNode *out, osmid_t id)
     return 0;
 }
 
-size_t node_persistent_cache::get_list(nodelist_t &out, const idlist_t nds)
+size_t node_persistent_cache::get_list(nodelist_t &out, osmium::WayNodeList const &nds)
 {
     set_read_mode();
 
@@ -426,10 +426,10 @@ size_t node_persistent_cache::get_list(nodelist_t &out, const idlist_t nds)
     bool need_fetch = false;
     for (size_t i = 0; i < nds.size(); ++i) {
         /* Check cache first */
-        if (ram_cache->get(&out[i], nds[i]) != 0) {
+        if (ram_cache->get(&out[i], nds[i].ref()) != 0) {
             /* In order to have a higher OS level I/O queue depth
                issue posix_fadvise(WILLNEED) requests for all I/O */
-            nodes_prefetch_async(nds[i]);
+            nodes_prefetch_async(nds[i].ref());
             need_fetch = true;
         }
     }
@@ -439,7 +439,7 @@ size_t node_persistent_cache::get_list(nodelist_t &out, const idlist_t nds)
     size_t wrtidx = 0;
     for (size_t i = 0; i < nds.size(); i++) {
         if (std::isnan(out[i].lat) && std::isnan(out[i].lon)) {
-            if (get(&(out[wrtidx]), nds[i]) == 0)
+            if (get(&(out[wrtidx]), nds[i].ref()) == 0)
                 wrtidx++;
         } else {
             if (wrtidx < i)

--- a/node-persistent-cache.hpp
+++ b/node-persistent-cache.hpp
@@ -57,7 +57,7 @@ struct node_persistent_cache : public boost::noncopyable
 
     void set(osmid_t id, double lat, double lon);
     int get(osmNode *out, osmid_t id);
-    size_t get_list(nodelist_t &out, const idlist_t nds);
+    size_t get_list(nodelist_t &out, osmium::WayNodeList const &nds);
 
 private:
 

--- a/node-ram-cache.cpp
+++ b/node-ram-cache.cpp
@@ -396,7 +396,7 @@ node_ram_cache::~node_ram_cache() {
   }
 }
 
-void node_ram_cache::set(osmid_t id, double lat, double lon, const taglist_t &) {
+void node_ram_cache::set(osmid_t id, double lat, double lon) {
     if ((id > 0 && id >> BLOCK_SHIFT >> 32) || (id < 0 && ~id >> BLOCK_SHIFT >> 32 )) {
         fprintf(stderr, "\nAbsolute node IDs must not be larger than %" PRId64 " (got%" PRId64 " )\n",
                 (int64_t) 1 << 42, (int64_t) id);

--- a/node-ram-cache.hpp
+++ b/node-ram-cache.hpp
@@ -109,7 +109,7 @@ struct node_ram_cache : public boost::noncopyable
     node_ram_cache(int strategy, int cacheSizeMB, int fixpointscale);
     ~node_ram_cache();
 
-    void set(osmid_t id, double lat, double lon, const taglist_t &tags);
+    void set(osmid_t id, double lat, double lon);
     int get(osmNode *out, osmid_t id);
 
 private:

--- a/osm2pgsql.cpp
+++ b/osm2pgsql.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
         std::vector<std::shared_ptr<output_t> > outputs = output_t::create_outputs(middle.get(), options);
 
         //let osmdata orchestrate between the middle and the outs
-        osmdata_t osmdata(middle, outputs);
+        osmdata_t osmdata(middle, outputs, options.projection, options.extra_attributes);
 
         fprintf(stderr, "Using projection SRS %d (%s)\n",
                 options.projection->target_srs(),
@@ -82,9 +82,7 @@ int main(int argc, char *argv[])
             fprintf(stderr, "\nReading in file: %s\n", filename.c_str());
             time_t start = time(nullptr);
 
-            parse_osmium_t parser(options.extra_attributes,
-                                  options.bbox, options.projection.get(),
-                                  options.append, &osmdata);
+            parse_osmium_t parser(options.bbox, options.append, &osmdata);
             parser.stream_file(filename, options.input_reader);
 
             stats.update(parser.stats());

--- a/osm2pgsql.cpp
+++ b/osm2pgsql.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
         std::vector<std::shared_ptr<output_t> > outputs = output_t::create_outputs(middle.get(), options);
 
         //let osmdata orchestrate between the middle and the outs
-        osmdata_t osmdata(middle, outputs, options.projection, options.extra_attributes);
+        osmdata_t osmdata(middle, outputs, options.projection);
 
         fprintf(stderr, "Using projection SRS %d (%s)\n",
                 options.projection->target_srs(),

--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -43,7 +43,7 @@ int osmdata_t::node_add(osmium::Node const &node) {
         tags.add_attributes(node);
     }
 
-    mid->nodes_set(node.id(), c.y, c.x, tags);
+    mid->nodes_set(node, c.y, c.x, extra_attributes);
 
     // guarantee that we use the same values as in the node cache
     ramNode n(c.x, c.y);
@@ -62,7 +62,7 @@ int osmdata_t::way_add(osmium::Way const &way) {
     }
     idlist_t nodes(way.nodes());
 
-    mid->ways_set(way.id(), nodes, tags);
+    mid->ways_set(way, extra_attributes);
 
     int status = 0;
     for (auto& out: outs) {
@@ -78,7 +78,7 @@ int osmdata_t::relation_add(osmium::Relation const &rel) {
     }
     memberlist_t members(rel.members());
 
-    mid->relations_set(rel.id(), members, tags);
+    mid->relations_set(rel, extra_attributes);
 
     int status = 0;
     for (auto& out: outs) {
@@ -97,7 +97,7 @@ int osmdata_t::node_modify(osmium::Node const &node) {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
     slim->nodes_delete(node.id());
-    slim->nodes_set(node.id(), c.y, c.x, tags);
+    slim->nodes_set(node, c.y, c.x, extra_attributes);
 
     // guarantee that we use the same values as in the node cache
     ramNode n(c.x, c.y);
@@ -122,7 +122,7 @@ int osmdata_t::way_modify(osmium::Way const &way) {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
     slim->ways_delete(way.id());
-    slim->ways_set(way.id(), nodes, tags);
+    slim->ways_set(way, extra_attributes);
 
     int status = 0;
     for (auto& out: outs) {
@@ -144,7 +144,7 @@ int osmdata_t::relation_modify(osmium::Relation const &rel) {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
     slim->relations_delete(rel.id());
-    slim->relations_set(rel.id(), members, tags);
+    slim->relations_set(rel, extra_attributes);
 
     int status = 0;
     for (auto& out: outs) {

--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -36,12 +36,9 @@ osmdata_t::~osmdata_t()
 {
 }
 
-int osmdata_t::node_add(osmium::Node const &node) {
+int osmdata_t::node_add(osmium::Node const &node)
+{
     auto c = projection->reproject(node.location());
-    taglist_t tags(node.tags());
-    if (extra_attributes) {
-        tags.add_attributes(node);
-    }
 
     mid->nodes_set(node, c.y, c.x, extra_attributes);
 
@@ -50,49 +47,36 @@ int osmdata_t::node_add(osmium::Node const &node) {
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->node_add(node.id(), n.lat(), n.lon(), tags);
+        status |= out->node_add(node, n.lat(), n.lon(), extra_attributes);
     }
     return status;
 }
 
-int osmdata_t::way_add(osmium::Way const &way) {
-    taglist_t tags(way.tags());
-    if (extra_attributes) {
-        tags.add_attributes(way);
-    }
-    idlist_t nodes(way.nodes());
-
+int osmdata_t::way_add(osmium::Way const &way)
+{
     mid->ways_set(way, extra_attributes);
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->way_add(way.id(), nodes, tags);
+        status |= out->way_add(way, extra_attributes);
     }
     return status;
 }
 
-int osmdata_t::relation_add(osmium::Relation const &rel) {
-    taglist_t tags(rel.tags());
-    if (extra_attributes) {
-        tags.add_attributes(rel);
-    }
-    memberlist_t members(rel.members());
-
+int osmdata_t::relation_add(osmium::Relation const &rel)
+{
     mid->relations_set(rel, extra_attributes);
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->relation_add(rel.id(), members, tags);
+        status |= out->relation_add(rel, extra_attributes);
     }
     return status;
 }
 
-int osmdata_t::node_modify(osmium::Node const &node) {
+int osmdata_t::node_modify(osmium::Node const &node)
+{
     auto c = projection->reproject(node.location());
-    taglist_t tags(node.tags());
-    if (extra_attributes) {
-        tags.add_attributes(node);
-    }
 
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
@@ -104,7 +88,7 @@ int osmdata_t::node_modify(osmium::Node const &node) {
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->node_modify(node.id(), n.lat(), n.lon(), tags);
+        status |= out->node_modify(node, n.lat(), n.lon(), extra_attributes);
     }
 
     slim->node_changed(node.id());
@@ -112,12 +96,8 @@ int osmdata_t::node_modify(osmium::Node const &node) {
     return status;
 }
 
-int osmdata_t::way_modify(osmium::Way const &way) {
-    taglist_t tags(way.tags());
-    if (extra_attributes) {
-        tags.add_attributes(way);
-    }
-
+int osmdata_t::way_modify(osmium::Way const &way)
+{
     idlist_t nodes(way.nodes());
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
@@ -126,7 +106,7 @@ int osmdata_t::way_modify(osmium::Way const &way) {
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->way_modify(way.id(), nodes, tags);
+        status |= out->way_modify(way, extra_attributes);
     }
 
     slim->way_changed(way.id());
@@ -134,13 +114,8 @@ int osmdata_t::way_modify(osmium::Way const &way) {
     return status;
 }
 
-int osmdata_t::relation_modify(osmium::Relation const &rel) {
-    taglist_t tags(rel.tags());
-    if (extra_attributes) {
-        tags.add_attributes(rel);
-    }
-    memberlist_t members(rel.members());
-
+int osmdata_t::relation_modify(osmium::Relation const &rel)
+{
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
     slim->relations_delete(rel.id());
@@ -148,7 +123,7 @@ int osmdata_t::relation_modify(osmium::Relation const &rel) {
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->relation_modify(rel.id(), members, tags);
+        status |= out->relation_modify(rel, extra_attributes);
     }
 
     slim->relation_changed(rel.id());

--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -11,13 +11,20 @@
 #include "osmdata.hpp"
 #include "output.hpp"
 
-osmdata_t::osmdata_t(std::shared_ptr<middle_t> mid_, const std::shared_ptr<output_t>& out_): mid(mid_)
+osmdata_t::osmdata_t(std::shared_ptr<middle_t> mid_,
+                     std::shared_ptr<output_t> const &out_,
+                     std::shared_ptr<reprojection> proj,
+                     bool extra_attrs)
+: mid(mid_), projection(proj), extra_attributes(extra_attrs)
 {
     outs.push_back(out_);
 }
 
-osmdata_t::osmdata_t(std::shared_ptr<middle_t> mid_, const std::vector<std::shared_ptr<output_t> > &outs_)
-    : mid(mid_), outs(outs_)
+osmdata_t::osmdata_t(std::shared_ptr<middle_t> mid_,
+                     std::vector<std::shared_ptr<output_t> > const &outs_,
+                     std::shared_ptr<reprojection> proj,
+                     bool extra_attrs)
+: mid(mid_), outs(outs_), projection(proj), extra_attributes(extra_attrs)
 {
     if (outs.empty()) {
         throw std::runtime_error("Must have at least one output, but none have "
@@ -29,86 +36,122 @@ osmdata_t::~osmdata_t()
 {
 }
 
-int osmdata_t::node_add(osmid_t id, double lat, double lon, const taglist_t &tags) {
-    mid->nodes_set(id, lat, lon, tags);
+int osmdata_t::node_add(osmium::Node const &node) {
+    auto c = projection->reproject(node.location());
+    taglist_t tags(node.tags());
+    if (extra_attributes) {
+        tags.add_attributes(node);
+    }
+
+    mid->nodes_set(node.id(), c.y, c.x, tags);
 
     // guarantee that we use the same values as in the node cache
-    ramNode n(lon, lat);
+    ramNode n(c.x, c.y);
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->node_add(id, n.lat(), n.lon(), tags);
+        status |= out->node_add(node.id(), n.lat(), n.lon(), tags);
     }
     return status;
 }
 
-int osmdata_t::way_add(osmid_t id, const idlist_t &nodes, const taglist_t &tags) {
-    mid->ways_set(id, nodes, tags);
+int osmdata_t::way_add(osmium::Way const &way) {
+    taglist_t tags(way.tags());
+    if (extra_attributes) {
+        tags.add_attributes(way);
+    }
+    idlist_t nodes(way.nodes());
+
+    mid->ways_set(way.id(), nodes, tags);
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->way_add(id, nodes, tags);
+        status |= out->way_add(way.id(), nodes, tags);
     }
     return status;
 }
 
-int osmdata_t::relation_add(osmid_t id, const memberlist_t &members, const taglist_t &tags) {
-    mid->relations_set(id, members, tags);
+int osmdata_t::relation_add(osmium::Relation const &rel) {
+    taglist_t tags(rel.tags());
+    if (extra_attributes) {
+        tags.add_attributes(rel);
+    }
+    memberlist_t members(rel.members());
+
+    mid->relations_set(rel.id(), members, tags);
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->relation_add(id, members, tags);
+        status |= out->relation_add(rel.id(), members, tags);
     }
     return status;
 }
 
-int osmdata_t::node_modify(osmid_t id, double lat, double lon, const taglist_t &tags) {
+int osmdata_t::node_modify(osmium::Node const &node) {
+    auto c = projection->reproject(node.location());
+    taglist_t tags(node.tags());
+    if (extra_attributes) {
+        tags.add_attributes(node);
+    }
+
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
-    slim->nodes_delete(id);
-    slim->nodes_set(id, lat, lon, tags);
+    slim->nodes_delete(node.id());
+    slim->nodes_set(node.id(), c.y, c.x, tags);
 
     // guarantee that we use the same values as in the node cache
-    ramNode n(lon, lat);
+    ramNode n(c.x, c.y);
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->node_modify(id, n.lat(), n.lon(), tags);
+        status |= out->node_modify(node.id(), n.lat(), n.lon(), tags);
     }
 
-    slim->node_changed(id);
+    slim->node_changed(node.id());
 
     return status;
 }
 
-int osmdata_t::way_modify(osmid_t id, const idlist_t &nodes, const taglist_t &tags) {
+int osmdata_t::way_modify(osmium::Way const &way) {
+    taglist_t tags(way.tags());
+    if (extra_attributes) {
+        tags.add_attributes(way);
+    }
+
+    idlist_t nodes(way.nodes());
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
-    slim->ways_delete(id);
-    slim->ways_set(id, nodes, tags);
+    slim->ways_delete(way.id());
+    slim->ways_set(way.id(), nodes, tags);
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->way_modify(id, nodes, tags);
+        status |= out->way_modify(way.id(), nodes, tags);
     }
 
-    slim->way_changed(id);
+    slim->way_changed(way.id());
 
     return status;
 }
 
-int osmdata_t::relation_modify(osmid_t id, const memberlist_t &members, const taglist_t &tags) {
+int osmdata_t::relation_modify(osmium::Relation const &rel) {
+    taglist_t tags(rel.tags());
+    if (extra_attributes) {
+        tags.add_attributes(rel);
+    }
+    memberlist_t members(rel.members());
+
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
-    slim->relations_delete(id);
-    slim->relations_set(id, members, tags);
+    slim->relations_delete(rel.id());
+    slim->relations_set(rel.id(), members, tags);
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->relation_modify(id, members, tags);
+        status |= out->relation_modify(rel.id(), members, tags);
     }
 
-    slim->relation_changed(id);
+    slim->relation_changed(rel.id());
 
     return status;
 }

--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -13,18 +13,16 @@
 
 osmdata_t::osmdata_t(std::shared_ptr<middle_t> mid_,
                      std::shared_ptr<output_t> const &out_,
-                     std::shared_ptr<reprojection> proj,
-                     bool extra_attrs)
-: mid(mid_), projection(proj), extra_attributes(extra_attrs)
+                     std::shared_ptr<reprojection> proj)
+: mid(mid_), projection(proj)
 {
     outs.push_back(out_);
 }
 
 osmdata_t::osmdata_t(std::shared_ptr<middle_t> mid_,
                      std::vector<std::shared_ptr<output_t> > const &outs_,
-                     std::shared_ptr<reprojection> proj,
-                     bool extra_attrs)
-: mid(mid_), outs(outs_), projection(proj), extra_attributes(extra_attrs)
+                     std::shared_ptr<reprojection> proj)
+: mid(mid_), outs(outs_), projection(proj)
 {
     if (outs.empty()) {
         throw std::runtime_error("Must have at least one output, but none have "
@@ -40,36 +38,36 @@ int osmdata_t::node_add(osmium::Node const &node)
 {
     auto c = projection->reproject(node.location());
 
-    mid->nodes_set(node, c.y, c.x, extra_attributes);
+    mid->nodes_set(node, c.y, c.x);
 
     // guarantee that we use the same values as in the node cache
     ramNode n(c.x, c.y);
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->node_add(node, n.lat(), n.lon(), extra_attributes);
+        status |= out->node_add(node, n.lat(), n.lon());
     }
     return status;
 }
 
 int osmdata_t::way_add(osmium::Way const &way)
 {
-    mid->ways_set(way, extra_attributes);
+    mid->ways_set(way);
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->way_add(way, extra_attributes);
+        status |= out->way_add(way);
     }
     return status;
 }
 
 int osmdata_t::relation_add(osmium::Relation const &rel)
 {
-    mid->relations_set(rel, extra_attributes);
+    mid->relations_set(rel);
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->relation_add(rel, extra_attributes);
+        status |= out->relation_add(rel);
     }
     return status;
 }
@@ -81,14 +79,14 @@ int osmdata_t::node_modify(osmium::Node const &node)
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
     slim->nodes_delete(node.id());
-    slim->nodes_set(node, c.y, c.x, extra_attributes);
+    slim->nodes_set(node, c.y, c.x);
 
     // guarantee that we use the same values as in the node cache
     ramNode n(c.x, c.y);
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->node_modify(node, n.lat(), n.lon(), extra_attributes);
+        status |= out->node_modify(node, n.lat(), n.lon());
     }
 
     slim->node_changed(node.id());
@@ -102,11 +100,11 @@ int osmdata_t::way_modify(osmium::Way const &way)
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
     slim->ways_delete(way.id());
-    slim->ways_set(way, extra_attributes);
+    slim->ways_set(way);
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->way_modify(way, extra_attributes);
+        status |= out->way_modify(way);
     }
 
     slim->way_changed(way.id());
@@ -119,11 +117,11 @@ int osmdata_t::relation_modify(osmium::Relation const &rel)
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
     slim->relations_delete(rel.id());
-    slim->relations_set(rel, extra_attributes);
+    slim->relations_set(rel);
 
     int status = 0;
     for (auto& out: outs) {
-        status |= out->relation_modify(rel, extra_attributes);
+        status |= out->relation_modify(rel);
     }
 
     slim->relation_changed(rel.id());

--- a/osmdata.hpp
+++ b/osmdata.hpp
@@ -12,23 +12,30 @@
 
 class output_t;
 struct middle_t;
+class reprojection;
 
 class osmdata_t {
 public:
-    osmdata_t(std::shared_ptr<middle_t> mid_, const std::shared_ptr<output_t>& out_);
-    osmdata_t(std::shared_ptr<middle_t> mid_, const std::vector<std::shared_ptr<output_t> > &outs_);
+    osmdata_t(std::shared_ptr<middle_t> mid_,
+              std::shared_ptr<output_t> const &out_,
+              std::shared_ptr<reprojection> proj,
+              bool extra_attributes);
+    osmdata_t(std::shared_ptr<middle_t> mid_,
+              std::vector<std::shared_ptr<output_t> > const &outs_,
+              std::shared_ptr<reprojection> proj,
+              bool extra_attributes);
     ~osmdata_t();
 
     void start();
     void stop();
 
-    int node_add(osmid_t id, double lat, double lon, const taglist_t &tags);
-    int way_add(osmid_t id, const idlist_t &nodes, const taglist_t &tags);
-    int relation_add(osmid_t id, const memberlist_t &members, const taglist_t &tags);
+    int node_add(osmium::Node const &node);
+    int way_add(osmium::Way const &way);
+    int relation_add(osmium::Relation const &rel);
 
-    int node_modify(osmid_t id, double lat, double lon, const taglist_t &tags);
-    int way_modify(osmid_t id, const idlist_t &nodes, const taglist_t &tags);
-    int relation_modify(osmid_t id, const memberlist_t &members, const taglist_t &tags);
+    int node_modify(osmium::Node const &node);
+    int way_modify(osmium::Way const &way);
+    int relation_modify(osmium::Relation const &rel);
 
     int node_delete(osmid_t id);
     int way_delete(osmid_t id);
@@ -37,6 +44,8 @@ public:
 private:
     std::shared_ptr<middle_t> mid;
     std::vector<std::shared_ptr<output_t> > outs;
+    std::shared_ptr<reprojection> projection;
+    bool extra_attributes;
 };
 
 #endif

--- a/osmdata.hpp
+++ b/osmdata.hpp
@@ -18,12 +18,10 @@ class osmdata_t {
 public:
     osmdata_t(std::shared_ptr<middle_t> mid_,
               std::shared_ptr<output_t> const &out_,
-              std::shared_ptr<reprojection> proj,
-              bool extra_attributes);
+              std::shared_ptr<reprojection> proj);
     osmdata_t(std::shared_ptr<middle_t> mid_,
               std::vector<std::shared_ptr<output_t> > const &outs_,
-              std::shared_ptr<reprojection> proj,
-              bool extra_attributes);
+              std::shared_ptr<reprojection> proj);
     ~osmdata_t();
 
     void start();
@@ -45,7 +43,6 @@ private:
     std::shared_ptr<middle_t> mid;
     std::vector<std::shared_ptr<output_t> > outs;
     std::shared_ptr<reprojection> projection;
-    bool extra_attributes;
 };
 
 #endif

--- a/osmtypes.hpp
+++ b/osmtypes.hpp
@@ -104,20 +104,28 @@ public:
     return 0;
   }
 
+  static bool value_to_bool(char const *value, bool defval)
+  {
+      if (!defval &&
+          (strcmp(value, "yes") == 0
+           || strcmp(value, "true") == 0
+           || strcmp(value, "1") == 0))
+          return true;
+      if (defval &&
+          (strcmp(value, "no") == 0 || strcmp(value, "false") == 0 || strcmp(value, "0") == 0))
+          return false;
+
+      return defval;
+  }
+
   bool get_bool(const std::string &key, bool defval) const
   {
-    for (base_t::const_iterator it = begin() ; it != end(); ++it)
-      if (it->key == key) {
-          if (!defval &&
-              (it->value == "yes" || it->value == "true" || it->value == "1"))
-              return true;
-          if (defval &&
-              (it->value == "no" || it->value == "false" || it->value == "0"))
-              return false;
-          return defval;
-      }
+      for (auto const &t : *this)
+          if (t.key == key) {
+              return value_to_bool(t.value.c_str(), defval);
+          }
 
-    return defval;
+      return defval;
   }
 
   void push_dedupe(const tag_t& t)
@@ -164,6 +172,6 @@ struct idlist_t : public std::vector<osmid_t> {
     }
 };
 
-typedef std::vector<const std::string *> rolelist_t;
+typedef std::vector<char const *> rolelist_t;
 
 #endif

--- a/osmtypes.hpp
+++ b/osmtypes.hpp
@@ -14,6 +14,7 @@
 #include <cmath>
 
 #include <osmium/osm.hpp>
+#include <osmium/builder/attr.hpp>
 
 typedef int64_t osmid_t;
 #define strtoosmid strtoll
@@ -37,6 +38,11 @@ struct member {
     osmid_t id;
     std::string role;
 
+    operator osmium::builder::attr::member_type const() const
+    {
+        return osmium::builder::attr::member_type(type, id, role.c_str());
+    }
+
     member(osmium::item_type t, osmid_t i, const std::string &r)
     : type(t), id(i), role(r) {}
 };
@@ -49,11 +55,26 @@ struct memberlist_t : public std::vector<member> {
             emplace_back(m.type(), m.ref(), m.role());
         }
     }
+
+    std::vector<osmium::builder::attr::member_type> for_builder() const
+    {
+        std::vector<osmium::builder::attr::member_type> ret;
+        for (auto const &m : *this) {
+            ret.emplace_back(m.type, m.id, m.role.c_str());
+        }
+
+        return ret;
+    }
 };
 
 struct tag_t {
   std::string key;
   std::string value;
+
+  operator std::pair<char const *, char const *> const() const
+  {
+      return std::pair<char const *, char const *>(key.c_str(), value.c_str());
+  }
 
   tag_t(const std::string &k, const std::string &v) : key(k), value(v) {}
 };

--- a/osmtypes.hpp
+++ b/osmtypes.hpp
@@ -41,7 +41,15 @@ struct member {
     : type(t), id(i), role(r) {}
 };
 
-typedef std::vector<member> memberlist_t;
+struct memberlist_t : public std::vector<member> {
+    memberlist_t() {}
+
+    explicit memberlist_t(osmium::RelationMemberList const &list) {
+        for (auto const &m: list) {
+            emplace_back(m.type(), m.ref(), m.role());
+        }
+    }
+};
 
 struct tag_t {
   std::string key;
@@ -56,6 +64,24 @@ class taglist_t : public std::vector<tag_t> {
   typedef std::vector<tag_t> base_t;
 
 public:
+  taglist_t() {}
+
+  explicit taglist_t(osmium::TagList const &list)
+  {
+      for (auto const &t : list) {
+          emplace_back(t.key(), t.value());
+      }
+  }
+
+  void add_attributes(const osmium::OSMObject &obj)
+  {
+      emplace_back("osm_user", obj.user());
+      emplace_back("osm_uid", std::to_string(obj.uid()));
+      emplace_back("osm_version", std::to_string(obj.version()));
+      emplace_back("osm_timestamp", obj.timestamp().to_iso());
+      emplace_back("osm_changeset", std::to_string(obj.changeset()));
+  }
+
   const tag_t *find(const std::string &key) const { return _find(key); }
 
   tag_t *find(const std::string &key) {  return const_cast<tag_t *>(_find(key)); }
@@ -128,7 +154,15 @@ private:
 
 typedef std::vector<taglist_t> multitaglist_t;
 
-typedef std::vector<osmid_t> idlist_t;
+struct idlist_t : public std::vector<osmid_t> {
+    idlist_t() {}
+
+    explicit idlist_t(osmium::NodeRefList const &list) {
+        for (auto const &n : list) {
+            push_back(n.ref());
+        }
+    }
+};
 
 typedef std::vector<const std::string *> rolelist_t;
 

--- a/osmtypes.hpp
+++ b/osmtypes.hpp
@@ -13,12 +13,12 @@
 #include <vector>
 #include <cmath>
 
+#include <osmium/osm.hpp>
+
 typedef int64_t osmid_t;
 #define strtoosmid strtoll
 #define PRIdOSMID PRId64
 #define POSTGRES_OSMID_TYPE "int8"
-
-enum OsmType { OSMTYPE_WAY, OSMTYPE_NODE, OSMTYPE_RELATION };
 
 struct osmNode {
   double lon;
@@ -33,11 +33,12 @@ typedef std::vector<osmNode> nodelist_t;
 typedef std::vector<nodelist_t> multinodelist_t;
 
 struct member {
-  OsmType type;
-  osmid_t id;
-  std::string role;
+    osmium::item_type type;
+    osmid_t id;
+    std::string role;
 
-  member(OsmType t, osmid_t i, const std::string &r) : type(t), id(i), role(r) {}
+    member(osmium::item_type t, osmid_t i, const std::string &r)
+    : type(t), id(i), role(r) {}
 };
 
 typedef std::vector<member> memberlist_t;

--- a/output-gazetteer.cpp
+++ b/output-gazetteer.cpp
@@ -691,7 +691,7 @@ int output_gazetteer_t::process_way(osmium::Way const &way)
     if (places.has_data()) {
         /* Fetch the node details */
         nodelist_t nodes;
-        m_mid->nodes_get_list(nodes, idlist_t(way.nodes()));
+        m_mid->nodes_get_list(nodes, way.nodes());
 
         /* Get the geometry of the object */
         auto geom = builder.get_wkb_simple(nodes, 1);

--- a/output-gazetteer.cpp
+++ b/output-gazetteer.cpp
@@ -734,7 +734,7 @@ int output_gazetteer_t::process_relation(osmid_t id, const memberlist_t &members
     idlist_t xid2;
     for (const auto& member: members) {
         /* only interested in ways */
-        if (member.type == OSMTYPE_WAY)
+        if (member.type == osmium::item_type::way)
             xid2.push_back(member.id);
     }
 

--- a/output-gazetteer.cpp
+++ b/output-gazetteer.cpp
@@ -11,6 +11,7 @@
 #include "util.hpp"
 
 #include <algorithm>
+#include <cstring>
 #include <iostream>
 #include <memory>
 
@@ -446,9 +447,13 @@ void place_tag_processor::copy_out(osmium::OSMObject const &o,
         if (!address.empty()) {
             for (const auto entry: address) {
                 if (strcmp(entry->key(), "tiger:county") == 0) {
-                    auto *end = strchrnul(entry->value(), ',');
-                    escape(std::string(entry->value(), (size_t) (end - entry->value())),
-                           buffer);
+                    auto *end = strchr(entry->value(), ',');
+                    if (end) {
+                        escape(std::string(entry->value(), (size_t) (end - entry->value())),
+                               buffer);
+                    } else {
+                        escape(entry->value(), buffer);
+                    }
                     buffer += " county";
                 } else {
                     escape(entry->value(), buffer);

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -176,34 +176,62 @@ public:
     void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) {}
     int pending_relation(osmid_t id, int exists) { return 0; }
 
-    int node_add(osmid_t id, double lat, double lon, const taglist_t &tags)
+    int node_add(osmium::Node const &node, double lat, double lon, bool extra_tags)
     {
-        return process_node(id, lat, lon, tags);
+        taglist_t tags(node.tags());
+        if (extra_tags) {
+            tags.add_attributes(node);
+        }
+        return process_node(node.id(), lat, lon, tags);
     }
 
-    int way_add(osmid_t id, const idlist_t &nodes, const taglist_t &tags)
+    int way_add(osmium::Way const &way, bool extra_tags)
     {
-        return process_way(id, nodes, tags);
+        taglist_t tags(way.tags());
+        if (extra_tags) {
+            tags.add_attributes(way);
+        }
+        idlist_t nodes(way.nodes());
+        return process_way(way.id(), nodes, tags);
     }
 
-    int relation_add(osmid_t id, const memberlist_t &members, const taglist_t &tags)
+    int relation_add(osmium::Relation const &rel, bool extra_tags)
     {
-        return process_relation(id, members, tags);
+        taglist_t tags(rel.tags());
+        if (extra_tags) {
+            tags.add_attributes(rel);
+        }
+        memberlist_t members(rel.members());
+        return process_relation(rel.id(), members, tags);
     }
 
-    int node_modify(osmid_t id, double lat, double lon, const taglist_t &tags)
+    int node_modify(osmium::Node const &node, double lat, double lon, bool extra_tags)
     {
-        return process_node(id, lat, lon, tags);
+        taglist_t tags(node.tags());
+        if (extra_tags) {
+            tags.add_attributes(node);
+        }
+        return process_node(node.id(), lat, lon, tags);
     }
 
-    int way_modify(osmid_t id, const idlist_t &nodes, const taglist_t &tags)
+    int way_modify(osmium::Way const &way, bool extra_tags)
     {
-        return process_way(id, nodes, tags);
+        taglist_t tags(way.tags());
+        if (extra_tags) {
+            tags.add_attributes(way);
+        }
+        idlist_t nodes(way.nodes());
+        return process_way(way.id(), nodes, tags);
     }
 
-    int relation_modify(osmid_t id, const memberlist_t &members, const taglist_t &tags)
+    int relation_modify(osmium::Relation const &rel, bool extra_tags)
     {
-        return process_relation(id, members, tags);
+        taglist_t tags(rel.tags());
+        if (extra_tags) {
+            tags.add_attributes(rel);
+        }
+        memberlist_t members(rel.members());
+        return process_relation(rel.id(), members, tags);
     }
 
     int node_delete(osmid_t id)

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -6,6 +6,7 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/format.hpp>
+#include <osmium/memory/buffer.hpp>
 
 #include "geometry-builder.hpp"
 #include "osmtypes.hpp"
@@ -136,7 +137,8 @@ public:
       ConnectionError(NULL),
       copy_active(false),
       single_fmt("%1%"),
-      point_fmt("POINT(%.15g %.15g)")
+      point_fmt("POINT(%.15g %.15g)"),
+      osmium_buffer(PLACE_BUFFER_SIZE, osmium::memory::Buffer::auto_grow::yes)
     {
         buffer.reserve(PLACE_BUFFER_SIZE);
     }
@@ -149,7 +151,8 @@ public:
       copy_active(false),
       reproj(other.reproj),
       single_fmt(other.single_fmt),
-      point_fmt(other.point_fmt)
+      point_fmt(other.point_fmt),
+      osmium_buffer(PLACE_BUFFER_SIZE, osmium::memory::Buffer::auto_grow::yes)
     {
         buffer.reserve(PLACE_BUFFER_SIZE);
         builder.set_exclude_broken_polygon(m_options.excludepoly);
@@ -224,7 +227,7 @@ public:
     }
 
 private:
-    enum { PLACE_BUFFER_SIZE = 4092 };
+    enum { PLACE_BUFFER_SIZE = 4096 };
 
     void stop_copy(void);
     void delete_unused_classes(char osm_type, osmid_t osm_id);
@@ -271,8 +274,7 @@ private:
     // Need to be part of the class, so we have one per thread.
     boost::format single_fmt;
     boost::format point_fmt;
+    osmium::memory::Buffer osmium_buffer;
 };
-
-extern output_gazetteer_t out_gazetteer;
 
 #endif

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -170,11 +170,11 @@ public:
     void stop();
     void commit() {}
 
-    void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) {}
-    int pending_way(osmid_t id, int exists) { return 0; }
+    void enqueue_ways(pending_queue_t &, osmid_t, size_t, size_t&) {}
+    int pending_way(osmid_t, int) { return 0; }
 
-    void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) {}
-    int pending_relation(osmid_t id, int exists) { return 0; }
+    void enqueue_relations(pending_queue_t &, osmid_t, size_t, size_t&) {}
+    int pending_relation(osmid_t, int) { return 0; }
 
     int node_add(osmium::Node const &node, double lat, double lon, bool extra_tags)
     {

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -161,22 +161,22 @@ public:
 
     virtual ~output_gazetteer_t() {}
 
-    virtual std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const
+    std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const override
     {
         output_gazetteer_t *clone = new output_gazetteer_t(*this);
         clone->m_mid = cloned_middle;
         return std::shared_ptr<output_t>(clone);
     }
 
-    int start();
-    void stop();
-    void commit() {}
+    int start() override;
+    void stop() override;
+    void commit() override {}
 
-    void enqueue_ways(pending_queue_t &, osmid_t, size_t, size_t&) {}
-    int pending_way(osmid_t, int) { return 0; }
+    void enqueue_ways(pending_queue_t &, osmid_t, size_t, size_t&) override {}
+    int pending_way(osmid_t, int) override { return 0; }
 
-    void enqueue_relations(pending_queue_t &, osmid_t, size_t, size_t&) {}
-    int pending_relation(osmid_t, int) { return 0; }
+    void enqueue_relations(pending_queue_t &, osmid_t, size_t, size_t&) override {}
+    int pending_relation(osmid_t, int) override { return 0; }
 
     int node_add(osmium::Node const &node, double lat, double lon) override
     {
@@ -208,19 +208,19 @@ public:
         return process_relation(rel);
     }
 
-    int node_delete(osmid_t id)
+    int node_delete(osmid_t id) override
     {
         delete_place('N', id);
         return 0;
     }
 
-    int way_delete(osmid_t id)
+    int way_delete(osmid_t id) override
     {
         delete_place('W', id);
         return 0;
     }
 
-    int relation_delete(osmid_t id)
+    int relation_delete(osmid_t id) override
     {
         delete_place('R', id);
         return 0;

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -178,32 +178,32 @@ public:
     void enqueue_relations(pending_queue_t &, osmid_t, size_t, size_t&) {}
     int pending_relation(osmid_t, int) { return 0; }
 
-    int node_add(osmium::Node const &node, double lat, double lon, bool) override
+    int node_add(osmium::Node const &node, double lat, double lon) override
     {
         return process_node(node, lat, lon);
     }
 
-    int way_add(osmium::Way const &way, bool) override
+    int way_add(osmium::Way const &way) override
     {
         return process_way(way);
     }
 
-    int relation_add(osmium::Relation const &rel, bool) override
+    int relation_add(osmium::Relation const &rel) override
     {
         return process_relation(rel);
     }
 
-    int node_modify(osmium::Node const &node, double lat, double lon, bool) override
+    int node_modify(osmium::Node const &node, double lat, double lon) override
     {
         return process_node(node, lat, lon);
     }
 
-    int way_modify(osmium::Way const &way, bool) override
+    int way_modify(osmium::Way const &way) override
     {
         return process_way(way);
     }
 
-    int relation_modify(osmium::Relation const &rel, bool) override
+    int relation_modify(osmium::Relation const &rel) override
     {
         return process_relation(rel);
     }

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -195,7 +195,7 @@ int output_multi_t::way_add(osmium::Way const &way, bool extra_tags) {
 
 int output_multi_t::relation_add(osmium::Relation const &rel, bool extra_tags) {
     if (m_processor->interests(geometry_processor::interest_relation)
-        && rel.members().size() > 0) {
+        && rel.members().empty()) {
         return process_relation(rel, extra_tags, 0);
     }
     return 0;

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -195,7 +195,7 @@ int output_multi_t::way_add(osmium::Way const &way) {
 
 int output_multi_t::relation_add(osmium::Relation const &rel) {
     if (m_processor->interests(geometry_processor::interest_relation)
-        && rel.members().empty()) {
+        && !rel.members().empty()) {
         return process_relation(rel, 0);
     }
     return 0;

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -20,7 +20,7 @@ output_multi_t::output_multi_t(const std::string &name,
       m_export_list(new export_list(export_list_)),
       m_processor(processor_),
       //TODO: we could in fact have something that is interested in nodes and ways..
-      m_osm_type(m_processor->interests(geometry_processor::interest_node) ? OSMTYPE_NODE : OSMTYPE_WAY),
+      m_osm_type(m_processor->interests(geometry_processor::interest_node) ? osmium::item_type::node : osmium::item_type::way),
       m_table(new table_t(m_options.database_options.conninfo(), name, m_processor->column_type(),
                           m_export_list->normal_columns(m_osm_type),
                           m_options.hstore_columns, m_processor->srid(),

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -315,8 +315,7 @@ int output_multi_t::process_way(osmium::Way const &way, bool extra) {
                                               *m_export_list.get(), outtags, true);
     if (!filter) {
         //get the geom from the middle
-        idlist_t nodes(way.nodes());
-        if(m_way_helper.set(nodes, m_mid) < 1)
+        if(m_way_helper.set(way.nodes(), m_mid) < 1)
             return 0;
         //grab its geom
         auto geom = m_processor->process_way(m_way_helper.node_cache);

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -82,6 +82,7 @@ protected:
     expire_tiles m_expire;
     way_helper m_way_helper;
     relation_helper m_relation_helper;
+    osmium::memory::Buffer buffer;
 };
 
 #endif

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -67,7 +67,6 @@ protected:
     int process_node(osmium::Node const &node, bool extra, double lat, double lon);
     int process_way(osmium::Way const &way, bool extra);
     int reprocess_way(osmid_t id, const nodelist_t &nodes, const taglist_t &tags, bool exists);
-    int process_relation(osmid_t id, const memberlist_t &members, const taglist_t &tags, bool exists, bool pending=false);
     int process_relation(osmium::Relation const &rel, bool extra, bool exists, bool pending=false);
     void copy_node_to_table(osmid_t id, const std::string &geom, taglist_t &tags);
     void copy_to_table(const osmid_t id, const geometry_builder::pg_geom_t &geom, taglist_t &tags, int polygon);

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -74,7 +74,7 @@ protected:
     std::unique_ptr<tagtransform> m_tagtransform;
     std::unique_ptr<export_list> m_export_list;
     std::shared_ptr<geometry_processor> m_processor;
-    const OsmType m_osm_type;
+    osmium::item_type const m_osm_type;
     std::unique_ptr<table_t> m_table;
     id_tracker ways_pending_tracker, rels_pending_tracker;
     std::shared_ptr<id_tracker> ways_done_tracker;

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -66,7 +66,7 @@ protected:
     void delete_from_output(osmid_t id);
     int process_node(osmium::Node const &node, bool extra, double lat, double lon);
     int process_way(osmium::Way const &way, bool extra);
-    int reprocess_way(osmid_t id, const nodelist_t &nodes, const taglist_t &tags, bool exists);
+    int reprocess_way(osmium::Way const &way, bool exists);
     int process_relation(osmium::Relation const &rel, bool extra, bool exists, bool pending=false);
     void copy_node_to_table(osmid_t id, const std::string &geom, taglist_t &tags);
     void copy_to_table(const osmid_t id, const geometry_builder::pg_geom_t &geom, taglist_t &tags, int polygon);

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -44,13 +44,13 @@ public:
     void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added);
     int pending_relation(osmid_t id, int exists);
 
-    int node_add(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
-    int way_add(osmium::Way const &way, bool extra_tags) override;
-    int relation_add(osmium::Relation const &rel, bool extra_tags) override;
+    int node_add(osmium::Node const &node, double lat, double lon) override;
+    int way_add(osmium::Way const &way) override;
+    int relation_add(osmium::Relation const &rel) override;
 
-    int node_modify(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
-    int way_modify(osmium::Way const &way, bool extra_tags) override;
-    int relation_modify(osmium::Relation const &rel, bool extra_tags) override;
+    int node_modify(osmium::Node const &node, double lat, double lon) override;
+    int way_modify(osmium::Way const &way) override;
+    int relation_modify(osmium::Relation const &rel) override;
 
     int node_delete(osmid_t id);
     int way_delete(osmid_t id);
@@ -64,10 +64,10 @@ public:
 protected:
 
     void delete_from_output(osmid_t id);
-    int process_node(osmium::Node const &node, bool extra, double lat, double lon);
-    int process_way(osmium::Way const &way, bool extra);
+    int process_node(osmium::Node const &node, double lat, double lon);
+    int process_way(osmium::Way const &way);
     int reprocess_way(osmium::Way const &way, bool exists);
-    int process_relation(osmium::Relation const &rel, bool extra, bool exists, bool pending=false);
+    int process_relation(osmium::Relation const &rel, bool exists, bool pending=false);
     void copy_node_to_table(osmid_t id, const std::string &geom, taglist_t &tags);
     void copy_to_table(const osmid_t id, const geometry_builder::pg_geom_t &geom, taglist_t &tags, int polygon);
 

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -44,13 +44,13 @@ public:
     void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added);
     int pending_relation(osmid_t id, int exists);
 
-    int node_add(osmid_t id, double lat, double lon, const taglist_t &tags);
-    int way_add(osmid_t id, const idlist_t &nodes, const taglist_t &tags);
-    int relation_add(osmid_t id, const memberlist_t &members, const taglist_t &tags);
+    int node_add(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
+    int way_add(osmium::Way const &way, bool extra_tags) override;
+    int relation_add(osmium::Relation const &rel, bool extra_tags) override;
 
-    int node_modify(osmid_t id, double lat, double lon, const taglist_t &tags);
-    int way_modify(osmid_t id, const idlist_t &nodes, const taglist_t &tags);
-    int relation_modify(osmid_t id, const memberlist_t &members, const taglist_t &tags);
+    int node_modify(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
+    int way_modify(osmium::Way const &way, bool extra_tags) override;
+    int relation_modify(osmium::Relation const &rel, bool extra_tags) override;
 
     int node_delete(osmid_t id);
     int way_delete(osmid_t id);

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -32,17 +32,17 @@ public:
     output_multi_t(const output_multi_t& other);
     virtual ~output_multi_t();
 
-    virtual std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const;
+    std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const override;
 
-    int start();
-    void stop();
-    void commit();
+    int start() override;
+    void stop() override;
+    void commit() override;
 
-    void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added);
-    int pending_way(osmid_t id, int exists);
+    void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) override;
+    int pending_way(osmid_t id, int exists) override;
 
-    void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added);
-    int pending_relation(osmid_t id, int exists);
+    void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) override;
+    int pending_relation(osmid_t id, int exists) override;
 
     int node_add(osmium::Node const &node, double lat, double lon) override;
     int way_add(osmium::Way const &way) override;
@@ -52,14 +52,14 @@ public:
     int way_modify(osmium::Way const &way) override;
     int relation_modify(osmium::Relation const &rel) override;
 
-    int node_delete(osmid_t id);
-    int way_delete(osmid_t id);
-    int relation_delete(osmid_t id);
+    int node_delete(osmid_t id) override;
+    int way_delete(osmid_t id) override;
+    int relation_delete(osmid_t id) override;
 
-    size_t pending_count() const;
+    size_t pending_count() const override;
 
-    void merge_pending_relations(output_t *other);
-    void merge_expire_trees(output_t *other);
+    void merge_pending_relations(output_t *other) override;
+    void merge_expire_trees(output_t *other) override;
 
 protected:
 

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -64,10 +64,11 @@ public:
 protected:
 
     void delete_from_output(osmid_t id);
-    int process_node(osmid_t id, double lat, double lon, const taglist_t &tags);
-    int process_way(osmid_t id, const idlist_t &nodes, const taglist_t &tags);
+    int process_node(osmium::Node const &node, bool extra, double lat, double lon);
+    int process_way(osmium::Way const &way, bool extra);
     int reprocess_way(osmid_t id, const nodelist_t &nodes, const taglist_t &tags, bool exists);
     int process_relation(osmid_t id, const memberlist_t &members, const taglist_t &tags, bool exists, bool pending=false);
+    int process_relation(osmium::Relation const &rel, bool extra, bool exists, bool pending=false);
     void copy_node_to_table(osmid_t id, const std::string &geom, taglist_t &tags);
     void copy_to_table(const osmid_t id, const geometry_builder::pg_geom_t &geom, taglist_t &tags, int polygon);
 

--- a/output-null.cpp
+++ b/output-null.cpp
@@ -31,15 +31,15 @@ int output_null_t::pending_relation(osmid_t, int) {
     return 0;
 }
 
-int output_null_t::node_add(osmium::Node const &, double, double, bool) {
+int output_null_t::node_add(osmium::Node const &, double, double) {
   return 0;
 }
 
-int output_null_t::way_add(osmium::Way const &, bool) {
+int output_null_t::way_add(osmium::Way const &) {
   return 0;
 }
 
-int output_null_t::relation_add(osmium::Relation const &, bool) {
+int output_null_t::relation_add(osmium::Relation const &) {
   return 0;
 }
 
@@ -55,15 +55,15 @@ int output_null_t::relation_delete(osmid_t) {
   return 0;
 }
 
-int output_null_t::node_modify(osmium::Node const &, double, double, bool) {
+int output_null_t::node_modify(osmium::Node const &, double, double) {
   return 0;
 }
 
-int output_null_t::way_modify(osmium::Way const &, bool) {
+int output_null_t::way_modify(osmium::Way const &) {
   return 0;
 }
 
-int output_null_t::relation_modify(osmium::Relation const &, bool) {
+int output_null_t::relation_modify(osmium::Relation const &) {
   return 0;
 }
 

--- a/output-null.cpp
+++ b/output-null.cpp
@@ -17,53 +17,53 @@ void output_null_t::stop() {
 void output_null_t::commit() {
 }
 
-void output_null_t::enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) {
+void output_null_t::enqueue_ways(pending_queue_t &, osmid_t, size_t, size_t&) {
 }
 
-int output_null_t::pending_way(osmid_t id, int exists) {
+int output_null_t::pending_way(osmid_t, int) {
     return 0;
 }
 
-void output_null_t::enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) {
+void output_null_t::enqueue_relations(pending_queue_t &, osmid_t, size_t, size_t&) {
 }
 
-int output_null_t::pending_relation(osmid_t id, int exists) {
+int output_null_t::pending_relation(osmid_t, int) {
     return 0;
 }
 
-int output_null_t::node_add(osmid_t, double, double, const taglist_t &) {
+int output_null_t::node_add(osmium::Node const &, double, double, bool) {
   return 0;
 }
 
-int output_null_t::way_add(osmid_t a, const idlist_t &, const taglist_t &) {
+int output_null_t::way_add(osmium::Way const &, bool) {
   return 0;
 }
 
-int output_null_t::relation_add(osmid_t a, const memberlist_t &, const taglist_t &) {
+int output_null_t::relation_add(osmium::Relation const &, bool) {
   return 0;
 }
 
-int output_null_t::node_delete(osmid_t i) {
+int output_null_t::node_delete(osmid_t) {
   return 0;
 }
 
-int output_null_t::way_delete(osmid_t i) {
+int output_null_t::way_delete(osmid_t) {
   return 0;
 }
 
-int output_null_t::relation_delete(osmid_t i) {
+int output_null_t::relation_delete(osmid_t) {
   return 0;
 }
 
-int output_null_t::node_modify(osmid_t, double, double, const taglist_t &) {
+int output_null_t::node_modify(osmium::Node const &, double, double, bool) {
   return 0;
 }
 
-int output_null_t::way_modify(osmid_t, const idlist_t &, const taglist_t &) {
+int output_null_t::way_modify(osmium::Way const &, bool) {
   return 0;
 }
 
-int output_null_t::relation_modify(osmid_t, const memberlist_t &, const taglist_t &) {
+int output_null_t::relation_modify(osmium::Relation const &, bool) {
   return 0;
 }
 

--- a/output-null.hpp
+++ b/output-null.hpp
@@ -25,13 +25,13 @@ public:
     void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added);
     int pending_relation(osmid_t id, int exists);
 
-    int node_add(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
-    int way_add(osmium::Way const &way, bool extra_tags) override;
-    int relation_add(osmium::Relation const &rel, bool extra_tags) override;
+    int node_add(osmium::Node const &node, double lat, double lon) override;
+    int way_add(osmium::Way const &way) override;
+    int relation_add(osmium::Relation const &rel) override;
 
-    int node_modify(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
-    int way_modify(osmium::Way const &way, bool extra_tags) override;
-    int relation_modify(osmium::Relation const &rel, bool extra_tags) override;
+    int node_modify(osmium::Node const &node, double lat, double lon) override;
+    int way_modify(osmium::Way const &way) override;
+    int relation_modify(osmium::Relation const &rel) override;
 
     int node_delete(osmid_t id);
     int way_delete(osmid_t id);

--- a/output-null.hpp
+++ b/output-null.hpp
@@ -12,18 +12,18 @@ public:
     output_null_t(const output_null_t& other);
     virtual ~output_null_t();
 
-    virtual std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const;
+    std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const override;
 
-    int start();
-    void stop();
-    void commit();
+    int start() override;
+    void stop() override;
+    void commit() override;
     void cleanup(void);
 
-    void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added);
-    int pending_way(osmid_t id, int exists);
+    void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) override;
+    int pending_way(osmid_t id, int exists) override;
 
-    void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added);
-    int pending_relation(osmid_t id, int exists);
+    void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) override;
+    int pending_relation(osmid_t id, int exists) override;
 
     int node_add(osmium::Node const &node, double lat, double lon) override;
     int way_add(osmium::Way const &way) override;
@@ -33,9 +33,9 @@ public:
     int way_modify(osmium::Way const &way) override;
     int relation_modify(osmium::Relation const &rel) override;
 
-    int node_delete(osmid_t id);
-    int way_delete(osmid_t id);
-    int relation_delete(osmid_t id);
+    int node_delete(osmid_t id) override;
+    int way_delete(osmid_t id) override;
+    int relation_delete(osmid_t id) override;
 };
 
 #endif

--- a/output-null.hpp
+++ b/output-null.hpp
@@ -25,13 +25,13 @@ public:
     void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added);
     int pending_relation(osmid_t id, int exists);
 
-    int node_add(osmid_t id, double lat, double lon, const taglist_t &tags);
-    int way_add(osmid_t id, const idlist_t &nodes, const taglist_t &tags);
-    int relation_add(osmid_t id, const memberlist_t &members, const taglist_t &tags);
+    int node_add(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
+    int way_add(osmium::Way const &way, bool extra_tags) override;
+    int relation_add(osmium::Relation const &rel, bool extra_tags) override;
 
-    int node_modify(osmid_t id, double lat, double lon, const taglist_t &tags);
-    int way_modify(osmid_t id, const idlist_t &nodes, const taglist_t &tags);
-    int relation_modify(osmid_t id, const memberlist_t &members, const taglist_t &tags);
+    int node_modify(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
+    int way_modify(osmium::Way const &way, bool extra_tags) override;
+    int relation_modify(osmium::Relation const &rel, bool extra_tags) override;
 
     int node_delete(osmid_t id);
     int way_delete(osmid_t id);

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -360,8 +360,6 @@ int output_pgsql_t::node_add(osmium::Node const &node, double lat, double lon, b
 
 int output_pgsql_t::way_add(osmium::Way const &way, bool extra_tags)
 {
-    idlist_t nds(way.nodes());
-
     int polygon = 0;
     int roads = 0;
     taglist_t outtags;
@@ -378,7 +376,7 @@ int output_pgsql_t::way_add(osmium::Way const &way, bool extra_tags)
     {
         /* Get actual node data and generate output */
         nodelist_t nodes;
-        m_mid->nodes_get_list(nodes, nds);
+        m_mid->nodes_get_list(nodes, way.nodes());
         pgsql_out_way(way.id(), outtags, nodes, polygon, roads);
     }
     return 0;

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -400,19 +400,22 @@ int output_pgsql_t::pgsql_process_relation(osmium::Relation const &rel, bool ext
   for (auto const &m : rel.members())
   {
     /* Need to handle more than just ways... */
-    if (m.type() == osmium::item_type::way)
+    if (m.type() == osmium::item_type::way) {
         xid2.push_back(m.ref());
+    }
+
   }
 
   buffer.clear();
   auto num_ways = m_mid->ways_get_list(xid2, buffer);
-  multitaglist_t xtags(num_ways);
+  multitaglist_t xtags(num_ways, taglist_t());
   rolelist_t xrole(num_ways);
-  multinodelist_t xnodes(num_ways);
+  multinodelist_t xnodes(num_ways, nodelist_t());
   idlist_t xid;
 
   size_t i = 0;
   for (auto const &w : buffer.select<osmium::Way>()) {
+      assert(i < num_ways);
       xid.push_back(w.id());
       m_mid->nodes_get_list(xnodes[i], w.nodes());
 
@@ -426,12 +429,12 @@ int output_pgsql_t::pgsql_process_relation(osmium::Relation const &rel, bool ext
       //should decrement the count and remove his nodes and tags etc. for
       //now we'll just keep him with no tags so he will get filtered later
       for (auto const &member : rel.members()) {
-          if (member.ref() == w.id()) {
+          if (member.ref() == w.id() && member.type() == osmium::item_type::way) {
               xrole[i] = member.role();
-              ++i;
               break;
           }
       }
+      ++i;
   }
 
   /* At some point we might want to consider storing the retrieved data in the members, rather than as separate arrays */

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -61,18 +61,6 @@ psql - 01 01000020 E6100000 30CCA462B6C3D4BF92998C9B38E04940
 Workaround - output SRID=4326;<WKB>
 */
 
-int output_pgsql_t::pgsql_out_node(osmid_t id, const taglist_t &tags, double node_lat, double node_lon)
-{
-    taglist_t outtags;
-    if (m_tagtransform->filter_node_tags(tags, *m_export_list.get(), outtags))
-        return 1;
-
-    expire.from_bbox(node_lon, node_lat, node_lon, node_lat);
-    m_tables[t_point]->write_node(id, outtags, node_lat, node_lon);
-
-    return 0;
-}
-
 
 /*
 COPY planet_osm (osm_id, name, place, landuse, leisure, "natural", man_made, waterway, highway, railway, amenity, tourism, learning, bu
@@ -360,22 +348,18 @@ void output_pgsql_t::stop()
 
 int output_pgsql_t::node_add(osmium::Node const &node, double lat, double lon, bool extra_tags)
 {
-    taglist_t tags(node.tags());
-    if (extra_tags) {
-        tags.add_attributes(node);
-    }
+    taglist_t outtags;
+    if (m_tagtransform->filter_tags(node, extra_tags, 0, 0, *m_export_list.get(), outtags))
+        return 1;
 
-    pgsql_out_node(node.id(), tags, lat, lon);
+    expire.from_bbox(lon, lat, lon, lat);
+    m_tables[t_point]->write_node(node.id(), outtags, lat, lon);
 
     return 0;
 }
 
 int output_pgsql_t::way_add(osmium::Way const &way, bool extra_tags)
 {
-    taglist_t tags(way.tags());
-    if (extra_tags) {
-        tags.add_attributes(way);
-    }
     idlist_t nds(way.nodes());
 
     int polygon = 0;
@@ -383,8 +367,8 @@ int output_pgsql_t::way_add(osmium::Way const &way, bool extra_tags)
     taglist_t outtags;
 
     /* Check whether the way is: (1) Exportable, (2) Maybe a polygon */
-    auto filter = m_tagtransform->filter_way_tags(tags, &polygon, &roads,
-            *m_export_list.get(), outtags);
+    auto filter = m_tagtransform->filter_tags(way, extra_tags, &polygon, &roads,
+                                              *m_export_list.get(), outtags);
 
     /* If this isn't a polygon then it can not be part of a multipolygon
        Hence only polygons are "pending" */
@@ -444,7 +428,7 @@ int output_pgsql_t::pgsql_process_relation(osmid_t id, const memberlist_t &membe
               //TODO: if the filter says that this member is now not interesting we
               //should decrement the count and remove his nodes and tags etc. for
               //now we'll just keep him with no tags so he will get filtered later
-              xrole[i] = &members[j].role;
+              xrole[i] = members[j].role.c_str();
               break;
           }
       }
@@ -452,6 +436,60 @@ int output_pgsql_t::pgsql_process_relation(osmid_t id, const memberlist_t &membe
 
   /* At some point we might want to consider storing the retrieved data in the members, rather than as separate arrays */
   pgsql_out_relation(id, outtags, xnodes, xtags, xid, xrole, pending);
+
+  return 0;
+}
+
+/* This is the workhorse of pgsql_add_relation, split out because it is used as the callback for iterate relations */
+int output_pgsql_t::pgsql_process_relation(osmium::Relation const &rel, bool extra,
+                                           bool exists, bool pending)
+{
+  /* If the flag says this object may exist already, delete it first */
+  if(exists)
+      pgsql_delete_relation_from_output(rel.id());
+
+  taglist_t outtags;
+  if (m_tagtransform->filter_tags(rel, extra, 0, 0, *m_export_list.get(), outtags))
+      return 1;
+
+  idlist_t xid2;
+  multitaglist_t xtags2;
+  multinodelist_t xnodes;
+
+  for (auto const &m : rel.members())
+  {
+    /* Need to handle more than just ways... */
+    if (m.type() == osmium::item_type::way)
+        xid2.push_back(m.ref());
+  }
+
+  idlist_t xid;
+  m_mid->ways_get_list(xid2, xid, xtags2, xnodes);
+  int polygon = 0, roads = 0;
+  multitaglist_t xtags(xid.size(), taglist_t());
+  rolelist_t xrole(xid.size(), 0);
+
+  for (size_t i = 0; i < xid.size(); i++) {
+      for (auto const &member : rel.members()) {
+          if (member.ref() == xid[i]) {
+              //filter the tags on this member because we got it from the middle
+              //and since the middle is no longer tied to the output it no longer
+              //shares any kind of tag transform and therefore all original tags
+              //will come back and need to be filtered by individual outputs before
+              //using these ways
+              m_tagtransform->filter_way_tags(xtags2[i], &polygon, &roads,
+                                              *m_export_list.get(), xtags[i]);
+              //TODO: if the filter says that this member is now not interesting we
+              //should decrement the count and remove his nodes and tags etc. for
+              //now we'll just keep him with no tags so he will get filtered later
+              xrole[i] = member.role();
+              break;
+          }
+      }
+  }
+
+  /* At some point we might want to consider storing the retrieved data in the members, rather than as separate arrays */
+  pgsql_out_relation(rel.id(), outtags, xnodes, xtags, xid, xrole, pending);
 
   return 0;
 }

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -410,7 +410,7 @@ int output_pgsql_t::pgsql_process_relation(osmid_t id, const memberlist_t &membe
   for (memberlist_t::const_iterator it = members.begin(); it != members.end(); ++it)
   {
     /* Need to handle more than just ways... */
-    if (it->type == OSMTYPE_WAY)
+    if (it->type == osmium::item_type::way)
         xid2.push_back(it->id);
   }
 
@@ -614,7 +614,9 @@ output_pgsql_t::output_pgsql_t(const middle_query_t* mid, const options_t &o)
     for (int i = 0; i < t_MAX; i++) {
 
         //figure out the columns this table needs
-        columns_t columns = m_export_list->normal_columns((i == t_point)?OSMTYPE_NODE:OSMTYPE_WAY);
+        columns_t columns = m_export_list->normal_columns((i == t_point)
+                            ? osmium::item_type::node
+                            : osmium::item_type::way);
 
         //figure out what name we are using for this and what type
         std::string name = m_options.prefix;

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -85,6 +85,7 @@ protected:
 
     id_tracker ways_pending_tracker, rels_pending_tracker;
     std::shared_ptr<id_tracker> ways_done_tracker;
+    osmium::memory::Buffer buffer;
 };
 
 #endif

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -39,13 +39,13 @@ public:
     void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added);
     int pending_relation(osmid_t id, int exists);
 
-    int node_add(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
-    int way_add(osmium::Way const &way, bool extra_tags) override;
-    int relation_add(osmium::Relation const &rel, bool extra_tags) override;
+    int node_add(osmium::Node const &node, double lat, double lon) override;
+    int way_add(osmium::Way const &way) override;
+    int relation_add(osmium::Relation const &rel) override;
 
-    int node_modify(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
-    int way_modify(osmium::Way const &way, bool extra_tags) override;
-    int relation_modify(osmium::Relation const &rel, bool extra_tags) override;
+    int node_modify(osmium::Node const &node, double lat, double lon) override;
+    int way_modify(osmium::Way const &way) override;
+    int relation_modify(osmium::Relation const &rel) override;
 
     int node_delete(osmid_t id);
     int way_delete(osmid_t id);
@@ -64,7 +64,7 @@ protected:
                            const idlist_t &xid, const rolelist_t &xrole,
                            bool pending);
     int pgsql_process_relation(osmium::Relation const &rel,
-                               bool extra, bool exists, bool pending=false);
+                               bool exists, bool pending=false);
     int pgsql_delete_way_from_output(osmid_t osm_id);
     int pgsql_delete_relation_from_output(osmid_t osm_id);
 

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -27,17 +27,17 @@ public:
     virtual ~output_pgsql_t();
     output_pgsql_t(const output_pgsql_t& other);
 
-    virtual std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const;
+    std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const override;
 
-    int start();
-    void stop();
-    void commit();
+    int start() override;
+    void stop() override;
+    void commit() override;
 
-    void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added);
-    int pending_way(osmid_t id, int exists);
+    void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) override;
+    int pending_way(osmid_t id, int exists) override;
 
-    void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added);
-    int pending_relation(osmid_t id, int exists);
+    void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) override;
+    int pending_relation(osmid_t id, int exists) override;
 
     int node_add(osmium::Node const &node, double lat, double lon) override;
     int way_add(osmium::Way const &way) override;
@@ -47,14 +47,14 @@ public:
     int way_modify(osmium::Way const &way) override;
     int relation_modify(osmium::Relation const &rel) override;
 
-    int node_delete(osmid_t id);
-    int way_delete(osmid_t id);
-    int relation_delete(osmid_t id);
+    int node_delete(osmid_t id) override;
+    int way_delete(osmid_t id) override;
+    int relation_delete(osmid_t id) override;
 
-    size_t pending_count() const;
+    size_t pending_count() const override;
 
-    void merge_pending_relations(output_t *other);
-    void merge_expire_trees(output_t *other);
+    void merge_pending_relations(output_t *other) override;
+    void merge_expire_trees(output_t *other) override;
 
 protected:
     int pgsql_out_way(osmid_t id, taglist_t &tags, const nodelist_t &nodes,

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -57,8 +57,6 @@ public:
     void merge_expire_trees(output_t *other);
 
 protected:
-
-    int pgsql_out_node(osmid_t id, const taglist_t &tags, double node_lat, double node_lon);
     int pgsql_out_way(osmid_t id, taglist_t &tags, const nodelist_t &nodes,
                       int polygons, int roads);
     int pgsql_out_relation(osmid_t id, const taglist_t &rel_tags,
@@ -66,6 +64,8 @@ protected:
                            const idlist_t &xid, const rolelist_t &xrole,
                            bool pending);
     int pgsql_process_relation(osmid_t id, const memberlist_t &members, const taglist_t &tags, int exists, bool pending=false);
+    int pgsql_process_relation(osmium::Relation const &rel,
+                               bool extra, bool exists, bool pending=false);
     int pgsql_delete_way_from_output(osmid_t osm_id);
     int pgsql_delete_relation_from_output(osmid_t osm_id);
 

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -85,6 +85,7 @@ protected:
     id_tracker ways_pending_tracker, rels_pending_tracker;
     std::shared_ptr<id_tracker> ways_done_tracker;
     osmium::memory::Buffer buffer;
+    osmium::memory::Buffer rels_buffer;
 };
 
 #endif

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -63,7 +63,6 @@ protected:
                            const multinodelist_t &xnodes, const multitaglist_t & xtags,
                            const idlist_t &xid, const rolelist_t &xrole,
                            bool pending);
-    int pgsql_process_relation(osmid_t id, const memberlist_t &members, const taglist_t &tags, int exists, bool pending=false);
     int pgsql_process_relation(osmium::Relation const &rel,
                                bool extra, bool exists, bool pending=false);
     int pgsql_delete_way_from_output(osmid_t osm_id);

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -39,13 +39,13 @@ public:
     void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added);
     int pending_relation(osmid_t id, int exists);
 
-    int node_add(osmid_t id, double lat, double lon, const taglist_t &tags);
-    int way_add(osmid_t id, const idlist_t &nodes, const taglist_t &tags);
-    int relation_add(osmid_t id, const memberlist_t &members, const taglist_t &tags);
+    int node_add(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
+    int way_add(osmium::Way const &way, bool extra_tags) override;
+    int relation_add(osmium::Relation const &rel, bool extra_tags) override;
 
-    int node_modify(osmid_t id, double lat, double lon, const taglist_t &tags);
-    int way_modify(osmid_t id, const idlist_t &nodes, const taglist_t &tags);
-    int relation_modify(osmid_t id, const memberlist_t &members, const taglist_t &tags);
+    int node_modify(osmium::Node const &node, double lat, double lon, bool extra_tags) override;
+    int way_modify(osmium::Way const &way, bool extra_tags) override;
+    int relation_modify(osmium::Relation const &rel, bool extra_tags) override;
 
     int node_delete(osmid_t id);
     int way_delete(osmid_t id);

--- a/output.cpp
+++ b/output.cpp
@@ -60,8 +60,8 @@ std::shared_ptr<output_t> parse_multi_single(const pt::ptree &conf,
         geometry_processor::create(proc_type, &new_opts);
 
     // TODO: we're faking this up, but there has to be a better way?
-    OsmType osm_type = ((processor->interests() & geometry_processor::interest_node) > 0)
-        ? OSMTYPE_NODE : OSMTYPE_WAY;
+    osmium::item_type osm_type = ((processor->interests() & geometry_processor::interest_node) > 0)
+        ? osmium::item_type::node : osmium::item_type::way;
 
     export_list columns;
     const pt::ptree &tags = conf.get_child("tags");

--- a/output.hpp
+++ b/output.hpp
@@ -49,13 +49,13 @@ public:
     virtual void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) = 0;
     virtual int pending_relation(osmid_t id, int exists) = 0;
 
-    virtual int node_add(osmid_t id, double lat, double lon, const taglist_t &tags) = 0;
-    virtual int way_add(osmid_t id, const idlist_t &nodes, const taglist_t &tags) = 0;
-    virtual int relation_add(osmid_t id, const memberlist_t &members, const taglist_t &tags) = 0;
+    virtual int node_add(osmium::Node const &node, double lat, double lon, bool extra_tags) = 0;
+    virtual int way_add(osmium::Way const &way, bool extra_tags) = 0;
+    virtual int relation_add(osmium::Relation const &rel, bool extra_tags) = 0;
 
-    virtual int node_modify(osmid_t id, double lat, double lon, const taglist_t &tags) = 0;
-    virtual int way_modify(osmid_t id, const idlist_t &nodes, const taglist_t &tags) = 0;
-    virtual int relation_modify(osmid_t id, const memberlist_t &members, const taglist_t &tags) = 0;
+    virtual int node_modify(osmium::Node const &node, double lat, double lon, bool extra_tags) = 0;
+    virtual int way_modify(osmium::Way const &way, bool extra_tags) = 0;
+    virtual int relation_modify(osmium::Relation const &rel, bool extra_tags) = 0;
 
     virtual int node_delete(osmid_t id) = 0;
     virtual int way_delete(osmid_t id) = 0;

--- a/output.hpp
+++ b/output.hpp
@@ -49,13 +49,13 @@ public:
     virtual void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) = 0;
     virtual int pending_relation(osmid_t id, int exists) = 0;
 
-    virtual int node_add(osmium::Node const &node, double lat, double lon, bool extra_tags) = 0;
-    virtual int way_add(osmium::Way const &way, bool extra_tags) = 0;
-    virtual int relation_add(osmium::Relation const &rel, bool extra_tags) = 0;
+    virtual int node_add(osmium::Node const &node, double lat, double lon) = 0;
+    virtual int way_add(osmium::Way const &way) = 0;
+    virtual int relation_add(osmium::Relation const &rel) = 0;
 
-    virtual int node_modify(osmium::Node const &node, double lat, double lon, bool extra_tags) = 0;
-    virtual int way_modify(osmium::Way const &way, bool extra_tags) = 0;
-    virtual int relation_modify(osmium::Relation const &rel, bool extra_tags) = 0;
+    virtual int node_modify(osmium::Node const &node, double lat, double lon) = 0;
+    virtual int way_modify(osmium::Way const &way) = 0;
+    virtual int relation_modify(osmium::Relation const &rel) = 0;
 
     virtual int node_delete(osmid_t id) = 0;
     virtual int way_delete(osmid_t id) = 0;

--- a/parse-osmium.cpp
+++ b/parse-osmium.cpp
@@ -216,14 +216,6 @@ void parse_osmium_t::convert_members(const osmium::RelationMemberList &in_rels)
     members.clear();
 
     for (auto const &m: in_rels) {
-        OsmType type;
-        switch (m.type()) {
-            case osmium::item_type::node: type = OSMTYPE_NODE; break;
-            case osmium::item_type::way: type = OSMTYPE_WAY; break;
-            case osmium::item_type::relation: type = OSMTYPE_RELATION; break;
-            default:
-                fprintf(stderr, "Unsupported type: %u""\n", unsigned(m.type()));
-        }
-        members.emplace_back(type, m.ref(), m.role());
+        members.emplace_back(m.type(), m.ref(), m.role());
     }
 }

--- a/parse-osmium.cpp
+++ b/parse-osmium.cpp
@@ -76,11 +76,9 @@ void parse_stats_t::print_status() const
 }
 
 
-parse_osmium_t::parse_osmium_t(bool extra_attrs,
-                               const boost::optional<std::string> &bbox,
-                               const reprojection *proj, bool do_append,
-                               osmdata_t *osmdata)
-: m_data(osmdata), m_append(do_append), m_attributes(extra_attrs), m_proj(proj)
+parse_osmium_t::parse_osmium_t(const boost::optional<std::string> &bbox,
+                               bool do_append, osmdata_t *osmdata)
+: m_data(osmdata), m_append(do_append)
 {
     if (bbox) {
         m_bbox = parse_bbox(bbox);
@@ -142,16 +140,10 @@ void parse_osmium_t::node(osmium::Node& node)
         }
 
         if (!m_bbox || m_bbox->contains(node.location())) {
-            auto c = m_proj->reproject(node.location());
-
-            taglist_t tags(node.tags());
-            if (m_attributes) {
-                tags.add_attributes(node);
-            }
             if (m_append) {
-                m_data->node_modify(node.id(), c.y, c.x, tags);
+                m_data->node_modify(node);
             } else {
-                m_data->node_add(node.id(), c.y, c.x, tags);
+                m_data->node_add(node);
             }
             m_stats.add_node(node.id());
         }
@@ -163,15 +155,10 @@ void parse_osmium_t::way(osmium::Way& way)
     if (way.deleted()) {
         m_data->way_delete(way.id());
     } else {
-        taglist_t tags(way.tags());
-        if (m_attributes) {
-            tags.add_attributes(way);
-        }
-        idlist_t nds(way.nodes());
         if (m_append) {
-            m_data->way_modify(way.id(), nds, tags);
+            m_data->way_modify(way);
         } else {
-            m_data->way_add(way.id(), nds, tags);
+            m_data->way_add(way);
         }
     }
     m_stats.add_way(way.id());
@@ -182,15 +169,10 @@ void parse_osmium_t::relation(osmium::Relation& rel)
     if (rel.deleted()) {
         m_data->relation_delete(rel.id());
     } else {
-        taglist_t tags(rel.tags());
-        if (m_attributes) {
-            tags.add_attributes(rel);
-        }
-        memberlist_t members(rel.members());
         if (m_append) {
-            m_data->relation_modify(rel.id(), members, tags);
+            m_data->relation_modify(rel);
         } else {
-            m_data->relation_add(rel.id(), members, tags);
+            m_data->relation_add(rel);
         }
     }
     m_stats.add_rel(rel.id());

--- a/parse-osmium.hpp
+++ b/parse-osmium.hpp
@@ -121,10 +121,6 @@ public:
     }
 
 private:
-    void convert_tags(const osmium::OSMObject &obj);
-    void convert_nodes(const osmium::NodeRefList &in_nodes);
-    void convert_members(const osmium::RelationMemberList &in_rels);
-
     osmium::Box parse_bbox(const boost::optional<std::string> &bbox);
 
     osmdata_t *m_data;
@@ -133,13 +129,6 @@ private:
     bool m_attributes;
     const reprojection *m_proj;
     parse_stats_t m_stats;
-
-    /* Since {node,way} elements are not nested we can guarantee that
-       elements are parsed sequentially and can therefore be cached.
-    */
-    taglist_t tags;
-    idlist_t nds;
-    memberlist_t members;
 };
 
 #endif

--- a/parse-osmium.hpp
+++ b/parse-osmium.hpp
@@ -35,7 +35,6 @@
 #include <osmium/handler.hpp>
 
 
-class reprojection;
 class osmdata_t;
 
 class parse_stats_t
@@ -106,8 +105,8 @@ private:
 class parse_osmium_t: public osmium::handler::Handler
 {
 public:
-    parse_osmium_t(bool extra_attrs, const boost::optional<std::string> &bbox,
-                   const reprojection *proj, bool do_append, osmdata_t *osmdata);
+    parse_osmium_t(const boost::optional<std::string> &bbox,
+                   bool do_append, osmdata_t *osmdata);
 
     void stream_file(const std::string &filename, const std::string &fmt);
 
@@ -126,8 +125,6 @@ private:
     osmdata_t *m_data;
     bool m_append;
     boost::optional<osmium::Box> m_bbox;
-    bool m_attributes;
-    const reprojection *m_proj;
     parse_stats_t m_stats;
 };
 

--- a/taginfo.cpp
+++ b/taginfo.cpp
@@ -43,37 +43,34 @@ taginfo::taginfo(const taginfo &other)
       flags(other.flags) {
 }
 
-export_list::export_list()
-    : num_tables(0), exportList() {
-}
-
-void export_list::add(enum OsmType id, const taginfo &info) {
+void export_list::add(osmium::item_type id, const taginfo &info) {
     std::vector<taginfo> &infos = get(id);
     infos.push_back(info);
 }
 
-std::vector<taginfo> &export_list::get(enum OsmType id) {
-    if (id >= num_tables) {
-        exportList.resize(id+1);
-        num_tables = id + 1;
+std::vector<taginfo> &export_list::get(osmium::item_type id) {
+    auto idx = item_type_to_nwr_index(id);
+    if (idx >= exportList.size()) {
+        exportList.resize(idx+1);
     }
-    return exportList[id];
+    return exportList[idx];
 }
 
-const std::vector<taginfo> &export_list::get(enum OsmType id) const {
+const std::vector<taginfo> &export_list::get(osmium::item_type id) const {
     // this fakes as if we have infinite taginfo vectors, but
     // means we don't actually have anything allocated unless
     // the info object has been assigned.
     static const std::vector<taginfo> empty;
 
-    if (id < num_tables) {
-        return exportList[id];
+    auto idx = item_type_to_nwr_index(id);
+    if (idx < exportList.size()) {
+        return exportList[idx];
     } else {
         return empty;
     }
 }
 
-columns_t export_list::normal_columns(OsmType id) const {
+columns_t export_list::normal_columns(osmium::item_type id) const {
     columns_t columns;
 
     for (auto const &info : get(id)) {
@@ -176,14 +173,14 @@ int read_style_file( const std::string &filename, export_list *exlist )
     //keep this tag info if it applies to nodes
     if( strstr( osmtype, "node" ) )
     {
-        exlist->add(OSMTYPE_NODE, temp);
+        exlist->add(osmium::item_type::node, temp);
         kept = true;
     }
 
     //keep this tag info if it applies to ways
     if( strstr( osmtype, "way" ) )
     {
-        exlist->add(OSMTYPE_WAY, temp);
+        exlist->add(osmium::item_type::way, temp);
         kept = true;
     }
 

--- a/taginfo_impl.hpp
+++ b/taginfo_impl.hpp
@@ -37,16 +37,13 @@ struct taginfo {
 };
 
 struct export_list {
-    export_list();
+    void add(osmium::item_type id, const taginfo &info);
+    std::vector<taginfo> &get(osmium::item_type id);
+    const std::vector<taginfo> &get(osmium::item_type id) const;
 
-    void add(enum OsmType id, const taginfo &info);
-    std::vector<taginfo> &get(enum OsmType id);
-    const std::vector<taginfo> &get(enum OsmType id) const;
+    columns_t normal_columns(osmium::item_type id) const;
 
-    columns_t normal_columns(OsmType id) const;
-
-    int num_tables;
-    std::vector<std::vector<taginfo> > exportList; /* Indexed by enum OsmType */
+    std::vector<std::vector<taginfo> > exportList; /* Indexed osmium nwr index */
 };
 
 /* Parse a comma or whitespace delimited list of tags to apply to

--- a/tagtransform.cpp
+++ b/tagtransform.cpp
@@ -449,15 +449,15 @@ tagtransform::~tagtransform() {
 #endif
 }
 
-bool tagtransform::filter_tags(osmium::OSMObject const &o, bool extra,
+bool tagtransform::filter_tags(osmium::OSMObject const &o,
                                int *polygon, int *roads, const export_list &exlist,
                                taglist_t &out_tags, bool strict)
 {
     if (transform_method) {
-        return lua_filter_basic_tags(o, extra, polygon, roads, out_tags);
+        return lua_filter_basic_tags(o, polygon, roads, out_tags);
     }
 
-    return c_filter_basic_tags(o, extra, polygon, roads, exlist,
+    return c_filter_basic_tags(o, polygon, roads, exlist,
                                out_tags, strict);
 }
 
@@ -477,7 +477,7 @@ unsigned tagtransform::filter_rel_member_tags(const taglist_t &rel_tags,
     }
 }
 
-bool tagtransform::lua_filter_basic_tags(osmium::OSMObject const &o, bool extra,
+bool tagtransform::lua_filter_basic_tags(osmium::OSMObject const &o,
                                          int *polygon, int *roads, taglist_t &out_tags)
 {
 #ifdef HAVE_LUA
@@ -504,7 +504,7 @@ bool tagtransform::lua_filter_basic_tags(osmium::OSMObject const &o, bool extra,
         lua_rawset(L, -3);
         ++sz;
     }
-    if (extra) {
+    if (options->extra_attributes && o.version() > 0) {
         taglist_t tags;
         tags.add_attributes(o);
         for (auto const &t: tags) {
@@ -554,7 +554,7 @@ bool tagtransform::lua_filter_basic_tags(osmium::OSMObject const &o, bool extra,
 
 /* Go through the given tags and determine the union of flags. Also remove
  * any tags from the list that we don't know about */
-bool tagtransform::c_filter_basic_tags(osmium::OSMObject const &o, bool extra, int *polygon,
+bool tagtransform::c_filter_basic_tags(osmium::OSMObject const &o, int *polygon,
                                        int *roads, const export_list &exlist,
                                        taglist_t &out_tags, bool strict)
 {
@@ -638,7 +638,7 @@ bool tagtransform::c_filter_basic_tags(osmium::OSMObject const &o, bool extra, i
             }
         }
     }
-    if (extra) {
+    if (options->extra_attributes && o.version() > 0) {
         out_tags.add_attributes(o);
     }
 

--- a/tagtransform.cpp
+++ b/tagtransform.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <vector>
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/format.hpp>
 
 #include "tagtransform.hpp"
@@ -233,7 +234,7 @@ unsigned int c_filter_rel_member_tags(const taglist_t &rel_tags,
         if (poly_tags.empty()) {
             int first_outerway = 1;
             for (size_t i = 0; i < member_tags.size(); i++) {
-                if (member_roles[i] && *(member_roles[i]) == "inner")
+                if (member_roles[i] && strcmp(member_roles[i], "inner") == 0)
                     continue;
 
                 /* insert all tags of the first outerway to the potential list of copied tags. */
@@ -354,7 +355,7 @@ unsigned tagtransform::lua_filter_rel_member_tags(const taglist_t &rel_tags,
 
     for (size_t i = 0; i < member_roles.size(); i++) {
         lua_pushnumber(L, i + 1);
-        lua_pushstring(L, member_roles[i]->c_str());
+        lua_pushstring(L, member_roles[i]);
         lua_rawset(L, -3);
     }
 
@@ -448,14 +449,15 @@ tagtransform::~tagtransform() {
 #endif
 }
 
-unsigned int tagtransform::filter_node_tags(const taglist_t &tags, const export_list &exlist,
-                                            taglist_t &out_tags, bool strict)
+bool tagtransform::filter_tags(osmium::OSMObject const &o, bool extra,
+                               int *polygon, int *roads, const export_list &exlist,
+                               taglist_t &out_tags, bool strict)
 {
     if (transform_method) {
-        return lua_filter_basic_tags(osmium::item_type::node, tags, 0, 0, out_tags);
+        return lua_filter_basic_tags(o, extra, polygon, roads, out_tags);
     }
 
-    return c_filter_basic_tags(osmium::item_type::node, tags, 0, 0, exlist,
+    return c_filter_basic_tags(o, extra, polygon, roads, exlist,
                                out_tags, strict);
 }
 
@@ -558,6 +560,78 @@ unsigned tagtransform::lua_filter_basic_tags(osmium::item_type type, const tagli
     return filter;
 #else
     return 1;
+#endif
+}
+
+bool tagtransform::lua_filter_basic_tags(osmium::OSMObject const &o, bool extra,
+                                         int *polygon, int *roads, taglist_t &out_tags)
+{
+#ifdef HAVE_LUA
+    switch (o.type()) {
+        case osmium::item_type::node:
+            lua_getglobal(L, m_node_func.c_str());
+            break;
+        case osmium::item_type::way:
+            lua_getglobal(L, m_way_func.c_str());
+            break;
+        case osmium::item_type::relation:
+            lua_getglobal(L, m_rel_func.c_str());
+            break;
+        default:
+            throw std::runtime_error("Unknown OSM type");
+    }
+
+    lua_newtable(L);    /* key value table */
+
+    lua_Integer sz = (lua_Integer) o.tags().size();
+    for (auto const &t: o.tags()) {
+        lua_pushstring(L, t.key());
+        lua_pushstring(L, t.value());
+        lua_rawset(L, -3);
+    }
+    if (extra) {
+        taglist_t tags;
+        tags.add_attributes(o);
+        for (auto const &t: tags) {
+            lua_pushstring(L, t.key.c_str());
+            lua_pushstring(L, t.value.c_str());
+            lua_rawset(L, -3);
+        }
+        sz += tags.size();
+    }
+
+    lua_pushinteger(L, sz);
+
+    if (lua_pcall(L, 2, (o.type() == osmium::item_type::way) ? 4 : 2, 0)) {
+        fprintf(stderr, "Failed to execute lua function for basic tag processing: %s\n", lua_tostring(L, -1));
+        /* lua function failed */
+        return 1;
+    }
+
+    if (o.type() == osmium::item_type::way) {
+        assert(roads);
+        *roads = lua_tointeger(L, -1);
+        lua_pop(L,1);
+        assert(polygon);
+        *polygon = lua_tointeger(L, -1);
+        lua_pop(L,1);
+    }
+
+    lua_pushnil(L);
+    while (lua_next(L,-2) != 0) {
+        const char *key = lua_tostring(L,-2);
+        const char *value = lua_tostring(L,-1);
+        out_tags.emplace_back(key, value);
+        lua_pop(L,1);
+    }
+
+    bool filter = lua_tointeger(L, -2);
+
+    lua_pop(L,2);
+
+    return filter;
+#else
+    return true;
 #endif
 }
 
@@ -666,6 +740,115 @@ unsigned int tagtransform::c_filter_basic_tags(osmium::item_type type, const tag
     }
 
     if (roads && !filter && (type == osmium::item_type::way)) {
+        add_z_order(out_tags, roads);
+    }
+
+    return filter;
+}
+
+bool tagtransform::c_filter_basic_tags(osmium::OSMObject const &o, bool extra, int *polygon,
+                                       int *roads, const export_list &exlist,
+                                       taglist_t &out_tags, bool strict)
+{
+    //assume we dont like this set of tags
+    bool filter = true;
+
+    int flags = 0;
+    int add_area_tag = 0;
+
+    auto export_type = o.type();
+    if (o.type() == osmium::item_type::relation) {
+        export_type = osmium::item_type::way;
+    }
+    const std::vector<taginfo> &infos = exlist.get(export_type);
+
+    /* We used to only go far enough to determine if it's a polygon or not,
+       but now we go through and filter stuff we don't need
+       pop each tag off and keep it in the temp list if we like it */
+    for (auto const &item : o.tags()) {
+        char const *k = item.key();
+        char const *v = item.value();
+        //if we want to do more than the export list says
+        if(!strict) {
+            if (o.type() == osmium::item_type::relation && strcmp("type", k) == 0) {
+                out_tags.emplace_back(k, v);
+                filter = false;
+                continue;
+            }
+            /* Allow named islands to appear as polygons */
+            if (strcmp("natural", k) == 0 && strcmp("coastline", v) == 0) {
+                add_area_tag = 1;
+
+                /* Discard natural=coastline tags (we render these from a shapefile instead) */
+                if (!options->keep_coastlines) {
+                    continue;
+                }
+            }
+        }
+
+        //go through the actual tags found on the item and keep the ones in the export list
+        size_t i = 0;
+        for (; i < infos.size(); i++) {
+            const taginfo &info = infos[i];
+            if (info.flags & FLAG_DELETE) {
+                if (wildMatch(info.name.c_str(), k)) {
+                    break;
+                }
+            } else if (strcmp(info.name.c_str(), k) == 0) {
+                filter = false;
+                flags |= info.flags;
+
+                out_tags.emplace_back(k, v);
+                break;
+            }
+        }
+
+        // if we didn't find any tags that we wanted to export
+        // and we aren't strictly adhering to the list
+        if (i == infos.size() && !strict) {
+            if (options->hstore_mode != HSTORE_NONE) {
+                /* with hstore, copy all tags... */
+                out_tags.emplace_back(k, v);
+                /* ... but if hstore_match_only is set then don't take this
+                 as a reason for keeping the object */
+                if (!options->hstore_match_only)
+                    filter = false;
+            } else if (options->hstore_columns.size() > 0) {
+                /* does this column match any of the hstore column prefixes? */
+                size_t j = 0;
+                for(; j < options->hstore_columns.size(); ++j) {
+                    if (boost::starts_with(k, options->hstore_columns[j])) {
+                        out_tags.emplace_back(k, v);
+                        /* ... but if hstore_match_only is set then don't take this
+                         as a reason for keeping the object */
+                        if (!options->hstore_match_only) {
+                            filter = false;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    if (extra) {
+        out_tags.add_attributes(o);
+    }
+
+    if (polygon) {
+        if (add_area_tag) {
+            /* If we need to force this as a polygon, append an area tag */
+            out_tags.push_dedupe(tag_t("area", "yes"));
+            *polygon = 1;
+        } else {
+            auto const *area = o.tags()["area"];
+            if (area)
+                *polygon = taglist_t::value_to_bool(o.tags()["area"], flags & FLAG_POLYGON);
+            else
+                *polygon = flags & FLAG_POLYGON;
+        }
+    }
+
+    if (roads && !filter && (o.type() == osmium::item_type::way)) {
         add_z_order(out_tags, roads);
     }
 

--- a/tagtransform.cpp
+++ b/tagtransform.cpp
@@ -497,11 +497,12 @@ bool tagtransform::lua_filter_basic_tags(osmium::OSMObject const &o, bool extra,
 
     lua_newtable(L);    /* key value table */
 
-    lua_Integer sz = (lua_Integer) o.tags().size();
+    lua_Integer sz = 0;
     for (auto const &t: o.tags()) {
         lua_pushstring(L, t.key());
         lua_pushstring(L, t.value());
         lua_rawset(L, -3);
+        ++sz;
     }
     if (extra) {
         taglist_t tags;
@@ -649,7 +650,7 @@ bool tagtransform::c_filter_basic_tags(osmium::OSMObject const &o, bool extra, i
         } else {
             auto const *area = o.tags()["area"];
             if (area)
-                *polygon = taglist_t::value_to_bool(o.tags()["area"], flags & FLAG_POLYGON);
+                *polygon = taglist_t::value_to_bool(area, flags & FLAG_POLYGON);
             else
                 *polygon = flags & FLAG_POLYGON;
         }

--- a/tagtransform.cpp
+++ b/tagtransform.cpp
@@ -475,17 +475,6 @@ unsigned tagtransform::filter_way_tags(const taglist_t &tags, int *polygon, int 
                                exlist, out_tags, strict);
 }
 
-unsigned tagtransform::filter_rel_tags(const taglist_t &tags, const export_list &exlist,
-                                       taglist_t &out_tags, bool strict)
-{
-    if (transform_method) {
-        return lua_filter_basic_tags(osmium::item_type::relation, tags, 0, 0, out_tags);
-    }
-
-    return c_filter_basic_tags(osmium::item_type::relation, tags, 0, 0,
-                               exlist, out_tags, strict);
-}
-
 unsigned tagtransform::filter_rel_member_tags(const taglist_t &rel_tags,
         const multitaglist_t &member_tags, const rolelist_t &member_roles,
         int *member_superseeded, int *make_boundary, int *make_polygon, int *roads,

--- a/tagtransform.hpp
+++ b/tagtransform.hpp
@@ -35,9 +35,9 @@ public:
         const export_list &exlist, taglist_t &out_tags, bool allow_typeless = false);
 
 private:
-    unsigned lua_filter_basic_tags(OsmType type, const taglist_t &tags,
+    unsigned lua_filter_basic_tags(osmium::item_type type, const taglist_t &tags,
                                    int *polygon, int *roads, taglist_t &out_tags);
-    unsigned c_filter_basic_tags(OsmType type, const taglist_t &tags, int *polygon,
+    unsigned c_filter_basic_tags(osmium::item_type type, const taglist_t &tags, int *polygon,
                                  int *roads, const export_list &exlist,
                                  taglist_t &out_tags, bool strict);
     unsigned int lua_filter_rel_member_tags(const taglist_t &rel_tags,

--- a/tagtransform.hpp
+++ b/tagtransform.hpp
@@ -28,8 +28,6 @@ public:
                      taglist_t &out_tags, bool strict = false);
     unsigned filter_way_tags(const taglist_t &tags, int *polygon, int *roads,
                              const export_list &exlist, taglist_t &out_tags, bool strict = false);
-    unsigned filter_rel_tags(const taglist_t &tags, const export_list &exlist,
-                             taglist_t &out_tags, bool strict = false);
     unsigned filter_rel_member_tags(const taglist_t &rel_tags,
         const multitaglist_t &member_tags, const rolelist_t &member_roles,
         int *member_superseeded, int *make_boundary, int *make_polygon, int *roads,

--- a/tagtransform.hpp
+++ b/tagtransform.hpp
@@ -23,8 +23,9 @@ public:
 	tagtransform(const options_t *options_);
 	~tagtransform();
 
-    unsigned filter_node_tags(const taglist_t &tags, const export_list &exlist,
-                              taglist_t &out_tags, bool strict = false);
+    bool filter_tags(osmium::OSMObject const &o, bool extra,
+                     int *polygon, int *roads, const export_list &exlist,
+                     taglist_t &out_tags, bool strict = false);
     unsigned filter_way_tags(const taglist_t &tags, int *polygon, int *roads,
                              const export_list &exlist, taglist_t &out_tags, bool strict = false);
     unsigned filter_rel_tags(const taglist_t &tags, const export_list &exlist,
@@ -40,6 +41,11 @@ private:
     unsigned c_filter_basic_tags(osmium::item_type type, const taglist_t &tags, int *polygon,
                                  int *roads, const export_list &exlist,
                                  taglist_t &out_tags, bool strict);
+    bool lua_filter_basic_tags(osmium::OSMObject const &o, bool extra,
+                               int *polygon, int *roads, taglist_t &out_tags);
+    bool c_filter_basic_tags(osmium::OSMObject const &o, bool extra, int *polygon,
+                             int *roads, const export_list &exlist,
+                             taglist_t &out_tags, bool strict);
     unsigned int lua_filter_rel_member_tags(const taglist_t &rel_tags,
         const multitaglist_t &members_tags, const rolelist_t &member_roles,
         int *member_superseeded, int *make_boundary, int *make_polygon, int *roads,

--- a/tagtransform.hpp
+++ b/tagtransform.hpp
@@ -23,7 +23,7 @@ public:
 	tagtransform(const options_t *options_);
 	~tagtransform();
 
-    bool filter_tags(osmium::OSMObject const &o, bool extra,
+    bool filter_tags(osmium::OSMObject const &o,
                      int *polygon, int *roads, const export_list &exlist,
                      taglist_t &out_tags, bool strict = false);
     unsigned filter_rel_member_tags(const taglist_t &rel_tags,
@@ -32,9 +32,9 @@ public:
         const export_list &exlist, taglist_t &out_tags, bool allow_typeless = false);
 
 private:
-    bool lua_filter_basic_tags(osmium::OSMObject const &o, bool extra,
+    bool lua_filter_basic_tags(osmium::OSMObject const &o,
                                int *polygon, int *roads, taglist_t &out_tags);
-    bool c_filter_basic_tags(osmium::OSMObject const &o, bool extra, int *polygon,
+    bool c_filter_basic_tags(osmium::OSMObject const &o, int *polygon,
                              int *roads, const export_list &exlist,
                              taglist_t &out_tags, bool strict);
     unsigned int lua_filter_rel_member_tags(const taglist_t &rel_tags,

--- a/tagtransform.hpp
+++ b/tagtransform.hpp
@@ -26,19 +26,12 @@ public:
     bool filter_tags(osmium::OSMObject const &o, bool extra,
                      int *polygon, int *roads, const export_list &exlist,
                      taglist_t &out_tags, bool strict = false);
-    unsigned filter_way_tags(const taglist_t &tags, int *polygon, int *roads,
-                             const export_list &exlist, taglist_t &out_tags, bool strict = false);
     unsigned filter_rel_member_tags(const taglist_t &rel_tags,
         const multitaglist_t &member_tags, const rolelist_t &member_roles,
         int *member_superseeded, int *make_boundary, int *make_polygon, int *roads,
         const export_list &exlist, taglist_t &out_tags, bool allow_typeless = false);
 
 private:
-    unsigned lua_filter_basic_tags(osmium::item_type type, const taglist_t &tags,
-                                   int *polygon, int *roads, taglist_t &out_tags);
-    unsigned c_filter_basic_tags(osmium::item_type type, const taglist_t &tags, int *polygon,
-                                 int *roads, const export_list &exlist,
-                                 taglist_t &out_tags, bool strict);
     bool lua_filter_basic_tags(osmium::OSMObject const &o, bool extra,
                                int *polygon, int *roads, taglist_t &out_tags);
     bool c_filter_basic_tags(osmium::OSMObject const &o, bool extra, int *polygon,

--- a/tests/common-pg.cpp
+++ b/tests/common-pg.cpp
@@ -5,6 +5,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <iostream>
 #include <unistd.h>
 #include <memory>
 

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -10,8 +10,7 @@ namespace testing {
     void parse(const char *filename, const char *format,
                 const options_t &options, osmdata_t *osmdata)
     {
-        parse_osmium_t parser(options.extra_attributes, options.bbox,
-                              options.projection.get(), options.append, osmdata);
+        parse_osmium_t parser(options.bbox, options.append, osmdata);
 
         osmdata->start();
         parser.stream_file(filename, format);

--- a/tests/middle-tests.cpp
+++ b/tests/middle-tests.cpp
@@ -209,31 +209,33 @@ int test_way_set(middle_t *mid)
     mid->commit();
 
     // get it back
-    idlist_t ways, xways;
+    idlist_t ways;
     ways.push_back(way_id);
-    std::vector<taglist_t> xtags;
-    multinodelist_t xnodes;
-    size_t way_count = mid->ways_get_list(ways, xways, xtags, xnodes);
+    auto buf_pos = buffer.committed();
+    size_t way_count = mid->ways_get_list(ways, buffer);
     if (way_count != 1) { std::cerr << "ERROR: Unable to get way list.\n"; return 1; }
 
+    auto const &way = buffer.get<osmium::Way>(buf_pos);
     // check that it's the same
-    if (xnodes[0].size() != nds.size()) {
+    if (way.nodes().size() != nds.size()) {
         std::cerr << "ERROR: Way should have " << nds.size() << " nodes, but got back "
-            << xnodes[0].size() << " from middle.\n";
+            << way.nodes().size() << " from middle.\n";
         return 1;
     }
-    if (xways[0] != way_id) {
+    if (way.id() != way_id) {
         std::cerr << "ERROR: Way should have id=" << way_id << ", but got back "
-            << xways[0] << " from middle.\n";
+            << way.id() << " from middle.\n";
         return 1;
     }
+    nodelist_t xnodes;
+    mid->nodes_get_list(xnodes, way.nodes());
     for (size_t i = 0; i < nds.size(); ++i) {
-        if (xnodes[0][i].lon != lon) {
+        if (xnodes[i].lon != lon) {
             std::cerr << "ERROR: Way node should have lon=" << lon << ", but got back "
                 << node_ptr[i].lon << " from middle.\n";
             return 1;
         }
-        if (xnodes[0][i].lat != lat) {
+        if (xnodes[i].lat != lat) {
             std::cerr << "ERROR: Way node should have lat=" << lat << ", but got back "
                 << node_ptr[i].lat << " from middle.\n";
             return 1;

--- a/tests/middle-tests.cpp
+++ b/tests/middle-tests.cpp
@@ -9,148 +9,164 @@
 #include "osmtypes.hpp"
 #include "tests/middle-tests.hpp"
 
+#include <osmium/builder/attr.hpp>
+#include <osmium/memory/buffer.hpp>
+
 #define BLOCK_SHIFT 13
 #define PER_BLOCK  (((osmid_t)1) << BLOCK_SHIFT)
 
-struct expected_node {
-  osmid_t id;
-  double lon;
-  double lat;
-
-  expected_node() : id(0), lon(NAN), lat(NAN) {}
-
-  expected_node(osmid_t id, double x, double y) : id(id), lon(x), lat(y) {}
-};
-
-typedef std::vector<expected_node> expected_nodelist_t;
+// simple osmium buffer to store all the objects in
+osmium::memory::Buffer buffer(4096, osmium::memory::Buffer::auto_grow::yes);
 
 #define ALLOWED_ERROR 10e-9
-bool node_okay(osmNode node, expected_node expected) {
-  if ((node.lat > expected.lat + ALLOWED_ERROR) || (node.lat < expected.lat - ALLOWED_ERROR)) {
-    std::cerr << "ERROR: Node should have lat=" << expected.lat << ", but got back "
-              << node.lat << " from middle.\n";
-    return false;
-  }
-  if ((node.lon > expected.lon + ALLOWED_ERROR) || (node.lon < expected.lon - ALLOWED_ERROR)) {
-    std::cerr << "ERROR: Node should have lon=" << expected.lon << ", but got back "
-              << node.lon << " from middle.\n";
-    return false;
-  }
-  return true;
+bool node_okay(osmNode node, osmium::Node const &expected) {
+    if ((node.lat > expected.location().lat() + ALLOWED_ERROR)
+            || (node.lat < expected.location().lat() - ALLOWED_ERROR)) {
+        std::cerr << "ERROR: Node should have lat=" << expected.location().lat() << ", but got back "
+            << node.lat << " from middle.\n";
+        return false;
+    }
+    if ((node.lon > expected.location().lon() + ALLOWED_ERROR)
+            || (node.lon < expected.location().lon() - ALLOWED_ERROR)) {
+        std::cerr << "ERROR: Node should have lon=" << expected.location().lon() << ", but got back "
+            << node.lon << " from middle.\n";
+        return false;
+    }
+    return true;
+}
+
+size_t add_node(osmid_t id, double lat, double lon)
+{
+    using namespace osmium::builder::attr;
+    return osmium::builder::add_node(buffer, _id(id), _location(lon, lat));
 }
 
 int test_node_set(middle_t *mid)
 {
-  idlist_t ids;
-  expected_node expected(1234, 12.3456789, 98.7654321);
-  taglist_t tags;
-  nodelist_t nodes;
+    buffer.clear();
 
-  // set the node
-  mid->nodes_set(expected.id, expected.lat, expected.lon, tags);
+    auto const &node = buffer.get<osmium::Node>(add_node(1234, 12.3456789, 98.7654321));
+    idlist_t ids;
+    nodelist_t nodes;
 
-  // get it back
-  ids.push_back(expected.id);
-  if (mid->nodes_get_list(nodes, ids) != ids.size()) { std::cerr << "ERROR: Unable to get node list.\n"; return 1; }
-  if (nodes.size() != ids.size()) { std::cerr << "ERROR: Mismatch in returned node list size.\n"; return 1; }
+    // set the node
+    mid->nodes_set(node, node.location().lat(), node.location().lon(), false);
 
-  // check that it's the same
-  if (!node_okay(nodes[0], expected)) {
-    return 1;
-  }
+    // get it back
+    ids.push_back(node.id());
+    if (mid->nodes_get_list(nodes, ids) != ids.size()) {
+        std::cerr << "ERROR: Unable to get node list.\n";
+        return 1;
+    }
+    if (nodes.size() != ids.size()) {
+        std::cerr << "ERROR: Mismatch in returned node list size.\n";
+        return 1;
+    }
 
-  return 0;
+    // check that it's the same
+    if (!node_okay(nodes[0], node)) {
+        return 1;
+    }
+
+    return 0;
 }
 
 inline double test_lat(osmid_t id) {
-  return 1 + 1e-5 * id;
+    return 1 + 1e-5 * id;
 }
 
 int test_nodes_comprehensive_set(middle_t *mid)
 {
-  taglist_t tags;
+    std::vector<size_t> expected_nodes;
+    expected_nodes.reserve(PER_BLOCK*8+1);
 
-  expected_nodelist_t expected_nodes;
-  expected_nodes.reserve(PER_BLOCK*8+1);
+    buffer.clear();
 
-  // 2 dense blocks, the second partially filled at the star
-  for (osmid_t id = 0; id < (PER_BLOCK+(PER_BLOCK >> 1) + 1); ++id)
-  {
-    expected_nodes.emplace_back(id, test_lat(id), 0.0);
-  }
-
-  // 1 dense block, 75% filled
-  for (osmid_t id = PER_BLOCK*2; id < PER_BLOCK*3; ++id)
-  {
-    if ((id % 4 == 0) || (id % 4 == 1) || (id % 4 == 2))
-      expected_nodes.emplace_back(id, test_lat(id), 0.0);
-  }
-
-  // 1 dense block, sparsly filled
-  for (osmid_t id = PER_BLOCK*3; id < PER_BLOCK*4; ++id)
-  {
-    if (id % 4 == 0)
-      expected_nodes.emplace_back(id, test_lat(id), 0.0);
-  }
-
-  // A lone sparse node
-  expected_nodes.emplace_back(PER_BLOCK*5, test_lat(PER_BLOCK*5), 0.0);
-
-  // A dense block of alternating positions of zero/non-zero
-  for (osmid_t id = PER_BLOCK*6; id < PER_BLOCK*7; ++id)
-  {
-    if (id % 2 == 0)
-      expected_nodes.emplace_back(id, 0.0, 0.0);
-    else
-      expected_nodes.emplace_back(id, test_lat(id), 0.0);
-  }
-  expected_nodes.emplace_back(PER_BLOCK*8, 0.0, 0.0);
-  expected_nodes.emplace_back(PER_BLOCK*8+1, 0.0, 0.0);
-
-  // Load up the nodes into the middle
-  idlist_t ids;
-  ids.reserve(expected_nodes.size());
-
-  for (expected_nodelist_t::iterator node = expected_nodes.begin(); node != expected_nodes.end(); ++node)
-  {
-    mid->nodes_set(node->id, node->lat, node->lon, tags);
-    ids.push_back(node->id);
-  }
-
-  nodelist_t nodes;
-  if (mid->nodes_get_list(nodes, ids) != ids.size()) { std::cerr << "ERROR: Unable to get node list.\n"; return 1; }
-
-  if (nodes.size() != ids.size()) { std::cerr << "ERROR: Mismatch in returned node list size.\n"; return 1; }
-
-  for (size_t i = 0; i < nodes.size(); ++i)
-  {
-    if (!node_okay(nodes[i], expected_nodes[i])) {
-      return 1;
+    // 2 dense blocks, the second partially filled at the star
+    for (osmid_t id = 0; id < (PER_BLOCK+(PER_BLOCK >> 1) + 1); ++id)
+    {
+        expected_nodes.emplace_back(add_node(id, test_lat(id), 0.0));
     }
-  }
-  return 0;
+
+    // 1 dense block, 75% filled
+    for (osmid_t id = PER_BLOCK*2; id < PER_BLOCK*3; ++id)
+    {
+        if ((id % 4 == 0) || (id % 4 == 1) || (id % 4 == 2))
+            expected_nodes.emplace_back(add_node(id, test_lat(id), 0.0));
+    }
+
+    // 1 dense block, sparsly filled
+    for (osmid_t id = PER_BLOCK*3; id < PER_BLOCK*4; ++id)
+    {
+        if (id % 4 == 0)
+            expected_nodes.emplace_back(add_node(id, test_lat(id), 0.0));
+    }
+
+    // A lone sparse node
+    expected_nodes.emplace_back(add_node(PER_BLOCK*5, test_lat(PER_BLOCK*5), 0.0));
+
+    // A dense block of alternating positions of zero/non-zero
+    for (osmid_t id = PER_BLOCK*6; id < PER_BLOCK*7; ++id)
+    {
+        if (id % 2 == 0)
+            expected_nodes.emplace_back(add_node(id, 0.0, 0.0));
+        else
+            expected_nodes.emplace_back(add_node(id, test_lat(id), 0.0));
+    }
+    expected_nodes.emplace_back(add_node(PER_BLOCK*8, 0.0, 0.0));
+    expected_nodes.emplace_back(add_node(PER_BLOCK*8+1, 0.0, 0.0));
+
+    // Load up the nodes into the middle
+    idlist_t ids;
+    ids.reserve(expected_nodes.size());
+
+    for (auto pos : expected_nodes)
+    {
+        auto const &node = buffer.get<osmium::Node>(pos);
+        mid->nodes_set(node, node.location().lat(), node.location().lon(), false);
+        ids.push_back(node.id());
+    }
+
+    nodelist_t nodes;
+    if (mid->nodes_get_list(nodes, ids) != ids.size()) {
+        std::cerr << "ERROR: Unable to get node list.\n";
+        return 1;
+    }
+
+    if (nodes.size() != ids.size()) {
+        std::cerr << "ERROR: Mismatch in returned node list size.\n";
+        return 1;
+    }
+
+    for (size_t i = 0; i < nodes.size(); ++i)
+    {
+        auto const &node = buffer.get<osmium::Node>(expected_nodes[i]);
+        if (!node_okay(nodes[i], node)) {
+            return 1;
+        }
+    }
+
+    return 0;
 }
 
 struct test_pending_processor : public middle_t::pending_processor {
     test_pending_processor(): pending_ways(), pending_rels() {}
-    virtual ~test_pending_processor() {}
-    virtual void enqueue_ways(osmid_t id) {
+    ~test_pending_processor() {}
+    void enqueue_ways(osmid_t id) override
+    {
         pending_ways.push_back(id);
     }
-    virtual void process_ways() {
+    void process_ways() override
+    {
         pending_ways.clear();
     }
-    virtual void enqueue_relations(osmid_t id) {
+    void enqueue_relations(osmid_t id) override
+    {
         pending_rels.push_back(id);
     }
-    virtual void process_relations() {
+    void process_relations() override
+    {
         pending_rels.clear();
-    }
-    virtual int thread_count() {
-        return 0;
-    }
-    virtual int size() {
-        return pending_ways.size() + pending_rels.size();
     }
     std::list<osmid_t> pending_ways;
     std::list<osmid_t> pending_rels;
@@ -158,84 +174,92 @@ struct test_pending_processor : public middle_t::pending_processor {
 
 int test_way_set(middle_t *mid)
 {
-  osmid_t way_id = 1;
-  double lat = 12.3456789;
-  double lon = 98.7654321;
-  taglist_t tags;
-  struct osmNode *node_ptr = nullptr;
-  idlist_t nds;
-  for (osmid_t i = 1; i <= 10; ++i)
-      nds.push_back(i);
+    buffer.clear();
 
-  // set the nodes
-  for (size_t i = 0; i < nds.size(); ++i) {
-    mid->nodes_set(nds[i], lat, lon, tags);
-  }
+    osmid_t way_id = 1;
+    double lat = 12.3456789;
+    double lon = 98.7654321;
+    osmNode *node_ptr = nullptr;
+    idlist_t nds;
+    std::vector<size_t> nodes;
 
-  // set the way
-  mid->ways_set(way_id, nds, tags);
+    // set nodes
+    for (osmid_t i = 1; i <= 10; ++i) {
+        nds.push_back(i);
+        nodes.push_back(add_node(i, lat, lon));
+        auto const &node = buffer.get<osmium::Node>(nodes.back());
+        mid->nodes_set(node, lat, lon, false);
+    }
 
-  // commit the setup data
-  mid->commit();
+    // set the way
+    {
+        using namespace osmium::builder::attr;
+        auto pos = osmium::builder::add_way(buffer, _id(way_id), _nodes(nds));
+        auto const &way = buffer.get<osmium::Way>(pos);
+        mid->ways_set(way, false);
+    }
 
-  // get it back
-  idlist_t ways, xways;
-  ways.push_back(way_id);
-  std::vector<taglist_t> xtags;
-  multinodelist_t xnodes;
-  size_t way_count = mid->ways_get_list(ways, xways, xtags, xnodes);
-  if (way_count != 1) { std::cerr << "ERROR: Unable to get way list.\n"; return 1; }
+    // commit the setup data
+    mid->commit();
 
-  // check that it's the same
-  if (xnodes[0].size() != nds.size()) {
-    std::cerr << "ERROR: Way should have " << nds.size() << " nodes, but got back "
-              << xnodes[0].size() << " from middle.\n";
-    return 1;
-  }
-  if (xways[0] != way_id) {
-    std::cerr << "ERROR: Way should have id=" << way_id << ", but got back "
-              << xways[0] << " from middle.\n";
-    return 1;
-  }
-  for (size_t i = 0; i < nds.size(); ++i) {
-    if (xnodes[0][i].lon != lon) {
-      std::cerr << "ERROR: Way node should have lon=" << lon << ", but got back "
+    // get it back
+    idlist_t ways, xways;
+    ways.push_back(way_id);
+    std::vector<taglist_t> xtags;
+    multinodelist_t xnodes;
+    size_t way_count = mid->ways_get_list(ways, xways, xtags, xnodes);
+    if (way_count != 1) { std::cerr << "ERROR: Unable to get way list.\n"; return 1; }
+
+    // check that it's the same
+    if (xnodes[0].size() != nds.size()) {
+        std::cerr << "ERROR: Way should have " << nds.size() << " nodes, but got back "
+            << xnodes[0].size() << " from middle.\n";
+        return 1;
+    }
+    if (xways[0] != way_id) {
+        std::cerr << "ERROR: Way should have id=" << way_id << ", but got back "
+            << xways[0] << " from middle.\n";
+        return 1;
+    }
+    for (size_t i = 0; i < nds.size(); ++i) {
+        if (xnodes[0][i].lon != lon) {
+            std::cerr << "ERROR: Way node should have lon=" << lon << ", but got back "
                 << node_ptr[i].lon << " from middle.\n";
-      return 1;
-    }
-    if (xnodes[0][i].lat != lat) {
-      std::cerr << "ERROR: Way node should have lat=" << lat << ", but got back "
+            return 1;
+        }
+        if (xnodes[0][i].lat != lat) {
+            std::cerr << "ERROR: Way node should have lat=" << lat << ", but got back "
                 << node_ptr[i].lat << " from middle.\n";
-      return 1;
+            return 1;
+        }
     }
-  }
 
-  // the way we just inserted should not be pending
-  test_pending_processor tpp;
-  mid->iterate_ways(tpp);
-  if (mid->pending_count() != 0) {
-    std::cerr << "ERROR: Was expecting no pending ways, but got "
-              << mid->pending_count() << " from middle.\n";
-    return 1;
-  }
+    // the way we just inserted should not be pending
+    test_pending_processor tpp;
+    mid->iterate_ways(tpp);
+    if (mid->pending_count() != 0) {
+        std::cerr << "ERROR: Was expecting no pending ways, but got "
+            << mid->pending_count() << " from middle.\n";
+        return 1;
+    }
 
-  // some middles don't support changing the nodes - they
-  // don't have diff update ability. here, we will just
-  // skip the test for that.
-  if (dynamic_cast<slim_middle_t *>(mid)) {
-      slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid);
+    // some middles don't support changing the nodes - they
+    // don't have diff update ability. here, we will just
+    // skip the test for that.
+    if (dynamic_cast<slim_middle_t *>(mid)) {
+        slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid);
 
-      // finally, try touching a node on a non-pending way. that should
-      // make it become pending. we just checked that the way is not
-      // pending, so any change must be due to the node changing.
-      slim->node_changed(nds[0]);
-      slim->iterate_ways(tpp);
-      if (slim->pending_count() != 1) {
-          std::cerr << "ERROR: Was expecting a single pending way from node update, but got "
-                    << slim->pending_count() << " from middle.\n";
-          return 1;
-      }
-  }
+        // finally, try touching a node on a non-pending way. that should
+        // make it become pending. we just checked that the way is not
+        // pending, so any change must be due to the node changing.
+        slim->node_changed(nds[0]);
+        slim->iterate_ways(tpp);
+        if (slim->pending_count() != 1) {
+            std::cerr << "ERROR: Was expecting a single pending way from node update, but got "
+                << slim->pending_count() << " from middle.\n";
+            return 1;
+        }
+    }
 
-  return 0;
+    return 0;
 }

--- a/tests/middle-tests.cpp
+++ b/tests/middle-tests.cpp
@@ -56,7 +56,7 @@ int test_node_set(middle_t *mid)
     nodelist_t nodes;
 
     // set the node
-    mid->nodes_set(node, node.location().lat(), node.location().lon(), false);
+    mid->nodes_set(node, node.location().lat(), node.location().lon());
 
     // get it back
     if (mid->nodes_get_list(nodes, way.nodes()) != way.nodes().size()) {
@@ -127,7 +127,7 @@ int test_nodes_comprehensive_set(middle_t *mid)
     for (auto pos : expected_nodes)
     {
         auto const &node = buffer.get<osmium::Node>(pos);
-        mid->nodes_set(node, node.location().lat(), node.location().lon(), false);
+        mid->nodes_set(node, node.location().lat(), node.location().lon());
         ids.push_back(node.id());
     }
 
@@ -194,7 +194,7 @@ int test_way_set(middle_t *mid)
         nds.push_back(i);
         nodes.push_back(add_node(i, lat, lon));
         auto const &node = buffer.get<osmium::Node>(nodes.back());
-        mid->nodes_set(node, lat, lon, false);
+        mid->nodes_set(node, lat, lon);
     }
 
     // set the way
@@ -202,7 +202,7 @@ int test_way_set(middle_t *mid)
         using namespace osmium::builder::attr;
         auto pos = osmium::builder::add_way(buffer, _id(way_id), _nodes(nds));
         auto const &way = buffer.get<osmium::Way>(pos);
-        mid->ways_set(way, false);
+        mid->ways_set(way);
     }
 
     // commit the setup data

--- a/tests/mockups.hpp
+++ b/tests/mockups.hpp
@@ -14,16 +14,16 @@ struct dummy_middle_t : public middle_t {
     void end(void) { }
     void commit(void) { }
 
-    void nodes_set(osmid_t, double, double, const taglist_t &) { }
+    void nodes_set(osmium::Node const &, double, double, bool) { }
     size_t nodes_get_list(nodelist_t &, const idlist_t) const { return 0; }
 
-    void ways_set(osmid_t, const idlist_t &, const taglist_t &) { }
+    void ways_set(osmium::Way const &, bool) { }
     bool ways_get(osmid_t, taglist_t &, nodelist_t &) const { return true; }
     size_t ways_get_list(const idlist_t &, idlist_t &,
                               std::vector<taglist_t> &,
                               std::vector<nodelist_t> &) const { return 0; }
 
-    void relations_set(osmid_t, const memberlist_t &, const taglist_t &) { }
+    void relations_set(osmium::Relation const &, bool) { }
     bool relations_get(osmid_t, memberlist_t &, taglist_t &) const { return 0; }
 
     void iterate_ways(pending_processor&) { }
@@ -46,16 +46,16 @@ struct dummy_slim_middle_t : public slim_middle_t {
     void end(void) { }
     void commit(void) { }
 
-    void nodes_set(osmid_t, double, double, const taglist_t &) { }
+    void nodes_set(osmium::Node const &, double, double, bool) { }
     size_t nodes_get_list(nodelist_t &, const idlist_t) const { return 0; }
 
-    void ways_set(osmid_t, const idlist_t &, const taglist_t &) { }
+    void ways_set(osmium::Way const &, bool) { }
     bool ways_get(osmid_t, taglist_t &, nodelist_t &) const { return true; }
     size_t ways_get_list(const idlist_t &, idlist_t &,
                               std::vector<taglist_t> &,
                               std::vector<nodelist_t> &) const { return 0; }
 
-    void relations_set(osmid_t, const memberlist_t &, const taglist_t &) { }
+    void relations_set(osmium::Relation const &, bool) { }
     bool relations_get(osmid_t, memberlist_t &, taglist_t &) const { return 0; }
 
     void iterate_ways(pending_processor&) { }

--- a/tests/mockups.hpp
+++ b/tests/mockups.hpp
@@ -24,7 +24,7 @@ struct dummy_middle_t : public middle_t {
                               std::vector<nodelist_t> &) const { return 0; }
 
     void relations_set(osmium::Relation const &, bool) { }
-    bool relations_get(osmid_t, memberlist_t &, taglist_t &) const { return 0; }
+    bool relations_get(osmid_t, osmium::memory::Buffer &) const override { return 0; }
 
     void iterate_ways(pending_processor&) { }
     void iterate_relations(pending_processor&) { }
@@ -56,7 +56,7 @@ struct dummy_slim_middle_t : public slim_middle_t {
                               std::vector<nodelist_t> &) const { return 0; }
 
     void relations_set(osmium::Relation const &, bool) { }
-    bool relations_get(osmid_t, memberlist_t &, taglist_t &) const { return 0; }
+    bool relations_get(osmid_t, osmium::memory::Buffer &) const override { return 0; }
 
     void iterate_ways(pending_processor&) { }
     void iterate_relations(pending_processor&) { }

--- a/tests/mockups.hpp
+++ b/tests/mockups.hpp
@@ -31,7 +31,7 @@ struct dummy_middle_t : public middle_t {
 
     virtual size_t pending_count() const { return 0; }
 
-    std::vector<osmid_t> relations_using_way(osmid_t) const { return std::vector<osmid_t>(); }
+    idlist_t relations_using_way(osmid_t) const { return idlist_t(); }
 
     virtual std::shared_ptr<const middle_query_t> get_instance() const {return std::shared_ptr<const middle_query_t>();}
 };
@@ -63,7 +63,7 @@ struct dummy_slim_middle_t : public slim_middle_t {
 
     size_t pending_count() const { return 0; }
 
-    std::vector<osmid_t> relations_using_way(osmid_t) const { return std::vector<osmid_t>(); }
+    idlist_t relations_using_way(osmid_t) const { return idlist_t(); }
 
     std::shared_ptr<const middle_query_t> get_instance() const {return std::shared_ptr<const middle_query_t>();}
 

--- a/tests/mockups.hpp
+++ b/tests/mockups.hpp
@@ -7,12 +7,12 @@
 struct dummy_middle_t : public middle_t {
     virtual ~dummy_middle_t() = default;
 
-    void start(const options_t *) { }
-    void stop(void) { }
+    void start(const options_t *) override { }
+    void stop(void) override  { }
     void cleanup(void) { }
-    void analyze(void) { }
-    void end(void) { }
-    void commit(void) { }
+    void analyze(void) override  { }
+    void end(void) override  { }
+    void commit(void) override  { }
 
     void nodes_set(osmium::Node const &, double, double) override { }
     size_t nodes_get_list(nodelist_t &, osmium::WayNodeList const &) const override { return 0; }
@@ -24,25 +24,28 @@ struct dummy_middle_t : public middle_t {
     void relations_set(osmium::Relation const &) override { }
     bool relations_get(osmid_t, osmium::memory::Buffer &) const override { return 0; }
 
-    void iterate_ways(pending_processor&) { }
-    void iterate_relations(pending_processor&) { }
+    void iterate_ways(pending_processor&) override  { }
+    void iterate_relations(pending_processor&) override  { }
 
-    virtual size_t pending_count() const { return 0; }
+    virtual size_t pending_count() const override  { return 0; }
 
-    idlist_t relations_using_way(osmid_t) const { return idlist_t(); }
+    idlist_t relations_using_way(osmid_t) const override  { return idlist_t(); }
 
-    virtual std::shared_ptr<const middle_query_t> get_instance() const {return std::shared_ptr<const middle_query_t>();}
+    std::shared_ptr<const middle_query_t> get_instance() const override
+    {
+        return std::shared_ptr<const middle_query_t>();
+    }
 };
 
 struct dummy_slim_middle_t : public slim_middle_t {
     virtual ~dummy_slim_middle_t() = default;
 
-    void start(const options_t *) { }
-    void stop(void) { }
+    void start(const options_t *) override  { }
+    void stop(void) override  { }
     void cleanup(void) { }
-    void analyze(void) { }
-    void end(void) { }
-    void commit(void) { }
+    void analyze(void) override  { }
+    void end(void) override  { }
+    void commit(void) override  { }
 
     void nodes_set(osmium::Node const &, double, double) override { }
     size_t nodes_get_list(nodelist_t &, osmium::WayNodeList const &) const override { return 0; }
@@ -54,23 +57,23 @@ struct dummy_slim_middle_t : public slim_middle_t {
     void relations_set(osmium::Relation const &) override { }
     bool relations_get(osmid_t, osmium::memory::Buffer &) const override { return 0; }
 
-    void iterate_ways(pending_processor&) { }
-    void iterate_relations(pending_processor&) { }
+    void iterate_ways(pending_processor&) override  { }
+    void iterate_relations(pending_processor&) override  { }
 
-    size_t pending_count() const { return 0; }
+    size_t pending_count() const override  { return 0; }
 
-    idlist_t relations_using_way(osmid_t) const { return idlist_t(); }
+    idlist_t relations_using_way(osmid_t) const override  { return idlist_t(); }
 
-    std::shared_ptr<const middle_query_t> get_instance() const {return std::shared_ptr<const middle_query_t>();}
+    std::shared_ptr<const middle_query_t> get_instance() const override  {return std::shared_ptr<const middle_query_t>();}
 
-    void nodes_delete(osmid_t) {};
-    void node_changed(osmid_t) {};
+    void nodes_delete(osmid_t) override  {};
+    void node_changed(osmid_t) override  {};
 
-    void ways_delete(osmid_t) {};
-    void way_changed(osmid_t) {};
+    void ways_delete(osmid_t) override  {};
+    void way_changed(osmid_t) override  {};
 
-    void relations_delete(osmid_t) {};
-    void relation_changed(osmid_t) {};
+    void relations_delete(osmid_t) override  {};
+    void relation_changed(osmid_t) override  {};
 };
 
 struct dummy_output_t : public output_null_t {

--- a/tests/mockups.hpp
+++ b/tests/mockups.hpp
@@ -15,7 +15,7 @@ struct dummy_middle_t : public middle_t {
     void commit(void) { }
 
     void nodes_set(osmium::Node const &, double, double, bool) { }
-    size_t nodes_get_list(nodelist_t &, const idlist_t) const { return 0; }
+    size_t nodes_get_list(nodelist_t &, osmium::WayNodeList const &) const { return 0; }
 
     void ways_set(osmium::Way const &, bool) { }
     bool ways_get(osmid_t, taglist_t &, nodelist_t &) const { return true; }
@@ -47,7 +47,7 @@ struct dummy_slim_middle_t : public slim_middle_t {
     void commit(void) { }
 
     void nodes_set(osmium::Node const &, double, double, bool) { }
-    size_t nodes_get_list(nodelist_t &, const idlist_t) const { return 0; }
+    size_t nodes_get_list(nodelist_t &, osmium::WayNodeList const &) const { return 0; }
 
     void ways_set(osmium::Way const &, bool) { }
     bool ways_get(osmid_t, taglist_t &, nodelist_t &) const { return true; }

--- a/tests/mockups.hpp
+++ b/tests/mockups.hpp
@@ -2,7 +2,7 @@
 #define TESTS_MOCKUPS_HPP
 
 #include "middle.hpp"
-#include "output.hpp"
+#include "output-null.hpp"
 
 struct dummy_middle_t : public middle_t {
     virtual ~dummy_middle_t() = default;
@@ -77,39 +77,13 @@ struct dummy_slim_middle_t : public slim_middle_t {
     void relation_changed(osmid_t) {};
 };
 
-struct dummy_output_t : public output_t {
+struct dummy_output_t : public output_null_t {
 
     explicit dummy_output_t(const options_t &options_)
-        : output_t(nullptr, options_) {
+        : output_null_t(nullptr, options_) {
     }
 
-    virtual ~dummy_output_t() = default;
-
-    int node_add(osmid_t, double, double, const taglist_t &) { return 0; }
-    int way_add(osmid_t, const idlist_t &, const taglist_t &) { return 0; }
-    int relation_add(osmid_t, const memberlist_t &, const taglist_t &) { return 0; }
-
-    int start() { return 0; }
-    int connect(int) { return 0; }
-    void stop() { }
-    void commit() { }
-    void cleanup(void) { }
-    void close(int) { }
-
-    void enqueue_ways(pending_queue_t &, osmid_t, size_t, size_t&) { }
-    int pending_way(osmid_t, int) { return 0; }
-
-    void enqueue_relations(pending_queue_t &, osmid_t, size_t, size_t&) { }
-    int pending_relation(osmid_t, int) { return 0; }
-
-    int node_modify(osmid_t, double, double, const taglist_t &) { return 0; }
-    int way_modify(osmid_t, const idlist_t &, const taglist_t &) { return 0; }
-    int relation_modify(osmid_t, const memberlist_t &, const taglist_t &) { return 0; }
-
-    int node_delete(osmid_t) { return 0; }
-    int way_delete(osmid_t) { return 0; }
-    int relation_delete(osmid_t) { return 0; }
-
+    ~dummy_output_t() = default;
 };
 
 #endif

--- a/tests/mockups.hpp
+++ b/tests/mockups.hpp
@@ -18,10 +18,8 @@ struct dummy_middle_t : public middle_t {
     size_t nodes_get_list(nodelist_t &, osmium::WayNodeList const &) const { return 0; }
 
     void ways_set(osmium::Way const &, bool) { }
-    bool ways_get(osmid_t, taglist_t &, nodelist_t &) const { return true; }
-    size_t ways_get_list(const idlist_t &, idlist_t &,
-                              std::vector<taglist_t> &,
-                              std::vector<nodelist_t> &) const { return 0; }
+    bool ways_get(osmid_t, osmium::memory::Buffer &) const override { return true; }
+    size_t ways_get_list(idlist_t const &, osmium::memory::Buffer &) const override { return 0; }
 
     void relations_set(osmium::Relation const &, bool) { }
     bool relations_get(osmid_t, osmium::memory::Buffer &) const override { return 0; }
@@ -50,10 +48,8 @@ struct dummy_slim_middle_t : public slim_middle_t {
     size_t nodes_get_list(nodelist_t &, osmium::WayNodeList const &) const { return 0; }
 
     void ways_set(osmium::Way const &, bool) { }
-    bool ways_get(osmid_t, taglist_t &, nodelist_t &) const { return true; }
-    size_t ways_get_list(const idlist_t &, idlist_t &,
-                              std::vector<taglist_t> &,
-                              std::vector<nodelist_t> &) const { return 0; }
+    bool ways_get(osmid_t, osmium::memory::Buffer &) const override { return true; }
+    size_t ways_get_list(idlist_t const &, osmium::memory::Buffer &) const override { return 0; }
 
     void relations_set(osmium::Relation const &, bool) { }
     bool relations_get(osmid_t, osmium::memory::Buffer &) const override { return 0; }

--- a/tests/mockups.hpp
+++ b/tests/mockups.hpp
@@ -14,14 +14,14 @@ struct dummy_middle_t : public middle_t {
     void end(void) { }
     void commit(void) { }
 
-    void nodes_set(osmium::Node const &, double, double, bool) { }
-    size_t nodes_get_list(nodelist_t &, osmium::WayNodeList const &) const { return 0; }
+    void nodes_set(osmium::Node const &, double, double) override { }
+    size_t nodes_get_list(nodelist_t &, osmium::WayNodeList const &) const override { return 0; }
 
-    void ways_set(osmium::Way const &, bool) { }
+    void ways_set(osmium::Way const &) override { }
     bool ways_get(osmid_t, osmium::memory::Buffer &) const override { return true; }
     size_t ways_get_list(idlist_t const &, osmium::memory::Buffer &) const override { return 0; }
 
-    void relations_set(osmium::Relation const &, bool) { }
+    void relations_set(osmium::Relation const &) override { }
     bool relations_get(osmid_t, osmium::memory::Buffer &) const override { return 0; }
 
     void iterate_ways(pending_processor&) { }
@@ -44,14 +44,14 @@ struct dummy_slim_middle_t : public slim_middle_t {
     void end(void) { }
     void commit(void) { }
 
-    void nodes_set(osmium::Node const &, double, double, bool) { }
-    size_t nodes_get_list(nodelist_t &, osmium::WayNodeList const &) const { return 0; }
+    void nodes_set(osmium::Node const &, double, double) override { }
+    size_t nodes_get_list(nodelist_t &, osmium::WayNodeList const &) const override { return 0; }
 
-    void ways_set(osmium::Way const &, bool) { }
+    void ways_set(osmium::Way const &) override { }
     bool ways_get(osmid_t, osmium::memory::Buffer &) const override { return true; }
     size_t ways_get_list(idlist_t const &, osmium::memory::Buffer &) const override { return 0; }
 
-    void relations_set(osmium::Relation const &, bool) { }
+    void relations_set(osmium::Relation const &) override { }
     bool relations_get(osmid_t, osmium::memory::Buffer &) const override { return 0; }
 
     void iterate_ways(pending_processor&) { }

--- a/tests/test-hstore-match-only.cpp
+++ b/tests/test-hstore-match-only.cpp
@@ -55,7 +55,7 @@ int main(int argc, char *argv[]) {
 
         auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-        osmdata_t osmdata(mid_pgsql, out_test);
+        osmdata_t osmdata(mid_pgsql, out_test, options.projection, false);
 
         testing::parse("tests/hstore-match-only.osm", "xml",
                        options, &osmdata);

--- a/tests/test-hstore-match-only.cpp
+++ b/tests/test-hstore-match-only.cpp
@@ -55,7 +55,7 @@ int main(int argc, char *argv[]) {
 
         auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-        osmdata_t osmdata(mid_pgsql, out_test, options.projection, false);
+        osmdata_t osmdata(mid_pgsql, out_test, options.projection);
 
         testing::parse("tests/hstore-match-only.osm", "xml",
                        options, &osmdata);

--- a/tests/test-options-projection.cpp
+++ b/tests/test-options-projection.cpp
@@ -45,7 +45,7 @@ static void check_tables(pg::tempdb *db, options_t &options,
     options.database_options = db->database_options;
     auto mid_ram = std::make_shared<middle_ram_t>();
     auto out_test = std::make_shared<output_pgsql_t>(mid_ram.get(), options);
-    osmdata_t osmdata(mid_ram, out_test, options.projection, false);
+    osmdata_t osmdata(mid_ram, out_test, options.projection);
 
     testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                    options, &osmdata);

--- a/tests/test-options-projection.cpp
+++ b/tests/test-options-projection.cpp
@@ -45,7 +45,7 @@ static void check_tables(pg::tempdb *db, options_t &options,
     options.database_options = db->database_options;
     auto mid_ram = std::make_shared<middle_ram_t>();
     auto out_test = std::make_shared<output_pgsql_t>(mid_ram.get(), options);
-    osmdata_t osmdata(mid_ram, out_test);
+    osmdata_t osmdata(mid_ram, out_test, options.projection, false);
 
     testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                    options, &osmdata);

--- a/tests/test-output-multi-line-storage.cpp
+++ b/tests/test-output-multi-line-storage.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[]) {
         std::vector<std::shared_ptr<output_t> > outputs = output_t::create_outputs(middle.get(), options);
 
         //let osmdata orchestrate between the middle and the outs
-        osmdata_t osmdata(middle, outputs, options.projection, options.extra_attributes);
+        osmdata_t osmdata(middle, outputs, options.projection);
 
         testing::parse("tests/test_output_multi_line_storage.osm", "xml",
                        options, &osmdata);

--- a/tests/test-output-multi-line-storage.cpp
+++ b/tests/test-output-multi-line-storage.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[]) {
         std::vector<std::shared_ptr<output_t> > outputs = output_t::create_outputs(middle.get(), options);
 
         //let osmdata orchestrate between the middle and the outs
-        osmdata_t osmdata(middle, outputs);
+        osmdata_t osmdata(middle, outputs, options.projection, options.extra_attributes);
 
         testing::parse("tests/test_output_multi_line_storage.osm", "xml",
                        options, &osmdata);

--- a/tests/test-output-multi-line.cpp
+++ b/tests/test-output-multi-line.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) {
         // This actually uses the multi-backend with C transforms, not Lua transforms. This is unusual and doesn't reflect real practice
         auto out_test = std::make_shared<output_multi_t>("foobar_highways", processor, columns, mid_pgsql.get(), options);
 
-        osmdata_t osmdata(mid_pgsql, out_test);
+        osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-multi-line.cpp
+++ b/tests/test-output-multi-line.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[]) {
             geometry_processor::create("line", &options);
 
         export_list columns;
-        { taginfo info; info.name = "highway"; info.type = "text"; columns.add(OSMTYPE_WAY, info); }
+        { taginfo info; info.name = "highway"; info.type = "text"; columns.add(osmium::item_type::way, info); }
 
         // This actually uses the multi-backend with C transforms, not Lua transforms. This is unusual and doesn't reflect real practice
         auto out_test = std::make_shared<output_multi_t>("foobar_highways", processor, columns, mid_pgsql.get(), options);

--- a/tests/test-output-multi-line.cpp
+++ b/tests/test-output-multi-line.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) {
         // This actually uses the multi-backend with C transforms, not Lua transforms. This is unusual and doesn't reflect real practice
         auto out_test = std::make_shared<output_multi_t>("foobar_highways", processor, columns, mid_pgsql.get(), options);
 
-        osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
+        osmdata_t osmdata(mid_pgsql, out_test, options.projection);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-multi-point-multi-table.cpp
+++ b/tests/test-output-multi-point-multi-table.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[]) {
         options.slim = true;
 
         export_list columns;
-        { taginfo info; info.name = "amenity"; info.type = "text"; columns.add(OSMTYPE_NODE, info); }
+        { taginfo info; info.name = "amenity"; info.type = "text"; columns.add(osmium::item_type::node, info); }
 
         std::vector<std::shared_ptr<output_t> > outputs;
 

--- a/tests/test-output-multi-point-multi-table.cpp
+++ b/tests/test-output-multi-point-multi-table.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[]) {
             outputs.push_back(out_test);
         }
 
-        osmdata_t osmdata(mid_pgsql, outputs);
+        osmdata_t osmdata(mid_pgsql, outputs, options.projection, options.extra_attributes);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-multi-point-multi-table.cpp
+++ b/tests/test-output-multi-point-multi-table.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[]) {
             outputs.push_back(out_test);
         }
 
-        osmdata_t osmdata(mid_pgsql, outputs, options.projection, options.extra_attributes);
+        osmdata_t osmdata(mid_pgsql, outputs, options.projection);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-multi-point.cpp
+++ b/tests/test-output-multi-point.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) {
 
         auto out_test = std::make_shared<output_multi_t>("foobar_amenities", processor, columns, mid_pgsql.get(), options);
 
-        osmdata_t osmdata(mid_pgsql, out_test);
+        osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-multi-point.cpp
+++ b/tests/test-output-multi-point.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) {
 
         auto out_test = std::make_shared<output_multi_t>("foobar_amenities", processor, columns, mid_pgsql.get(), options);
 
-        osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
+        osmdata_t osmdata(mid_pgsql, out_test, options.projection);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-multi-point.cpp
+++ b/tests/test-output-multi-point.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[]) {
             geometry_processor::create("point", &options);
 
         export_list columns;
-        { taginfo info; info.name = "amenity"; info.type = "text"; columns.add(OSMTYPE_NODE, info); }
+        { taginfo info; info.name = "amenity"; info.type = "text"; columns.add(osmium::item_type::node, info); }
 
         auto out_test = std::make_shared<output_multi_t>("foobar_amenities", processor, columns, mid_pgsql.get(), options);
 

--- a/tests/test-output-multi-poly-trivial.cpp
+++ b/tests/test-output-multi-poly-trivial.cpp
@@ -31,7 +31,7 @@ void run_osm2pgsql(options_t &options) {
   std::vector<std::shared_ptr<output_t> > outputs = output_t::create_outputs(middle.get(), options);
 
   //let osmdata orchestrate between the middle and the outs
-  osmdata_t osmdata(middle, outputs, options.projection, options.extra_attributes);
+  osmdata_t osmdata(middle, outputs, options.projection);
 
   testing::parse("tests/test_output_multi_poly_trivial.osm", "xml",
                  options, &osmdata);

--- a/tests/test-output-multi-poly-trivial.cpp
+++ b/tests/test-output-multi-poly-trivial.cpp
@@ -31,7 +31,7 @@ void run_osm2pgsql(options_t &options) {
   std::vector<std::shared_ptr<output_t> > outputs = output_t::create_outputs(middle.get(), options);
 
   //let osmdata orchestrate between the middle and the outs
-  osmdata_t osmdata(middle, outputs);
+  osmdata_t osmdata(middle, outputs, options.projection, options.extra_attributes);
 
   testing::parse("tests/test_output_multi_poly_trivial.osm", "xml",
                  options, &osmdata);

--- a/tests/test-output-multi-polygon.cpp
+++ b/tests/test-output-multi-polygon.cpp
@@ -48,7 +48,7 @@ int main(int argc, char *argv[]) {
 
         auto out_test = std::make_shared<output_multi_t>("foobar_buildings", processor, columns, mid_pgsql.get(), options);
 
-        osmdata_t osmdata(mid_pgsql, out_test);
+        osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-multi-polygon.cpp
+++ b/tests/test-output-multi-polygon.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[]) {
         std::shared_ptr<geometry_processor> processor = geometry_processor::create("polygon", &options);
 
         export_list columns;
-        { taginfo info; info.name = "building"; info.type = "text"; columns.add(OSMTYPE_WAY, info); }
+        { taginfo info; info.name = "building"; info.type = "text"; columns.add(osmium::item_type::way, info); }
 
         auto out_test = std::make_shared<output_multi_t>("foobar_buildings", processor, columns, mid_pgsql.get(), options);
 

--- a/tests/test-output-multi-polygon.cpp
+++ b/tests/test-output-multi-polygon.cpp
@@ -48,7 +48,7 @@ int main(int argc, char *argv[]) {
 
         auto out_test = std::make_shared<output_multi_t>("foobar_buildings", processor, columns, mid_pgsql.get(), options);
 
-        osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
+        osmdata_t osmdata(mid_pgsql, out_test, options.projection);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-multi-tags.cpp
+++ b/tests/test-output-multi-tags.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[]) {
         std::vector<std::shared_ptr<output_t> > outputs = output_t::create_outputs(middle.get(), options);
 
         //let osmdata orchestrate between the middle and the outs
-        osmdata_t osmdata(middle, outputs, options.projection, options.extra_attributes);
+        osmdata_t osmdata(middle, outputs, options.projection);
 
         testing::parse("tests/test_output_multi_tags.osm", "xml",
                        options, &osmdata);

--- a/tests/test-output-multi-tags.cpp
+++ b/tests/test-output-multi-tags.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[]) {
         std::vector<std::shared_ptr<output_t> > outputs = output_t::create_outputs(middle.get(), options);
 
         //let osmdata orchestrate between the middle and the outs
-        osmdata_t osmdata(middle, outputs);
+        osmdata_t osmdata(middle, outputs, options.projection, options.extra_attributes);
 
         testing::parse("tests/test_output_multi_tags.osm", "xml",
                        options, &osmdata);

--- a/tests/test-output-pgsql-area.cpp
+++ b/tests/test-output-pgsql-area.cpp
@@ -76,7 +76,7 @@ void test_area_base(bool latlon, bool reproj, double expect_area_poly, double ex
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
     testing::parse("tests/test_output_pgsql_area.osm", "xml",
                    options, &osmdata);
 

--- a/tests/test-output-pgsql-area.cpp
+++ b/tests/test-output-pgsql-area.cpp
@@ -76,7 +76,7 @@ void test_area_base(bool latlon, bool reproj, double expect_area_poly, double ex
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection);
     testing::parse("tests/test_output_pgsql_area.osm", "xml",
                    options, &osmdata);
 

--- a/tests/test-output-pgsql-schema.cpp
+++ b/tests/test-output-pgsql-schema.cpp
@@ -77,7 +77,7 @@ void test_other_output_schema() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection);
 
     testing::parse("tests/test_output_pgsql_z_order.osm", "xml",
                    options, &osmdata);

--- a/tests/test-output-pgsql-schema.cpp
+++ b/tests/test-output-pgsql-schema.cpp
@@ -77,7 +77,7 @@ void test_other_output_schema() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
 
     testing::parse("tests/test_output_pgsql_z_order.osm", "xml",
                    options, &osmdata);

--- a/tests/test-output-pgsql-tablespace.cpp
+++ b/tests/test-output-pgsql-tablespace.cpp
@@ -78,7 +78,7 @@ void test_regression_simple() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
 
     testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                    options, &osmdata);

--- a/tests/test-output-pgsql-tablespace.cpp
+++ b/tests/test-output-pgsql-tablespace.cpp
@@ -78,7 +78,7 @@ void test_regression_simple() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection);
 
     testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                    options, &osmdata);

--- a/tests/test-output-pgsql-validgeom.cpp
+++ b/tests/test-output-pgsql-validgeom.cpp
@@ -73,7 +73,7 @@ void test_z_order() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection);
 
     testing::parse("tests/test_output_pgsql_validgeom.osm", "xml",
                    options, &osmdata);

--- a/tests/test-output-pgsql-z_order.cpp
+++ b/tests/test-output-pgsql-z_order.cpp
@@ -73,7 +73,7 @@ void test_z_order() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
 
     testing::parse("tests/test_output_pgsql_z_order.osm", "xml",
                    options, &osmdata);

--- a/tests/test-output-pgsql-z_order.cpp
+++ b/tests/test-output-pgsql-z_order.cpp
@@ -73,7 +73,7 @@ void test_z_order() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection);
 
     testing::parse("tests/test_output_pgsql_z_order.osm", "xml",
                    options, &osmdata);

--- a/tests/test-output-pgsql.cpp
+++ b/tests/test-output-pgsql.cpp
@@ -77,7 +77,7 @@ void test_regression_simple() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
 
     testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                    options, &osmdata);
@@ -130,7 +130,7 @@ void test_latlong() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
 
     testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                    options, &osmdata);
@@ -183,7 +183,7 @@ void test_area_way_simple() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
 
     testing::parse("tests/test_output_pgsql_way_area.osm", "xml",
                    options, &osmdata);
@@ -222,7 +222,7 @@ void test_route_rel() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_ram.get(), options);
 
-    osmdata_t osmdata(mid_ram, out_test);
+    osmdata_t osmdata(mid_ram, out_test, options.projection, options.extra_attributes);
 
     testing::parse("tests/test_output_pgsql_route_rel.osm", "xml",
                    options, &osmdata);
@@ -267,7 +267,7 @@ void test_clone() {
     //std::shared_ptr<middle_t> mid_clone = mid_pgsql->get_instance();
     std::shared_ptr<output_t> out_clone = out_test.clone(mid_pgsql.get());
 
-    osmdata_t osmdata(mid_pgsql, out_clone);
+    osmdata_t osmdata(mid_pgsql, out_clone, options.projection, options.extra_attributes);
 
     testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                    options, &osmdata);

--- a/tests/test-output-pgsql.cpp
+++ b/tests/test-output-pgsql.cpp
@@ -77,7 +77,7 @@ void test_regression_simple() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection);
 
     testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                    options, &osmdata);
@@ -130,7 +130,7 @@ void test_latlong() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection);
 
     testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                    options, &osmdata);
@@ -183,7 +183,7 @@ void test_area_way_simple() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
 
-    osmdata_t osmdata(mid_pgsql, out_test, options.projection, options.extra_attributes);
+    osmdata_t osmdata(mid_pgsql, out_test, options.projection);
 
     testing::parse("tests/test_output_pgsql_way_area.osm", "xml",
                    options, &osmdata);
@@ -222,7 +222,7 @@ void test_route_rel() {
 
     auto out_test = std::make_shared<output_pgsql_t>(mid_ram.get(), options);
 
-    osmdata_t osmdata(mid_ram, out_test, options.projection, options.extra_attributes);
+    osmdata_t osmdata(mid_ram, out_test, options.projection);
 
     testing::parse("tests/test_output_pgsql_route_rel.osm", "xml",
                    options, &osmdata);
@@ -267,7 +267,7 @@ void test_clone() {
     //std::shared_ptr<middle_t> mid_clone = mid_pgsql->get_instance();
     std::shared_ptr<output_t> out_clone = out_test.clone(mid_pgsql.get());
 
-    osmdata_t osmdata(mid_pgsql, out_clone, options.projection, options.extra_attributes);
+    osmdata_t osmdata(mid_pgsql, out_clone, options.projection);
 
     testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                    options, &osmdata);

--- a/tests/test-parse-diff.cpp
+++ b/tests/test-parse-diff.cpp
@@ -105,10 +105,10 @@ int main() {
   options.projection = projection;
 
   auto out_test = std::make_shared<test_output_t>(options);
-  osmdata_t osmdata(std::make_shared<dummy_slim_middle_t>(), out_test);
+  osmdata_t osmdata(std::make_shared<dummy_slim_middle_t>(), out_test, options.projection, options.extra_attributes);
 
   boost::optional<std::string> bbox;
-  parse_osmium_t parser(false, bbox, projection.get(), true, &osmdata);
+  parse_osmium_t parser(bbox, true, &osmdata);
 
   parser.stream_file(inputfile, "");
 

--- a/tests/test-parse-diff.cpp
+++ b/tests/test-parse-diff.cpp
@@ -41,33 +41,33 @@ struct test_output_t : public dummy_output_t {
         return std::shared_ptr<output_t>(clone);
     }
 
-    int node_add(osmium::Node const &n, double, double, bool) override {
+    int node_add(osmium::Node const &n, double, double) override {
         assert(n.id() > 0);
         ++node.added;
         return 0;
     }
 
-    int way_add(osmium::Way const &w, bool) override {
+    int way_add(osmium::Way const &w) override {
         assert(w.id() > 0);
         ++way.added;
         return 0;
     }
 
-    int relation_add(osmium::Relation const &r, bool) override {
+    int relation_add(osmium::Relation const &r) override {
         assert(r.id() > 0);
         ++rel.added;
         return 0;
     }
 
-    int node_modify(osmium::Node const &, double, double, bool) override {
+    int node_modify(osmium::Node const &, double, double) override {
         ++node.modified;
         return 0;
     }
-    int way_modify(osmium::Way const &, bool) override {
+    int way_modify(osmium::Way const &) override {
         ++way.modified;
         return 0;
     }
-    int relation_modify(osmium::Relation const &, bool) override {
+    int relation_modify(osmium::Relation const &) override {
         ++rel.modified;
         return 0;
     }
@@ -105,7 +105,7 @@ int main() {
   options.projection = projection;
 
   auto out_test = std::make_shared<test_output_t>(options);
-  osmdata_t osmdata(std::make_shared<dummy_slim_middle_t>(), out_test, options.projection, options.extra_attributes);
+  osmdata_t osmdata(std::make_shared<dummy_slim_middle_t>(), out_test, options.projection);
 
   boost::optional<std::string> bbox;
   parse_osmium_t parser(bbox, true, &osmdata);

--- a/tests/test-parse-diff.cpp
+++ b/tests/test-parse-diff.cpp
@@ -41,33 +41,33 @@ struct test_output_t : public dummy_output_t {
         return std::shared_ptr<output_t>(clone);
     }
 
-    int node_add(osmid_t id, double, double, const taglist_t &) {
-        assert(id > 0);
+    int node_add(osmium::Node const &n, double, double, bool) override {
+        assert(n.id() > 0);
         ++node.added;
         return 0;
     }
 
-    int way_add(osmid_t id, const idlist_t &, const taglist_t &) {
-        assert(id > 0);
+    int way_add(osmium::Way const &w, bool) override {
+        assert(w.id() > 0);
         ++way.added;
         return 0;
     }
 
-    int relation_add(osmid_t id, const memberlist_t &, const taglist_t &) {
-        assert(id > 0);
+    int relation_add(osmium::Relation const &r, bool) override {
+        assert(r.id() > 0);
         ++rel.added;
         return 0;
     }
 
-    int node_modify(osmid_t, double, double, const taglist_t &) {
+    int node_modify(osmium::Node const &, double, double, bool) override {
         ++node.modified;
         return 0;
     }
-    int way_modify(osmid_t, const idlist_t &, const taglist_t &) {
+    int way_modify(osmium::Way const &, bool) override {
         ++way.modified;
         return 0;
     }
-    int relation_modify(osmid_t, const memberlist_t &, const taglist_t &) {
+    int relation_modify(osmium::Relation const &, bool) override {
         ++rel.modified;
         return 0;
     }

--- a/tests/test-parse-diff.cpp
+++ b/tests/test-parse-diff.cpp
@@ -35,7 +35,7 @@ struct test_output_t : public dummy_output_t {
 
     virtual ~test_output_t() = default;
 
-    std::shared_ptr<output_t> clone(const middle_query_t *cloned_middle) const{
+    std::shared_ptr<output_t> clone(const middle_query_t *cloned_middle) const override {
         test_output_t *clone = new test_output_t(m_options);
         clone->m_mid = cloned_middle;
         return std::shared_ptr<output_t>(clone);
@@ -72,15 +72,15 @@ struct test_output_t : public dummy_output_t {
         return 0;
     }
 
-    int node_delete(osmid_t) {
+    int node_delete(osmid_t) override {
         ++node.deleted;
         return 0;
     }
-    int way_delete(osmid_t) {
+    int way_delete(osmid_t) override {
         ++way.deleted;
         return 0;
     }
-    int relation_delete(osmid_t) {
+    int relation_delete(osmid_t) override {
         ++rel.deleted;
         return 0;
     }

--- a/tests/test-parse-xml2.cpp
+++ b/tests/test-parse-xml2.cpp
@@ -107,10 +107,10 @@ int main(int argc, char *argv[]) {
   options.projection = projection;
 
   auto out_test = std::make_shared<test_output_t>(options);
-  osmdata_t osmdata(std::make_shared<dummy_middle_t>(), out_test);
+  osmdata_t osmdata(std::make_shared<dummy_middle_t>(), out_test, options.projection, options.extra_attributes);
 
   boost::optional<std::string> bbox;
-  parse_osmium_t parser(false, bbox, projection.get(), false, &osmdata);
+  parse_osmium_t parser(bbox, false, &osmdata);
 
   parser.stream_file(inputfile, "");
 

--- a/tests/test-parse-xml2.cpp
+++ b/tests/test-parse-xml2.cpp
@@ -42,14 +42,14 @@ struct test_output_t : public output_null_t {
         return std::shared_ptr<output_t>(clone);
     }
 
-    int node_add(osmium::Node const &node, double, double, bool) override {
+    int node_add(osmium::Node const &node, double, double) override {
         assert(node.id() > 0);
         sum_ids += (unsigned) node.id();
         num_nodes += 1;
         return 0;
     }
 
-    int way_add(osmium::Way const &way, bool) override {
+    int way_add(osmium::Way const &way) override {
         assert(way.id() > 0);
         sum_ids += (unsigned) way.id();
         num_ways += 1;
@@ -58,7 +58,7 @@ struct test_output_t : public output_null_t {
         return 0;
     }
 
-    int relation_add(osmium::Relation const &rel, bool) override {
+    int relation_add(osmium::Relation const &rel) override {
         assert(rel.id() > 0);
         sum_ids += (unsigned) rel.id();
         num_relations += 1;
@@ -85,7 +85,7 @@ int main(int argc, char *argv[]) {
   options.projection = projection;
 
   auto out_test = std::make_shared<test_output_t>(options);
-  osmdata_t osmdata(std::make_shared<dummy_middle_t>(), out_test, options.projection, options.extra_attributes);
+  osmdata_t osmdata(std::make_shared<dummy_middle_t>(), out_test, options.projection);
 
   boost::optional<std::string> bbox;
   parse_osmium_t parser(bbox, false, &osmdata);

--- a/tests/test-parse-xml2.cpp
+++ b/tests/test-parse-xml2.cpp
@@ -11,7 +11,7 @@
 #include "options.hpp"
 #include "osmdata.hpp"
 #include "osmtypes.hpp"
-#include "output.hpp"
+#include "output-null.hpp"
 #include "parse-osmium.hpp"
 
 void exit_nicely()
@@ -20,16 +20,16 @@ void exit_nicely()
     exit(1);
 }
 
-struct test_output_t : public output_t {
+struct test_output_t : public output_null_t {
     uint64_t sum_ids, num_nodes, num_ways, num_relations, num_nds, num_members;
 
     explicit test_output_t(const options_t &options_)
-        : output_t(nullptr, options_), sum_ids(0), num_nodes(0), num_ways(0), num_relations(0),
+        : output_null_t(nullptr, options_), sum_ids(0), num_nodes(0), num_ways(0), num_relations(0),
           num_nds(0), num_members(0) {
     }
 
     explicit test_output_t(const test_output_t &other)
-        : output_t(other.m_mid, other.m_options), sum_ids(0), num_nodes(0), num_ways(0), num_relations(0),
+        : output_null_t(other.m_mid, other.m_options), sum_ids(0), num_nodes(0), num_ways(0), num_relations(0),
           num_nds(0), num_members(0) {
     }
 
@@ -42,52 +42,30 @@ struct test_output_t : public output_t {
         return std::shared_ptr<output_t>(clone);
     }
 
-    int node_add(osmid_t id, double lat, double lon, const taglist_t &tags) {
-        assert(id > 0);
-        sum_ids += id;
+    int node_add(osmium::Node const &node, double, double, bool) override {
+        assert(node.id() > 0);
+        sum_ids += (unsigned) node.id();
         num_nodes += 1;
         return 0;
     }
 
-    int way_add(osmid_t id, const idlist_t &nds, const taglist_t &tags) {
-        assert(id > 0);
-        sum_ids += id;
+    int way_add(osmium::Way const &way, bool) override {
+        assert(way.id() > 0);
+        sum_ids += (unsigned) way.id();
         num_ways += 1;
-        assert(nds.size() >= 0);
-        num_nds += uint64_t(nds.size());
+        assert(way.nodes().size() >= 0);
+        num_nds += uint64_t(way.nodes().size());
         return 0;
     }
 
-    int relation_add(osmid_t id, const memberlist_t &members, const taglist_t &tags) {
-        assert(id > 0);
-        sum_ids += id;
+    int relation_add(osmium::Relation const &rel, bool) override {
+        assert(rel.id() > 0);
+        sum_ids += (unsigned) rel.id();
         num_relations += 1;
-        assert(members.size() >= 0);
-        num_members += uint64_t(members.size());
+        assert(rel.members().size() >= 0);
+        num_members += uint64_t(rel.members().size());
         return 0;
     }
-
-    int start() { return 0; }
-    int connect(int startTransaction) { return 0; }
-    void stop() { }
-    void commit() { }
-    void cleanup(void) { }
-    void close(int stopTransaction) { }
-
-    void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) { }
-    int pending_way(osmid_t id, int exists) { return 0; }
-
-    void enqueue_relations(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) { }
-    int pending_relation(osmid_t id, int exists) { return 0; }
-
-    int node_modify(osmid_t id, double lat, double lon, const taglist_t &tags) { return 0; }
-    int way_modify(osmid_t id, const idlist_t &nds, const taglist_t &tags) { return 0; }
-    int relation_modify(osmid_t id, const memberlist_t &members, const taglist_t &tags) { return 0; }
-
-    int node_delete(osmid_t id) { return 0; }
-    int way_delete(osmid_t id) { return 0; }
-    int relation_delete(osmid_t id) { return 0; }
-
 };
 
 

--- a/tests/test-parse-xml2.cpp
+++ b/tests/test-parse-xml2.cpp
@@ -36,7 +36,7 @@ struct test_output_t : public output_null_t {
     virtual ~test_output_t() {
     }
 
-    std::shared_ptr<output_t> clone(const middle_query_t *cloned_middle) const{
+    std::shared_ptr<output_t> clone(const middle_query_t *cloned_middle) const override {
         test_output_t *clone = new test_output_t(*this);
         clone->m_mid = cloned_middle;
         return std::shared_ptr<output_t>(clone);


### PR DESCRIPTION
Forward the data coming from libosmium directly into the processing pipeline instead of copying them into custom types. To make this work, middle also has to create libosmium types when fetching objects from its cache. osm2pgsql types are still used whenever data is manipulated, most notably after tagtransform and for the results of geometry projection.

This work is mostly a preparation for using more libosmium functions in osm2pgsql. Performance is about the same as before.

For details about the change, see the individual commits. Up to 'move ways_get* functions to libosmium types' is the step-by-step conversion of the code, after that follow bug fixes.