### PR TITLE
gazetteer: correctly escape backslashes

### DIFF
--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -91,7 +91,7 @@ private:
     {
         for (const char c: in) {
             switch(c) {
-                case '\\': out += "\\\\\\\\\\\\\\\\"; break;
+                case '\\': out += "\\\\\\\\"; break;
                 case '\n':
                 case '\r':
                 case '\t':

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -91,7 +91,13 @@ private:
     {
         for (const char c: in) {
             switch(c) {
-                case '\\': out += "\\\\\\\\"; break;
+                case '\\':
+                    // Tripple escaping required: string escaping leaves us
+                    // with 4 backslashes, COPY then reduces it to two, which
+                    // are then interpreted as a single backslash by the hash
+                    // parsing code.
+                    out += "\\\\\\\\";
+                    break;
                 case '\n':
                 case '\r':
                 case '\t':


### PR DESCRIPTION
fixes https://trac.openstreetmap.org/ticket/5434