### PR TITLE
Add config for clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+---
+Language:        Cpp
+BasedOnStyle:  LLVM
+AccessModifierOffset: -4
+BreakBeforeBraces: Mozilla
+IndentWidth:     4
+ConstructorInitializerIndentWidth: 0
+ReflowComments: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,36 +32,23 @@ for easy bug fixes, or if a patch backporting a fix is provided.
 
 ## Code style
 
-The current codebase is a mix of styles, but new code should be written in the
+Code must be written in the
 [K&R 1TBS style](https://en.wikipedia.org/wiki/Indent_style#Variant:_1TBS) with
-4 spaces indentation. Tabs should never be used in the C++ code.
-
-e.g.
-
-```
-int main(int argc, char *argv[])
-{
-    ...
-    while (x == y) {
-        something();
-        somethingelse();
-
-        if (some_error) {
-            do_correct();
-        } else {
-            continue_as_usual();
-        }
-    }
-
-    finalthing();
-    ...
-}
-```
+4 spaces indentation. Tabs should never be used in the C++ code. Braces must
+always be used for code blocks, even one-liners.
 
 Names should use underscores, not camel case, with class/struct names ending in `_t`.
 
 Headers should be included in the order `config.h`, C++ standard library headers,
 C library headers, Boost headers, and last osm2pgsql files.
+
+There is a .clang-format configuration avialable and all code must be run through
+clang-format before submitting. You can use git-clang-format after staging all
+your changes:
+
+    git-clang-format --style=file *pp tests/*pp
+
+clang-format 3.8 or later is required.
 
 ## Documentation
 

--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -1141,6 +1141,7 @@ middle_pgsql_t::middle_pgsql_t()
     : tables(), num_tables(0), node_table(nullptr), way_table(nullptr), rel_table(nullptr),
       append(false), mark_pending(true), cache(), persistent_cache(), build_indexes(true)
 {
+    // clang-format off
     /*table = t_node,*/
     tables.push_back(table_desc(
             /*name*/ "%p_nodes",
@@ -1201,6 +1202,7 @@ middle_pgsql_t::middle_pgsql_t()
             /*stop*/  "COMMIT;\n",
    /*array_indexes*/ "CREATE INDEX %p_rels_parts ON %p_rels USING gin (parts) WITH (FASTUPDATE=OFF) {TABLESPACE %i};\n"
                          ));
+    // clang-format on
 
     // set up the rest of the variables from the tables.
     num_tables = tables.size();


### PR DESCRIPTION
Running clang-format on the current code touches about 5k lines, which is a bit excessive. So I would suggest to require running git-clang-format for all future PRs.