### PR TITLE
Don't transform relation member tag for multi backend

### DIFF
--- a/geometry-processor.cpp
+++ b/geometry-processor.cpp
@@ -140,16 +140,17 @@ size_t relation_helper::set(osmium::RelationMemberList const &member_list, middl
     return num_ways;
 }
 
-multitaglist_t relation_helper::get_filtered_tags(tagtransform *transform, export_list const &el) const
+multitaglist_t relation_helper::get_member_tags(tagtransform *transform,
+                                                export_list const &el) const
 {
-    multitaglist_t filtered(roles.size());
+    multitaglist_t member_tags(roles.size());
 
     size_t i = 0;
     for (auto const &w : data.select<osmium::Way>()) {
-        transform->filter_tags(w, nullptr, nullptr, el, filtered[i++]);
+        member_tags[i++] = taglist_t(w.tags());
     }
 
-    return filtered;
+    return member_tags;
 }
 
 multinodelist_t relation_helper::get_nodes(middle_t const *mid) const

--- a/geometry-processor.hpp
+++ b/geometry-processor.hpp
@@ -90,7 +90,8 @@ struct relation_helper
     relation_helper();
     ~relation_helper();
     size_t set(osmium::RelationMemberList const &member_list, middle_t const *mid);
-    multitaglist_t get_filtered_tags(tagtransform *transform, export_list const &el) const;
+    multitaglist_t get_member_tags(tagtransform *transform,
+                                   export_list const &el) const;
     multinodelist_t get_nodes(middle_t const *mid) const;
 
     osmium::memory::ItemIteratorRange<const osmium::Way> way_iterator() const

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -357,14 +357,12 @@ int output_multi_t::process_relation(osmium::Relation const &rel,
         if (m_relation_helper.set(rel.members(), (middle_t*)m_mid) < 1)
             return 0;
 
-        //filter the tags on each member because we got them from the middle
-        //and since the middle is no longer tied to the output it no longer
-        //shares any kind of tag transform and therefore has all original tags
-        //so we filter here because each individual outputs cares about different tags
+        // Roads is ignored by the multi backend, but we need a variable for it
         int roads;
-        multitaglist_t filtered =
-            m_relation_helper.get_filtered_tags(m_tagtransform.get(),
-                                                *m_export_list.get());
+        // We want the original tags here so the transforms have enough information to
+        // construct old-style MPs
+        multitaglist_t member_tags = m_relation_helper.get_member_tags(
+            m_tagtransform.get(), *m_export_list.get());
 
         //do the members of this relation have anything interesting to us
         //NOTE: make_polygon is preset here this is to force the tag matching/superseded stuff
@@ -375,10 +373,10 @@ int output_multi_t::process_relation(osmium::Relation const &rel,
         //all this trickery
         int make_boundary, make_polygon = 1;
         taglist_t outtags;
-        filter = m_tagtransform->filter_rel_member_tags(rel_outtags, filtered, m_relation_helper.roles,
-                                                        &m_relation_helper.superseded.front(),
-                                                        &make_boundary, &make_polygon, &roads,
-                                                        *m_export_list.get(), outtags, true);
+        filter = m_tagtransform->filter_rel_member_tags(
+            rel_outtags, member_tags, m_relation_helper.roles,
+            &m_relation_helper.superseded.front(), &make_boundary,
+            &make_polygon, &roads, *m_export_list.get(), outtags, true);
         if (!filter)
         {
             auto nodes = m_relation_helper.get_nodes((middle_t *)m_mid);


### PR DESCRIPTION
Fixes #659

To be able to process old-style multipolygons correctly it's necessary to have the untransformed tags for the rel_member transform, or else it's impossible to tell between some cases.

I'd like to backport this to fix the bug in 0.90.x, and if reasonable 0.88.x, so I've kept the diff minimal rather than looking for a cleaner way to pass the member tag information around.

I've formatted this with .clang-format from #662