### PR TITLE
fix finding PostgreSQL from yum.postgresql.org with newer CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if (NOT WIN32 AND NOT APPLE)
 endif()
 
 # Just in case user installed RPMs from http://yum.postgresql.org/
-list(APPEND PostgreSQL_ADDITIONAL_SEARCH_PATHS /usr/pgsql-9.3 /usr/pgsql-9.4 /usr/pgsql-9.5 /usr/pgsql-9.6)
+list(APPEND CMAKE_PREFIX_PATH /usr/pgsql-9.3 /usr/pgsql-9.4 /usr/pgsql-9.5 /usr/pgsql-9.6)
 
 if (PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
   message(FATAL_ERROR "In-source builds are not allowed, please use a separate build directory like `mkdir build && cd build && cmake ..`")


### PR DESCRIPTION
This will break on newer CMake versions (>=3.3) since PostgreSQL_ADDITIONAL_SEARCH_PATHS is not honored there anymore. Use CMAKE_PREFIX_PATH instead, which is the generic solution that works with all versions of CMake and all find modules.

Tested on CentOS 7 with CMake 2.8.12.2 and 3.7.1.