### PR TITLE
Do not assume a default database name

### DIFF
--- a/docs/lua.md
+++ b/docs/lua.md
@@ -8,7 +8,7 @@ This allows you to unify disparate tagging (for example, `highway=path; foot=yes
 
 Pass a Lua script to osm2pgsql using the command line switch `--tag-transform-script`:
 
-    osm2pgsql -S your.style --tag-transform-script your.lua --hstore-all extract.osm.pbf
+    osm2pgsql -d gis -S your.style --tag-transform-script your.lua --hstore-all extract.osm.pbf
 
 This Lua script needs to implement the following functions:
 

--- a/docs/osm2pgsql.1
+++ b/docs/osm2pgsql.1
@@ -1,4 +1,4 @@
-.TH OSM2PGSQL 1 "October 31, 2016"
+.TH OSM2PGSQL 1 "February 5, 2017"
 .\" Please adjust this date whenever revising the manpage.
 .SH NAME
 osm2pgsql \- Openstreetmap data to PostgreSQL converter.
@@ -53,8 +53,7 @@ Remove existing data from the database. This is the
 default if \fB\-\-append\fR is not specified.
 .TP
 \fB\-d\fR|\-\-database name
-The name of the PostgreSQL database to connect
-to (default: gis).
+The name of the PostgreSQL database to connect to.
 .TP
 \fB\-i\fR|\-\-tablespace\-index tablespacename
 Store all indices in a separate PostgreSQL tablespace named by this parameter.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -45,8 +45,8 @@ that only impact performance.
 ## Database options ##
 
 osm2pgsql supports standard options for how to connect to PostgreSQL. If left
-unset, it will attempt to connect to the ``gis`` database using a unix socket.
-Most usage only requires setting ``--database``.
+unset, it will attempt to connect to the default database (usually the username)
+using a unix socket. Most usage only requires setting ``--database``.
 
 ``--tablespace`` options allow the location of main and slim tables and indexes
 to be set to different tablespaces independently, typically on machines with

--- a/options.cpp
+++ b/options.cpp
@@ -102,8 +102,7 @@ namespace
        -C|--cache       Use up to this many MB for caching nodes (default: 800)\n\
     \n\
     Database options:\n\
-       -d|--database    The name of the PostgreSQL database to connect\n\
-                        to (default: gis).\n\
+       -d|--database    The name of the PostgreSQL database to connect to.\n\
        -U|--username    PostgreSQL user name (specify passsword in PGPASS\n\
                         environment variable or use -W).\n\
        -W|--password    Force password prompt.\n\
@@ -234,7 +233,7 @@ namespace
 } // anonymous namespace
 
 database_options_t::database_options_t():
-    db("gis"), username(boost::none), host(boost::none),
+    db(boost::none), username(boost::none), host(boost::none),
     password(boost::none), port(boost::none)
 {
 
@@ -244,8 +243,9 @@ std::string database_options_t::conninfo() const
 {
     std::ostringstream out;
 
-    out << "dbname='" << db << "'";
-
+    if (db) {
+        out << "dbname='" << *db << "'";
+    }
     if (username) {
         out << " user='" << *username << "'";
     }

--- a/options.hpp
+++ b/options.hpp
@@ -23,7 +23,7 @@
 class database_options_t {
 public:
     database_options_t();
-    std::string db;
+    boost::optional<std::string> db;
     boost::optional<std::string> username;
     boost::optional<std::string> host;
     boost::optional<std::string> password;

--- a/tests/common-pg.cpp
+++ b/tests/common-pg.cpp
@@ -84,8 +84,9 @@ tempdb::tempdb()
     : m_postgres_conn(conn::connect("dbname=postgres"))
 {
     result_ptr res = nullptr;
+    // osm2pgsql doesn't require a db name, but subsequent uses of database_options.db.get() in this file assume one is set
     database_options.db = (boost::format("osm2pgsql-test-%1%-%2%") % getpid() % time(nullptr)).str();
-    m_postgres_conn->exec(boost::format("DROP DATABASE IF EXISTS \"%1%\"") % database_options.db);
+    m_postgres_conn->exec(boost::format("DROP DATABASE IF EXISTS \"%1%\"") % database_options.db.get());
     //tests can be run concurrently which means that this query can collide with other similar ones
     //so we implement a simple retry here to get around the case that they do collide if we dont
     //we often fail due to both trying to access template1 at the same time
@@ -94,7 +95,7 @@ tempdb::tempdb()
     while(status != PGRES_COMMAND_OK && retries++ < 20)
     {
         sleep(1);
-        res = m_postgres_conn->exec(boost::format("CREATE DATABASE \"%1%\" WITH ENCODING 'UTF8'") % database_options.db);
+        res = m_postgres_conn->exec(boost::format("CREATE DATABASE \"%1%\" WITH ENCODING 'UTF8'") % database_options.db.get());
         status = PQresultStatus(res->get());
     }
     if (PQresultStatus(res->get()) != PGRES_COMMAND_OK) {
@@ -217,7 +218,7 @@ void tempdb::assert_has_table(const std::string &table_name) {
 tempdb::~tempdb() {
     m_conn.reset(); // close the connection to the db
     if (m_postgres_conn) {
-        m_postgres_conn->exec(boost::format("DROP DATABASE IF EXISTS \"%1%\"") % database_options.db);
+        m_postgres_conn->exec(boost::format("DROP DATABASE IF EXISTS \"%1%\"") % database_options.db.get());
     }
 }
 

--- a/tests/test-options-database.cpp
+++ b/tests/test-options-database.cpp
@@ -49,25 +49,25 @@ void expect_conninfo(const database_options_t &db, const std::string &expect) {
  */
 void test_conninfo() {
     database_options_t db;
-    expect_conninfo(db, "dbname='gis'");
+    expect_conninfo(db, "");
     db.db = "foo";
     expect_conninfo(db, "dbname='foo'");
 
     db = database_options_t();
     db.username = "bar";
-    expect_conninfo(db, "dbname='gis' user='bar'");
+    expect_conninfo(db, " user='bar'");
 
     db = database_options_t();
     db.password = "bar";
-    expect_conninfo(db, "dbname='gis' password='bar'");
+    expect_conninfo(db, " password='bar'");
 
     db = database_options_t();
     db.host = "bar";
-    expect_conninfo(db, "dbname='gis' host='bar'");
+    expect_conninfo(db, " host='bar'");
 
     db = database_options_t();
     db.port = "bar";
-    expect_conninfo(db, "dbname='gis' port='bar'");
+    expect_conninfo(db, " port='bar'");
 
     db = database_options_t();
     db.db = "foo";

--- a/tests/test-options-parse.cpp
+++ b/tests/test-options-parse.cpp
@@ -215,7 +215,9 @@ void test_random_perms()
         args.push_back(style);
 
         add_arg_and_val_or_not("--cache", args, options.cache, rand() % 800);
-        add_arg_and_val_or_not("--database", args, options.database_options.db.c_str(), get_random_string(6));
+        if (options.database_options.db) {
+            add_arg_and_val_or_not("--database", args, options.database_options.db->c_str(), get_random_string(6));
+        }
         if (options.database_options.username) {
             add_arg_and_val_or_not("--username", args, options.database_options.username->c_str(), get_random_string(6));
         }


### PR DESCRIPTION
Instead of defaulting to gis, the default database is unspecified, and libpq will decide what to connect to in those cases. This will normally rely on `PGDATABASE` or its compiled defaults.

Fixes #561