### PR TITLE
Don't give a variable name for an exception nothing is done with

### DIFF
--- a/osmium-builder.cpp
+++ b/osmium-builder.cpp
@@ -393,7 +393,7 @@ osmium_builder_t::create_polygons(osmium::Area const &area)
             ret.push_back(m_writer.polygon_finish(num_rings));
         }
 
-    } catch (osmium::geometry_error &e) { /* ignored */
+    } catch (osmium::geometry_error) { /* ignored */
     }
 
     return ret;


### PR DESCRIPTION
Fixes a MSVC warning