### PR TITLE
Set fallback_application_name

### DIFF
--- a/options.cpp
+++ b/options.cpp
@@ -241,8 +241,9 @@ std::string database_options_t::conninfo() const
 {
     std::ostringstream out;
 
+    out << "fallback_application_name='osm2pgsql'";
     if (db) {
-        out << "dbname='" << *db << "'";
+        out << " dbname='" << *db << "'";
     }
     if (username) {
         out << " user='" << *username << "'";

--- a/tests/test-options-database.cpp
+++ b/tests/test-options-database.cpp
@@ -49,25 +49,25 @@ void expect_conninfo(const database_options_t &db, const std::string &expect) {
  */
 void test_conninfo() {
     database_options_t db;
-    expect_conninfo(db, "");
+    expect_conninfo(db, "fallback_application_name='osm2pgsql'");
     db.db = "foo";
-    expect_conninfo(db, "dbname='foo'");
+    expect_conninfo(db, "fallback_application_name='osm2pgsql' dbname='foo'");
 
     db = database_options_t();
     db.username = "bar";
-    expect_conninfo(db, " user='bar'");
+    expect_conninfo(db, "fallback_application_name='osm2pgsql' user='bar'");
 
     db = database_options_t();
     db.password = "bar";
-    expect_conninfo(db, " password='bar'");
+    expect_conninfo(db, "fallback_application_name='osm2pgsql' password='bar'");
 
     db = database_options_t();
     db.host = "bar";
-    expect_conninfo(db, " host='bar'");
+    expect_conninfo(db, "fallback_application_name='osm2pgsql' host='bar'");
 
     db = database_options_t();
     db.port = "bar";
-    expect_conninfo(db, " port='bar'");
+    expect_conninfo(db, "fallback_application_name='osm2pgsql' port='bar'");
 
     db = database_options_t();
     db.db = "foo";
@@ -75,7 +75,7 @@ void test_conninfo() {
     db.password = "baz";
     db.host = "bzz";
     db.port = "123";
-    expect_conninfo(db, "dbname='foo' user='bar' password='baz' host='bzz' port='123'");
+    expect_conninfo(db, "fallback_application_name='osm2pgsql' dbname='foo' user='bar' password='baz' host='bzz' port='123'");
 }
 
 } // anonymous namespace


### PR DESCRIPTION
This sets a default application name which then appears in DB logs and pg_stat_activity.

Fixes #707

Tested by watching pg_stat_activity while running the tests.