### PR TITLE
Added libgeos dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ On a Debian or Ubuntu system, this can be done with:
 ```sh
 sudo apt-get install make cmake g++ libboost-dev libboost-system-dev \
   libboost-filesystem-dev libexpat1-dev zlib1g-dev \
-  libbz2-dev libpq-dev libproj-dev lua5.2 liblua5.2-dev
+  libbz2-dev libpq-dev libproj-dev lua5.2 liblua5.2-dev libgeos-dev libgeos++-dev
 ```
 
 On a Fedora system, use


### PR DESCRIPTION
Update the docs. Without the libgeos packages I had the problem:

```
# cmake ..
...
CMake Warning at cmake/FindOsmium.cmake:163 (message):
  Osmium: GEOS library is required but not found, please install it or
  configure the paths.
Call Stack (most recent call first):
  CMakeLists.txt:95 (find_package)


CMake Error at /usr/share/cmake-3.0/Modules/FindPackageHandleStandardArgs.cmake:136 (message):
  Could NOT find Osmium (missing: GEOS_INCLUDE_DIR GEOS_LIBRARY)
Call Stack (most recent call first):
  /usr/share/cmake-3.0/Modules/FindPackageHandleStandardArgs.cmake:343 (_FPHSA_FAILURE_MESSAGE)
  cmake/FindOsmium.cmake:262 (find_package_handle_standard_args)
  CMakeLists.txt:95 (find_package)


-- Configuring incomplete, errors occurred!
```