### PR TITLE
Ignore relations with more than 32k members

### DIFF
--- a/parse-osmium.cpp
+++ b/parse-osmium.cpp
@@ -176,6 +176,9 @@ void parse_osmium_t::relation(osmium::Relation const &rel)
     if (rel.deleted()) {
         m_data->relation_delete(rel.id());
     } else {
+        if (rel.members().size() > 32767) {
+            return;
+        }
         if (m_append) {
             m_data->relation_modify(rel);
         } else {


### PR DESCRIPTION
There is a hard restriction in the pgsql middle tables, where relation members are indexed using a smallint. This change just restricts to the technical limit to fix the issue with the diff file.

Fixes #713.