### PR TITLE
Don't pre-filter relation member tags

### DIFF
--- a/geometry-processor.cpp
+++ b/geometry-processor.cpp
@@ -94,19 +94,6 @@ size_t relation_helper::set(osmium::Relation const &rel, middle_t const *mid)
     return num_ways;
 }
 
-multitaglist_t relation_helper::get_filtered_tags(tagtransform_t *transform,
-                                                  export_list const &el) const
-{
-    multitaglist_t filtered(roles.size());
-
-    size_t i = 0;
-    for (auto const &w : data.select<osmium::Way>()) {
-        transform->filter_tags(w, nullptr, nullptr, el, filtered[i++]);
-    }
-
-    return filtered;
-}
-
 void relation_helper::add_way_locations(middle_t const *mid)
 {
     for (auto &w : data.select<osmium::Way>()) {

--- a/geometry-processor.hpp
+++ b/geometry-processor.hpp
@@ -84,8 +84,6 @@ public:
     relation_helper();
 
     size_t set(osmium::Relation const &rel, middle_t const *mid);
-    multitaglist_t get_filtered_tags(tagtransform_t *transform,
-                                     export_list const &el) const;
     void add_way_locations(middle_t const *mid);
 
     rolelist_t roles;

--- a/osmtypes.hpp
+++ b/osmtypes.hpp
@@ -170,8 +170,6 @@ private:
 
 };
 
-typedef std::vector<taglist_t> multitaglist_t;
-
 struct idlist_t : public std::vector<osmid_t> {
     idlist_t() {}
 

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -366,28 +366,19 @@ int output_multi_t::process_relation(osmium::Relation const &rel,
         if (m_relation_helper.set(rel, (middle_t *)m_mid) < 1)
             return 0;
 
-        //filter the tags on each member because we got them from the middle
-        //and since the middle is no longer tied to the output it no longer
-        //shares any kind of tag transform and therefore has all original tags
-        //so we filter here because each individual outputs cares about different tags
-        int roads;
-        multitaglist_t filtered =
-            m_relation_helper.get_filtered_tags(m_tagtransform.get(),
-                                                *m_export_list.get());
-
-        //do the members of this relation have anything interesting to us
         //NOTE: make_polygon is preset here this is to force the tag matching/superseded stuff
         //normally this wouldnt work but we tell the tag transform to allow typeless relations
         //this is needed because the type can get stripped off by the rel_tag filter above
         //if the export list did not include the type tag.
         //TODO: find a less hacky way to do the matching/superseded and tag copying stuff without
         //all this trickery
+        int roads;
         int make_boundary, make_polygon;
         taglist_t outtags;
-        filter = m_tagtransform->filter_rel_member_tags(rel_outtags, filtered, m_relation_helper.roles,
-                                                        &m_relation_helper.superseded.front(),
-                                                        &make_boundary, &make_polygon, &roads,
-                                                        *m_export_list.get(), outtags, true);
+        filter = m_tagtransform->filter_rel_member_tags(
+            rel_outtags, m_relation_helper.data, m_relation_helper.roles,
+            &m_relation_helper.superseded.front(), &make_boundary,
+            &make_polygon, &roads, *m_export_list.get(), outtags, true);
         if (!filter)
         {
             m_relation_helper.add_way_locations((middle_t *)m_mid);

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -332,25 +332,6 @@ int output_pgsql_t::pgsql_process_relation(osmium::Relation const &rel,
     if (num_ways == 0)
         return 0;
 
-    multitaglist_t xtags(num_ways, taglist_t());
-
-    size_t i = 0;
-    for (auto const &w : buffer.select<osmium::Way>()) {
-        assert(i < num_ways);
-
-        //filter the tags on this member because we got it from the middle
-        //and since the middle is no longer tied to the output it no longer
-        //shares any kind of tag transform and therefore all original tags
-        //will come back and need to be filtered by individual outputs before
-        //using these ways
-        m_tagtransform->filter_tags(w, nullptr, nullptr, *m_export_list.get(),
-                                    xtags[i]);
-        //TODO: if the filter says that this member is now not interesting we
-        //should decrement the count and remove his nodes and tags etc. for
-        //now we'll just keep him with no tags so he will get filtered later
-        ++i;
-  }
-
   int roads = 0;
   int make_polygon = 0;
   int make_boundary = 0;
@@ -360,7 +341,7 @@ int output_pgsql_t::pgsql_process_relation(osmium::Relation const &rel,
   // If it's a route relation make_boundary and make_polygon will be false
   // otherwise one or the other will be true.
   if (m_tagtransform->filter_rel_member_tags(
-          prefiltered_tags, xtags, xrole, &(members_superseded[0]),
+          prefiltered_tags, buffer, xrole, &(members_superseded[0]),
           &make_boundary, &make_polygon, &roads, *m_export_list.get(),
           outtags)) {
       return 0;

--- a/style.lua
+++ b/style.lua
@@ -261,7 +261,8 @@ function filter_tags_relation_member (keyvalues, keyvaluemembers, roles, memberc
         -- Count the number of polygon tags of the object
         for i,k in ipairs(polygon_keys) do
             if keyvalues[k] then
-                polytagcount = polytagcount + 1
+                polytagcount = 1
+                break
             end
         end
         -- If there are no polygon tags, add tags from all outer elements to the multipolygon itself
@@ -272,6 +273,19 @@ function filter_tags_relation_member (keyvalues, keyvaluemembers, roles, memberc
                         keyvalues[k] = v
                     end
                 end
+            end
+
+            f, keyvalues = filter_tags_generic(keyvalues, 1)
+            -- check again if there are still polygon tags left
+            polytagcount = 0
+            for i,k in ipairs(polygon_keys) do
+                if keyvalues[k] then
+                    polytagcount = 1
+                    break
+                end
+            end
+            if polytagcount == 0 then
+                filter = 1
             end
         end
         -- For any member of the multipolygon, set membersuperseded to 1 (i.e. don't deal with it as area as well),

--- a/tagtransform-c.hpp
+++ b/tagtransform-c.hpp
@@ -1,6 +1,7 @@
 #ifndef TAGTRANSFORM_C_H
 #define TAGTRANSFORM_C_H
 
+#include "taginfo_impl.hpp"
 #include "tagtransform.hpp"
 
 class c_tagtransform_t : public tagtransform_t
@@ -12,16 +13,18 @@ public:
                      export_list const &exlist, taglist_t &out_tags,
                      bool strict = false) override;
 
-    unsigned filter_rel_member_tags(taglist_t const &rel_tags,
-                                    multitaglist_t const &member_tags,
-                                    rolelist_t const &member_roles,
-                                    int *member_superseded, int *make_boundary,
-                                    int *make_polygon, int *roads,
-                                    export_list const &exlist,
-                                    taglist_t &out_tags,
-                                    bool allow_typeless = false) override;
+    bool filter_rel_member_tags(taglist_t const &rel_tags,
+                                osmium::memory::Buffer const &members,
+                                rolelist_t const &member_roles,
+                                int *member_superseded, int *make_boundary,
+                                int *make_polygon, int *roads,
+                                export_list const &exlist, taglist_t &out_tags,
+                                bool allow_typeless = false) override;
 
 private:
+    bool check_key(std::vector<taginfo> const &infos, char const *k,
+                   bool *filter, int *flags, bool strict);
+
     options_t const *m_options;
 };
 

--- a/tagtransform-lua.hpp
+++ b/tagtransform-lua.hpp
@@ -19,14 +19,13 @@ public:
                      export_list const &exlist, taglist_t &out_tags,
                      bool strict = false) override;
 
-    unsigned filter_rel_member_tags(taglist_t const &rel_tags,
-                                    multitaglist_t const &member_tags,
-                                    rolelist_t const &member_roles,
-                                    int *member_superseded, int *make_boundary,
-                                    int *make_polygon, int *roads,
-                                    export_list const &exlist,
-                                    taglist_t &out_tags,
-                                    bool allow_typeless = false) override;
+    bool filter_rel_member_tags(taglist_t const &rel_tags,
+                                osmium::memory::Buffer const &members,
+                                rolelist_t const &member_roles,
+                                int *member_superseded, int *make_boundary,
+                                int *make_polygon, int *roads,
+                                export_list const &exlist, taglist_t &out_tags,
+                                bool allow_typeless = false) override;
 
 private:
     void check_lua_function_exists(std::string const &func_name);

--- a/tagtransform.hpp
+++ b/tagtransform.hpp
@@ -1,9 +1,11 @@
 #ifndef TAGTRANSFORM_H
 #define TAGTRANSFORM_H
 
-#include "osmtypes.hpp"
-
 #include <string>
+
+#include <osmium/memory/buffer.hpp>
+
+#include "osmtypes.hpp"
 
 struct options_t;
 struct export_list;
@@ -20,12 +22,14 @@ public:
                              int *roads, export_list const &exlist,
                              taglist_t &out_tags, bool strict = false) = 0;
 
-    virtual unsigned filter_rel_member_tags(
-        taglist_t const &rel_tags, multitaglist_t const &member_tags,
-        rolelist_t const &member_roles, int *member_superseded,
-        int *make_boundary, int *make_polygon, int *roads,
-        export_list const &exlist, taglist_t &out_tags,
-        bool allow_typeless = false) = 0;
+    virtual bool filter_rel_member_tags(taglist_t const &rel_tags,
+                                        osmium::memory::Buffer const &members,
+                                        rolelist_t const &member_roles,
+                                        int *member_superseded,
+                                        int *make_boundary, int *make_polygon,
+                                        int *roads, export_list const &exlist,
+                                        taglist_t &out_tags,
+                                        bool allow_typeless = false) = 0;
 };
 
 #endif //TAGTRANSFORM_H


### PR DESCRIPTION
Tags for ways of multipolygons are no longer prefiltered before handing them into the relation member filter function. For new-style MPs the tags are not relevant anyways. For old-style MPs, the filter now first creates a list of common tags and then filters the result with the standard relation tags filter.

I have adapted style.lua but noticed that old-style MPs are handled slightly differently. The tags of the MP are computed as the union of all tags on the out ways while the C transform computes them as the intersection of tags. I haven't touched multi.lua yet.

Tests pass but it could possibly do with visual verification that results are the same.    

Fixes #605 and #659.
