### PR TITLE
middle-ram: properly deallocate in clear() function

### DIFF
--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -75,7 +75,7 @@ public:
     void clear()
     {
         for (auto &ele : arr) {
-            ele.release();
+            ele.reset();
         }
     }
 };


### PR DESCRIPTION
Fixes #729.