### PR TITLE
autodestruct PGresult

### DIFF
--- a/pgsql.hpp
+++ b/pgsql.hpp
@@ -11,10 +11,23 @@
 #include <libpq-fe.h>
 #include <memory>
 
-PGresult *pgsql_execPrepared( PGconn *sql_conn, const char *stmtName, const int nParams, const char *const * paramValues, const ExecStatusType expect);
+struct pg_result_deleter_t
+{
+    void operator()(PGresult *p) const { PQclear(p); }
+};
+
+typedef std::unique_ptr<PGresult, pg_result_deleter_t> pg_result_t;
+
+pg_result_t pgsql_execPrepared(PGconn *sql_conn, const char *stmtName,
+                               int nParams, const char *const *paramValues,
+                               ExecStatusType expect);
 void pgsql_CopyData(const char *context, PGconn *sql_conn, std::string const &sql);
-std::shared_ptr<PGresult> pgsql_exec_simple(PGconn *sql_conn, const ExecStatusType expect, const std::string& sql);
-std::shared_ptr<PGresult> pgsql_exec_simple(PGconn *sql_conn, const ExecStatusType expect, const char *sql);
+
+pg_result_t pgsql_exec_simple(PGconn *sql_conn, ExecStatusType expect,
+                              std::string const &sql);
+pg_result_t pgsql_exec_simple(PGconn *sql_conn, ExecStatusType expect,
+                              const char *sql);
+
 int pgsql_exec(PGconn *sql_conn, const ExecStatusType expect, const char *fmt, ...)
 #ifndef _MSC_VER
  __attribute__ ((format (printf, 3, 4)))

--- a/table.hpp
+++ b/table.hpp
@@ -36,15 +36,6 @@ class table_t
 
         std::string const& get_name();
 
-        struct pg_result_closer
-        {
-            void operator() (PGresult* result)
-            {
-                PQclear(result);
-            }
-
-        };
-
         //interface from retrieving well known binary geometry from the table
         class wkb_reader
         {
@@ -66,11 +57,12 @@ class table_t
                     m_current = 0;
                 }
             private:
-                wkb_reader(PGresult* result)
-                : m_result(result), m_count(PQntuples(result)), m_current(0)
+                wkb_reader(pg_result_t &&result)
+                : m_result(std::move(result)), m_count(PQntuples(result.get())),
+                  m_current(0)
                 {}
 
-                std::unique_ptr<PGresult, pg_result_closer> m_result;
+                pg_result_t m_result;
                 int m_count;
                 int m_current;
         };


### PR DESCRIPTION
Wrap all instances of PGresult in a unique_ptr that automatically
calls PQclear on destruct to avoid accidental resource leaks.

Fixes #731.