### PR TITLE
Include wikidata and wikipedia columns as well

### DIFF
--- a/default.style
+++ b/default.style
@@ -146,6 +146,8 @@ node,way   tunnel       text         linear
 node,way   water        text         polygon
 node,way   waterway     text         polygon
 node,way   wetland      text         polygon
+node,way   wikidata     text         linear
+node,way   wikipedia    text         linear
 node,way   width        text         linear
 node,way   wood         text         linear
 node,way   z_order      int4         linear # This is calculated during import


### PR DESCRIPTION
Since most of the tags are included in the default style, I feel like `wikidata` and `wikipedia` should be included as well.