### PR TITLE
Enable more tests on Appveyor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,11 +90,6 @@ if (WITH_LUA)
   set(HAVE_LUA 1)
 endif()
 
-if (MSVC)
-  # Boost thread needs extra libraries
-  set(BOOST_EXTRA date_time chrono)
-endif()
-
 if (NOT Boost_ADDITIONAL_VERSIONS)
   set(Boost_ADDITIONAL_VERSIONS "1.55;1.56;1.57;1.58;1.59;1.60;1.61")
 endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,6 +59,7 @@ test_script:
   - ctest -VV -L NoDB
 #  - ctest -VV -LE FlatNodes # enable when Postgis will be available
 
+
 artifacts:
   - path: osm2pgsql_Release.zip
     name: osm2pgsql_Release.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,6 +55,7 @@ build_script:
 
 test_script:
   - set PATH=c:\osm2pgsql\build\osm2pgsql-bin;%PATH%
+  - set PROJ_LIB=c:\libs\share
   - cd c:\osm2pgsql\build
   - ctest -VV -L NoDB
 #  - ctest -VV -LE FlatNodes # enable when Postgis will be available

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,9 @@ environment:
     PGPASSWORD: Password12!
     BOOST_ROOT: c:\libs\boost
     PREFIX: c:\libs
-    PSQL_ROOT: C:\Program Files\PostgreSQL\9.4
+    PSQL_ROOT: C:/Program Files/PostgreSQL/9.4
     CMAKE_PREFIX_PATH: c:\libs;C:\Program Files\PostgreSQL\9.4
-    PYTHONPATH: c:\libs
+    POSTGIS_FILE: postgis-pg94-binaries-2.3.2w64gcc48
   matrix:
   - configuration: Release
 
@@ -14,8 +14,12 @@ environment:
 
 os: Visual Studio 2015
 
+cache:
+  - C:\libs\%POSTGIS_FILE%.zip -> appveyor.yml
+  - C:\osm2pgsql_win_deps.7z -> appveyor.yml
+
 services:
-#  - postgresql # enable when Postgis will be available
+  - postgresql94 # enable when Postgis will be available
 
 # scripts that are called at very beginning, before repo cloning
 init:
@@ -32,8 +36,21 @@ install:
   # by default, all script lines are interpreted as batch
   - cd c:\
   - mkdir libs
-  - curl -O http://lonvia.de/osm2pgsql_win_deps.7z
+  - if not exist osm2pgsql_win_deps.7z ( curl -O http://lonvia.de/osm2pgsql_win_deps.7z )
   - 7z x osm2pgsql_win_deps.7z | find ":"
+  - cd c:\libs
+  - echo Downloading and installing PostGIS:
+  - if not exist %POSTGIS_FILE%.zip ( curl -L -O -S -s http://winnie.postgis.net/download/windows/pg94/buildbot/%POSTGIS_FILE%.zip )
+  - 7z x %POSTGIS_FILE%.zip
+  - echo xcopy /e /y /q %POSTGIS_FILE% %PSQL_ROOT%
+  - xcopy /e /y /q %POSTGIS_FILE% "%PSQL_ROOT%"
+  - echo Creating tablespace for tablespace test...
+  - mkdir temp
+  - cacls temp /T /E /G Users:F
+  - cacls temp /T /E /G "Network Service":F
+  - echo Installing psycopg2 Python module...
+  - python -V
+  - pip install psycopg2
 
 build_script:
   - mkdir c:\osm2pgsql\build
@@ -54,11 +71,13 @@ build_script:
   - 7z a c:\osm2pgsql\osm2pgsql_%Configuration%.zip osm2pgsql-bin -tzip
 
 test_script:
+  - |
+    "%PSQL_ROOT%/bin/psql" -c "CREATE TABLESPACE tablespacetest LOCATION 'c:/libs/temp'"
   - set PATH=c:\osm2pgsql\build\osm2pgsql-bin;%PATH%
   - set PROJ_LIB=c:\libs\share
   - cd c:\osm2pgsql\build
-  - ctest -VV -L NoDB
-#  - ctest -VV -LE FlatNodes # enable when Postgis will be available
+#  - ctest -VV -L NoDB
+  - ctest -VV -LE FlatNodes # enable when Postgis will be available
 
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,15 +32,15 @@ install:
   # by default, all script lines are interpreted as batch
   - cd c:\
   - mkdir libs
-  - curl -O https://dl.dropboxusercontent.com/u/63393258/libs_osm2pgsql_%Configuration%.7z
-  - 7z x libs_osm2pgsql_%Configuration%.7z | find ":"
+  - curl -O http://lonvia.de/osm2pgsql_win_deps.7z
+  - 7z x osm2pgsql_win_deps.7z | find ":"
 
 build_script:
   - mkdir c:\osm2pgsql\build
   - cd c:\osm2pgsql\build
   - echo Running cmake...
   - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
-  - cmake .. -LA -G "NMake Makefiles" -DBOOST_ROOT=%BOOST_ROOT% -DCMAKE_BUILD_TYPE=%Configuration% -DCMAKE_INSTALL_PREFIX=%PREFIX% -DBoost_USE_STATIC_LIBS=ON -DBUILD_TESTS=ON -DBoost_ADDITIONAL_VERSIONS=1.57;1.58;1.59
+  - cmake .. -LA -G "NMake Makefiles" -DBOOST_ROOT=%BOOST_ROOT% -DCMAKE_BUILD_TYPE=%Configuration% -DCMAKE_INSTALL_PREFIX=%PREFIX% -DBoost_USE_STATIC_LIBS=ON -DBUILD_TESTS=ON -DBZIP2_LIBRARY_RELEASE=C:/libs/lib/libbz2.lib -DZLIB_LIBRARY=C:\libs\lib\zlibwapi.lib
   - nmake
   - mkdir osm2pgsql-bin
   - copy /y *.exe osm2pgsql-bin
@@ -58,10 +58,6 @@ test_script:
   - cd c:\osm2pgsql\build
   - ctest -VV -L NoDB
 #  - ctest -VV -LE FlatNodes # enable when Postgis will be available
-
-#deploy_script:
-#  - cd c:\build
-#  - curl -T osm2pgsql_%Configuration%.zip --user %ACCOUNT% https://webdav.yandex.ru/libs/osm2pgsql_%Configuration%.zip
 
 artifacts:
   - path: osm2pgsql_Release.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ build_script:
   - copy /y *.exe osm2pgsql-bin
   - copy /y ..\*.style osm2pgsql-bin
   - copy /y ..\*.lua osm2pgsql-bin
-  - copy /y %PREFIX%\bin\lua.dll osm2pgsql-bin
+  - copy /y %PREFIX%\bin\*.dll osm2pgsql-bin
   - copy /y "%PSQL_ROOT%\bin\libpq.dll" osm2pgsql-bin
   - copy /y "%PSQL_ROOT%\bin\libintl-8.dll" osm2pgsql-bin
   - copy /y "%PSQL_ROOT%\bin\libeay32.dll" osm2pgsql-bin


### PR DESCRIPTION
I have found a solution http://help.appveyor.com/discussions/suggestions/409-postgis-extension-for-postgresql#comment_40144818 to enable postgis on Appveyor and was able to run 25 tests successfully (regression test needed also psycopg2 installation).
Also enabled caching of downloaded dependencies and archives, should speed up building.

Continuation of https://github.com/openstreetmap/osm2pgsql/pull/742 , the dependencies pack may still need updating.