### PR TITLE
Rewrite tile expiry (management of expired tiles)

### DIFF
--- a/expire-tiles.cpp
+++ b/expire-tiles.cpp
@@ -41,20 +41,25 @@ tile_output_t::~tile_output_t()
     }
 }
 
-void tile_output_t::output_dirty_tile(int x, int y, int zoom)
+void tile_output_t::output_dirty_tile(uint32_t x, uint32_t y, uint32_t zoom)
 {
     if (outfile) {
         fprintf(outfile, "%i/%i/%i\n", zoom, x, y);
+        ++outcount;
+        if (outcount % 1000 == 0) {
+            fprintf(stderr, "\rWriting dirty tile list (%iK)", outcount / 1000);
+        }
     }
 }
 
-void expire_tiles::output_and_destroy(const char *filename, int minzoom)
+void expire_tiles::output_and_destroy(const char *filename, uint32_t minzoom)
 {
     tile_output_t output_writer(filename);
     output_and_destroy<tile_output_t>(output_writer, minzoom);
 }
 
-expire_tiles::expire_tiles(int max, double bbox, const std::shared_ptr<reprojection> &proj)
+expire_tiles::expire_tiles(uint32_t max, double bbox,
+                           const std::shared_ptr<reprojection> &proj)
 : max_bbox(bbox), maxzoom(max), projection(proj)
 {
     if (maxzoom >= 0) {
@@ -63,30 +68,33 @@ expire_tiles::expire_tiles(int max, double bbox, const std::shared_ptr<reproject
     }
 }
 
-int64_t expire_tiles::xy_to_quadkey(int x, int y, int zoom)
+uint64_t expire_tiles::xy_to_quadkey(uint32_t x, uint32_t y, uint32_t zoom)
 {
     int64_t quadkey = 0;
     // the two highest bits are the bits of zoom level 1, the third and fourth bit are level 2, …
-    for (int z = 0; z < zoom; z++) {
-        quadkey = quadkey + ((x & (1l << z)) << z);
-        quadkey = quadkey + ((y & (1l << z)) << (z + 1));
+    for (uint32_t z = 0; z < zoom; z++) {
+        quadkey |= ((x & (1ULL << z)) << z);
+        quadkey |= ((y & (1ULL << z)) << (z + 1));
     }
     return quadkey;
 }
 
-xy_coord_t expire_tiles::quadkey_to_xy(int64_t quadkey_coord, int zoom)
+xy_coord_t expire_tiles::quadkey_to_xy(uint64_t quadkey_coord, uint32_t zoom)
 {
     xy_coord_t result;
-    for (int z = zoom; z > 0; z -= 1) {
-        int next_zoom = z - 1;
-        result.y = result.y + ((quadkey_coord & (1l << (z + next_zoom))) >> z);
+    for (int z = zoom; z > 0; --z) {
+        /* The quadkey contains Y and X bits interleaved in following order: YXYX...
+         * We have to pick out the bit representing the y/x bit of the current zoom
+         * level and then shift it back to the right on its position in a y-/x-only
+         * coordinate.*/
+        result.y = result.y + ((quadkey_coord & (1ULL << (2 * z - 1))) >> z);
         result.x =
-            result.x + ((quadkey_coord & (1l << (2 * next_zoom))) >> next_zoom);
+            result.x + ((quadkey_coord & (1ULL << (2 * (z - 1)))) >> (z - 1));
     }
     return result;
 }
 
-void expire_tiles::expire_tile(int x, int y)
+void expire_tiles::expire_tile(uint32_t x, uint32_t y)
 {
     m_dirty_tiles.insert(xy_to_quadkey(x, y, maxzoom));
 }

--- a/expire-tiles.cpp
+++ b/expire-tiles.cpp
@@ -62,12 +62,10 @@ expire_tiles::expire_tiles(uint32_t max, double bbox,
                            const std::shared_ptr<reprojection> &proj)
 : max_bbox(bbox), maxzoom(max), projection(proj)
 {
-    if (maxzoom > 0) {
-        map_width = 1 << maxzoom;
-        tile_width = EARTH_CIRCUMFERENCE / map_width;
-        last_tile_x = static_cast<uint32_t>(map_width) + 1;
-        last_tile_y = static_cast<uint32_t>(map_width) + 1;
-    }
+    map_width = 1 << maxzoom;
+    tile_width = EARTH_CIRCUMFERENCE / map_width;
+    last_tile_x = static_cast<uint32_t>(map_width) + 1;
+    last_tile_y = static_cast<uint32_t>(map_width) + 1;
 }
 
 uint64_t expire_tiles::xy_to_quadkey(uint32_t x, uint32_t y, uint32_t zoom)

--- a/expire-tiles.cpp
+++ b/expire-tiles.cpp
@@ -88,10 +88,7 @@ xy_coord_t expire_tiles::quadtree_to_xy(int64_t qt_coord, int zoom)
 
 void expire_tiles::expire_tile(int x, int y)
 {
-    if (m_dirty_tiles.find(xy_to_quadtree(x, y, maxzoom)) ==
-        m_dirty_tiles.end()) {
-        m_dirty_tiles.insert(xy_to_quadtree(x, y, maxzoom));
-    }
+    m_dirty_tiles.insert(xy_to_quadtree(x, y, maxzoom));
 }
 
 int expire_tiles::normalise_tile_x_coord(int x) {

--- a/expire-tiles.cpp
+++ b/expire-tiles.cpp
@@ -63,32 +63,32 @@ expire_tiles::expire_tiles(int max, double bbox, const std::shared_ptr<reproject
     }
 }
 
-int64_t expire_tiles::xy_to_quadtree(int x, int y, int zoom)
+int64_t expire_tiles::xy_to_quadkey(int x, int y, int zoom)
 {
-    int64_t qt = 0;
+    int64_t quadkey = 0;
     // the two highest bits are the bits of zoom level 1, the third and fourth bit are level 2, …
     for (int z = 0; z < zoom; z++) {
-        qt = qt + ((x & (1l << z)) << z);
-        qt = qt + ((y & (1l << z)) << (z + 1));
+        quadkey = quadkey + ((x & (1l << z)) << z);
+        quadkey = quadkey + ((y & (1l << z)) << (z + 1));
     }
-    return qt;
+    return quadkey;
 }
 
-xy_coord_t expire_tiles::quadtree_to_xy(int64_t qt_coord, int zoom)
+xy_coord_t expire_tiles::quadkey_to_xy(int64_t quadkey_coord, int zoom)
 {
     xy_coord_t result;
     for (int z = zoom; z > 0; z -= 1) {
         int next_zoom = z - 1;
-        result.y = result.y + ((qt_coord & (1l << (z + next_zoom))) >> z);
+        result.y = result.y + ((quadkey_coord & (1l << (z + next_zoom))) >> z);
         result.x =
-            result.x + ((qt_coord & (1l << (2 * next_zoom))) >> next_zoom);
+            result.x + ((quadkey_coord & (1l << (2 * next_zoom))) >> next_zoom);
     }
     return result;
 }
 
 void expire_tiles::expire_tile(int x, int y)
 {
-    m_dirty_tiles.insert(xy_to_quadtree(x, y, maxzoom));
+    m_dirty_tiles.insert(xy_to_quadkey(x, y, maxzoom));
 }
 
 int expire_tiles::normalise_tile_x_coord(int x) {

--- a/expire-tiles.cpp
+++ b/expire-tiles.cpp
@@ -65,6 +65,8 @@ expire_tiles::expire_tiles(uint32_t max, double bbox,
     if (maxzoom >= 0) {
         map_width = 1 << maxzoom;
         tile_width = EARTH_CIRCUMFERENCE / map_width;
+        last_tile_x = map_width + 1;
+        last_tile_y = map_width + 1;
     }
 }
 
@@ -96,7 +98,13 @@ xy_coord_t expire_tiles::quadkey_to_xy(uint64_t quadkey_coord, uint32_t zoom)
 
 void expire_tiles::expire_tile(uint32_t x, uint32_t y)
 {
-    m_dirty_tiles.insert(xy_to_quadkey(x, y, maxzoom));
+    // Only try to insert to tile into the set if the last inserted tile
+    // is different from this tile.
+    if (last_tile_x != x || last_tile_y != y) {
+        m_dirty_tiles.insert(xy_to_quadkey(x, y, maxzoom));
+        last_tile_x = x;
+        last_tile_y = y;
+    }
 }
 
 int expire_tiles::normalise_tile_x_coord(int x) {

--- a/expire-tiles.hpp
+++ b/expire-tiles.hpp
@@ -155,7 +155,7 @@ private:
 
     double tile_width;
     double max_bbox;
-    uint32_t map_width;
+    int map_width;
     uint32_t maxzoom;
     std::shared_ptr<reprojection> projection;
 

--- a/expire-tiles.hpp
+++ b/expire-tiles.hpp
@@ -14,10 +14,7 @@ class parser_t;
 }
 
 /**
- * \brief Simple struct for a method converting a quadtree node ID to a pair of a x and y coordinate.
- *
- * If we used std::pair<int, int> instead of this type, we would have to write foo.first instead
- * of foo.x. The latter one is easier to understand, isn't it?
+ * \brief Simple struct for the x and y index of a tile ID.
  */
 struct xy_coord_t
 {
@@ -27,8 +24,7 @@ struct xy_coord_t
 };
 
 /**
- * This struct is handed over as template parameter to output_and_destroy
- * method.
+ * Implementation of the output of the tile expiry list to a file.
  */
 class tile_output_t
 {
@@ -70,7 +66,7 @@ struct expire_tiles
     void output_and_destroy(const char *filename, int minzoom);
 
     /**
-     * \brief Output expried tiles on all requested zoom levels.
+     * \brief Output expired tiles on all requested zoom levels.
      *
      * \param output_writer class which implements the method
      * output_dirty_tile(int x, int y, int zoom) which usually writes the tile ID to a file
@@ -94,7 +90,7 @@ struct expire_tiles
                 int64_t qt_new = *it >> (dz * 2);
                 if (expired_tiles.insert(qt_new).second) {
                     // expired_tiles.insert(qt_new).second is true if the tile has not been written to the list yet
-                    xy_coord_t xy = quadtree_to_xy(qt_new, maxzoom - dz);
+                    xy_coord_t xy = quadkey_to_xy(qt_new, maxzoom - dz);
                     output_writer.output_dirty_tile(xy.x, xy.y, maxzoom - dz);
                 }
             }
@@ -108,27 +104,27 @@ struct expire_tiles
     void merge_and_destroy(expire_tiles &other);
 
     /**
-     * \brief Helper method to convert a tile ID (x and y) into quadtree
-     * coordinate using bitshifts.
+     * \brief Helper method to convert a tile ID (x and y) into a quadkey
+     * using bitshifts.
      *
-     * Quadtree coordinates are interleaved this way: YXYX…
+     * Quadkeys are interleaved this way: YXYX…
      *
      * \param x x index
      * \param y y index
      * \param zoom zoom level
      * \returns quadtree ID as integer
      */
-    static int64_t xy_to_quadtree(int x, int y, int zoom);
+    static int64_t xy_to_quadkey(int x, int y, int zoom);
 
     /**
-     * \brief Convert a quadtree coordinate into a tile ID (x and y) using bitshifts.
+     * \brief Convert a quadkey into a tile ID (x and y) using bitshifts.
      *
-     * Quadtree coordinates are interleaved this way: YXYX…
+     * Quadkeys coordinates are interleaved this way: YXYX…
      *
-     * \param qt_coord quadtree ID
+     * \param quadkey the quadkey to be converted
      * \param zoom zoom level
      */
-    static xy_coord_t quadtree_to_xy(int64_t qt_coord, int zoom);
+    static xy_coord_t quadkey_to_xy(int64_t quadkey, int zoom);
 
 private:
     /**

--- a/expire-tiles.hpp
+++ b/expire-tiles.hpp
@@ -81,15 +81,16 @@ struct expire_tiles
     template <class tile_writer_t>
     void output_and_destroy(tile_writer_t &output_writer, int minzoom)
     {
-        // iterate over all expired tiles
-        for (std::unordered_set<int64_t>::iterator it = m_dirty_tiles.begin();
-             it != m_dirty_tiles.end(); it++) {
-            /* Loop over all requested zoom levels (from maximum down to the minimum zoom level).
-             * Tile IDs of the tiles enclosing this tile at lower zoom levels are calculated using
-             * bit shifts.
-             */
-            for (int dz = 0; dz <= maxzoom - minzoom; dz++) {
-                std::unordered_set<int64_t> expired_tiles;
+        /* Loop over all requested zoom levels (from maximum down to the minimum zoom level).
+         * Tile IDs of the tiles enclosing this tile at lower zoom levels are calculated using
+         * bit shifts.
+         */
+        for (int dz = 0; dz <= maxzoom - minzoom; dz++) {
+            // track which tiles have already been written
+            std::unordered_set<int64_t> expired_tiles;
+            // iterate over all expired tiles
+            for (std::unordered_set<int64_t>::iterator it = m_dirty_tiles.begin();
+                    it != m_dirty_tiles.end(); it++) {
                 int64_t qt_new = *it >> (dz * 2);
                 if (expired_tiles.insert(qt_new).second) {
                     // expired_tiles.insert(qt_new).second is true if the tile has not been written to the list yet

--- a/expire-tiles.hpp
+++ b/expire-tiles.hpp
@@ -2,6 +2,7 @@
 #define EXPIRE_TILES_H
 
 #include <memory>
+#include <unordered_set>
 
 #include "osmtypes.hpp"
 
@@ -12,6 +13,42 @@ namespace ewkb {
 class parser_t;
 }
 
+/**
+ * \brief Simple struct for a method converting a quadtree node ID to a pair of a x and y coordinate.
+ *
+ * If we used std::pair<int, int> instead of this type, we would have to write foo.first instead
+ * of foo.x. The latter one is easier to understand, isn't it?
+ */
+struct xy_coord_t
+{
+    int x;
+    int y;
+    xy_coord_t() : x(0), y(0) {}
+};
+
+/**
+ * This struct is handed over as template parameter to output_and_destroy
+ * method.
+ */
+class tile_output_t
+{
+    FILE *outfile;
+
+public:
+    tile_output_t(const char *filename);
+
+    ~tile_output_t();
+
+    /**
+     * \brief output dirty tile
+     *
+     * \param x x index
+     * \param y y index
+     * \param zoom zoom level of the tile
+     */
+    void output_dirty_tile(int x, int y, int zoom);
+};
+
 struct expire_tiles
 {
     expire_tiles(int maxzoom, double maxbbox,
@@ -21,30 +58,84 @@ struct expire_tiles
     void from_wkb(const char* wkb, osmid_t osm_id);
     int from_db(table_t* table, osmid_t osm_id);
 
-    /* customisable tile output. this can be passed into the
-     * `output_and_destroy` function to override output to a file.
-     * this is primarily useful for testing.
+    /**
+     * \brief Write the list of expired tiles to a file.
+     *
+     * You will probably use tile_output_t as template argument for production code
+     * and another class which does not write to a file for unit tests.
+     *
+     * \param filename name of the file
+     * \param minzoom minimum zoom level
      */
-    struct tile_output {
-        virtual ~tile_output() = default;
-        // dirty a tile at x, y & zoom, and all descendants of that
-        // tile at the given zoom if zoom < min_zoom.
-        virtual void output_dirty_tile(int x, int y, int zoom) = 0;
-    };
-
-    // output the list of expired tiles to a file. note that this
-    // consumes the list of expired tiles destructively.
     void output_and_destroy(const char *filename, int minzoom);
 
-    // output the list of expired tiles using a `tile_output`
-    // functor. this consumes the list of expired tiles destructively.
-    void output_and_destroy(tile_output *output);
+    /**
+     * \brief Output expried tiles on all requested zoom levels.
+     *
+     * \param output_writer class which implements the method
+     * output_dirty_tile(int x, int y, int zoom) which usually writes the tile ID to a file
+     * (production code) or does something else (usually unit tests)
+     *
+     * \param minzoom minimum zoom level
+     */
+    template <class tile_writer_t>
+    void output_and_destroy(tile_writer_t &output_writer, int minzoom)
+    {
+        // iterate over all expired tiles
+        for (std::unordered_set<int64_t>::iterator it = m_dirty_tiles.begin();
+             it != m_dirty_tiles.end(); it++) {
+            /* Loop over all requested zoom levels (from maximum down to the minimum zoom level).
+             * Tile IDs of the tiles enclosing this tile at lower zoom levels are calculated using
+             * bit shifts.
+             */
+            for (int dz = 0; dz <= maxzoom - minzoom; dz++) {
+                std::unordered_set<int64_t> expired_tiles;
+                int64_t qt_new = *it >> (dz * 2);
+                if (expired_tiles.insert(qt_new).second) {
+                    // expired_tiles.insert(qt_new).second is true if the tile has not been written to the list yet
+                    xy_coord_t xy = quadtree_to_xy(qt_new, maxzoom - dz);
+                    output_writer.output_dirty_tile(xy.x, xy.y, maxzoom - dz);
+                }
+            }
+        }
+    }
 
-    // merge the list of expired tiles in the other object into this
-    // object, destroying the list in the other object.
-    void merge_and_destroy(expire_tiles &);
+    /**
+    * merge the list of expired tiles in the other object into this
+    * object, destroying the list in the other object.
+    */
+    void merge_and_destroy(expire_tiles &other);
+
+    /**
+     * \brief Helper method to convert a tile ID (x and y) into quadtree
+     * coordinate using bitshifts.
+     *
+     * Quadtree coordinates are interleaved this way: YXYX…
+     *
+     * \param x x index
+     * \param y y index
+     * \param zoom zoom level
+     * \returns quadtree ID as integer
+     */
+    static int64_t xy_to_quadtree(int x, int y, int zoom);
+
+    /**
+     * \brief Convert a quadtree coordinate into a tile ID (x and y) using bitshifts.
+     *
+     * Quadtree coordinates are interleaved this way: YXYX…
+     *
+     * \param qt_coord quadtree ID
+     * \param zoom zoom level
+     */
+    static xy_coord_t quadtree_to_xy(int64_t qt_coord, int zoom);
 
 private:
+    /**
+     * Expire a single tile.
+     *
+     * \param x x index of the tile to be expired.
+     * \param y y index of the tile to be expired.
+     */
     void expire_tile(int x, int y);
     int normalise_tile_x_coord(int x);
     void from_line(double lon_a, double lat_a, double lon_b, double lat_b);
@@ -58,29 +149,27 @@ private:
     int map_width;
     int maxzoom;
     std::shared_ptr<reprojection> projection;
-    std::unique_ptr<tile> dirty;
-};
 
-
-class tile
-{
-public:
-    int mark_tile(int x, int y, int zoom, int this_zoom);
-    void output_and_destroy(expire_tiles::tile_output *output,
-                            int x, int y, int this_zoom);
-    int merge(tile *other);
-
-private:
-    int sub2x(int sub) const { return sub >> 1; }
-    int sub2y(int sub) const { return sub & 1; }
-
-    int num_complete() const
-    {
-        return complete[0] + complete[1] + complete[2] + complete[3];
-    }
-
-    std::unique_ptr<tile> subtiles[4];
-    char complete[4] = {0, 0, 0, 0};
+    /**
+     * \brief manages which tiles have been marked as empty
+     *
+     * This set stores the IDs of the tiles at the maximum zoom level. We don't
+     * store the IDs of the expired tiles of lower zoom levels. They are calculated
+     * on the fly at the end.
+     *
+     * Tile IDs are converted into so-called quadkeys as used by Bing Maps.
+     * https://msdn.microsoft.com/en-us/library/bb259689.aspx
+     * A quadkey is generated by interleaving the x and y index in following order:
+     * YXYX...
+     *
+     * Example:
+     * x = 3 = 0b011, y = 5 = 0b101
+     * results in the quadkey 0b100111.
+     *
+     * Bing Maps itself uses the quadkeys as a base-4 number converted to a string.
+     * We interpret this IDs as simple 64-bit integers due to performance reasons.
+     */
+    std::unordered_set<int64_t> m_dirty_tiles;
 };
 
 #endif

--- a/options.cpp
+++ b/options.cpp
@@ -267,7 +267,7 @@ options_t::options_t()
   slim(false), cache(800), tblsmain_index(boost::none),
   tblsslim_index(boost::none), tblsmain_data(boost::none),
   tblsslim_data(boost::none), style(OSM2PGSQL_DATADIR "/default.style"),
-  expire_tiles_zoom(-1), expire_tiles_zoom_min(-1),
+  expire_tiles_zoom(0), expire_tiles_zoom_min(0),
   expire_tiles_max_bbox(20000.0), expire_tiles_filename("dirty_tiles"),
   hstore_mode(HSTORE_NONE), enable_hstore_index(false), enable_multi(false),
   hstore_columns(), keep_coastlines(false), parallel_indexing(true),

--- a/options.cpp
+++ b/options.cpp
@@ -549,4 +549,17 @@ void options_t::check_options()
         fprintf(stderr, "!! exceptions during import, you should try running in slim\n");
         fprintf(stderr, "!! mode using parameter -s.\n");
     }
+
+    // zoom level 31 is the technical limit because we use 32-bit integers for the x and y index of a tile ID
+    if (expire_tiles_zoom_min >= 32) {
+        expire_tiles_zoom_min = 31;
+        fprintf(stderr, "WARNING: mimimum zoom level for tile expiry is too "
+                        "large and has been set to 31.\n\n");
+    }
+
+    if (expire_tiles_zoom >= 32) {
+        expire_tiles_zoom = 31;
+        fprintf(stderr, "WARNING: maximum zoom level for tile expiry is too "
+                        "large and has been set to 31.\n\n");
+    }
 }

--- a/options.hpp
+++ b/options.hpp
@@ -55,8 +55,9 @@ public:
     boost::optional<std::string> tblsmain_data; ///< Pg Tablespace to store main tables (no default TABLESPACE)
     boost::optional<std::string> tblsslim_data; ///< Pg Tablespace to store slim tables (no default TABLESPACE)
     std::string style; ///< style file to use
-    int expire_tiles_zoom; ///< Zoom level for tile expiry list
-    int expire_tiles_zoom_min; ///< Minimum zoom level for tile expiry list
+    uint32_t expire_tiles_zoom = 0; ///< Zoom level for tile expiry list
+    uint32_t expire_tiles_zoom_min =
+        0;                        ///< Minimum zoom level for tile expiry list
     double expire_tiles_max_bbox; ///< Max bbox size in either dimension to expire full bbox for a polygon
     std::string expire_tiles_filename; ///< File name to output expired tiles list to
     int hstore_mode; ///< add an additional hstore column with objects key/value pairs, and what type of hstore column

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -179,7 +179,7 @@ int output_multi_t::pending_relation(osmid_t id, int exists) {
 void output_multi_t::stop()
 {
     m_table->stop();
-    if (m_options.expire_tiles_zoom_min >= 0) {
+    if (m_options.expire_tiles_zoom_min > 0) {
         m_expire.output_and_destroy(m_options.expire_tiles_filename.c_str(),
                                     m_options.expire_tiles_zoom_min);
     }

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -261,7 +261,7 @@ void output_pgsql_t::stop()
       }
     }
 
-    if (m_options.expire_tiles_zoom_min >= 0) {
+    if (m_options.expire_tiles_zoom_min > 0) {
         expire.output_and_destroy(m_options.expire_tiles_filename.c_str(),
                                   m_options.expire_tiles_zoom_min);
     }

--- a/tests/test-expire-tiles.cpp
+++ b/tests/test-expire-tiles.cpp
@@ -192,6 +192,67 @@ void test_expire_simple_z18() {
     ++itr;
 }
 
+/**
+ * Test tile expiry on two zoom levels.
+ */
+void test_expire_simple_z17_18()
+{
+    int minzoom = 17;
+    expire_tiles et(18, 20000, defproj);
+    tile_output_set set(minzoom);
+
+    // dirty a smaller bbox this time, as at z18 the scale is
+    // pretty small.
+    et.from_bbox(-1, -1, 1, 1);
+    et.output_and_destroy(set, minzoom);
+
+    ASSERT_EQ(set.m_tiles.size(), 8);
+    std::set<xyz>::iterator itr = set.m_tiles.begin();
+    ASSERT_EQ(*itr, xyz(17, 65535, 65535));
+    ++itr;
+    ASSERT_EQ(*itr, xyz(17, 65535, 65536));
+    ++itr;
+    ASSERT_EQ(*itr, xyz(17, 65536, 65535));
+    ++itr;
+    ASSERT_EQ(*itr, xyz(17, 65536, 65536));
+    ++itr;
+    ASSERT_EQ(*itr, xyz(18, 131071, 131071));
+    ++itr;
+    ASSERT_EQ(*itr, xyz(18, 131071, 131072));
+    ++itr;
+    ASSERT_EQ(*itr, xyz(18, 131072, 131071));
+    ++itr;
+    ASSERT_EQ(*itr, xyz(18, 131072, 131072));
+    ++itr;
+}
+
+/**
+ * Similar to test_expire_simple_z17_18 but now all z18 tiles are children
+ * of the same z17 tile.
+ */
+void test_expire_simple_z17_18_one_superior_tile()
+{
+    int minzoom = 17;
+    expire_tiles et(18, 20000, defproj);
+    tile_output_set set(minzoom);
+
+    et.from_bbox(-163, 140, -140, 164);
+    et.output_and_destroy(set, minzoom);
+
+    ASSERT_EQ(set.m_tiles.size(), 5);
+    std::set<xyz>::iterator itr = set.m_tiles.begin();
+    ASSERT_EQ(*itr, xyz(17, 65535, 65535));
+    ++itr;
+    ASSERT_EQ(*itr, xyz(18, 131070, 131070));
+    ++itr;
+    ASSERT_EQ(*itr, xyz(18, 131070, 131071));
+    ++itr;
+    ASSERT_EQ(*itr, xyz(18, 131071, 131070));
+    ++itr;
+    ASSERT_EQ(*itr, xyz(18, 131071, 131071));
+    ++itr;
+}
+
 std::set<xyz> generate_random(int zoom, size_t count) {
   size_t num = 0;
   std::set<xyz> set;
@@ -389,6 +450,8 @@ int main(int argc, char *argv[])
     RUN_TEST(test_expire_simple_z1);
     RUN_TEST(test_expire_simple_z3);
     RUN_TEST(test_expire_simple_z18);
+    RUN_TEST(test_expire_simple_z17_18);
+    RUN_TEST(test_expire_simple_z17_18_one_superior_tile);
     RUN_TEST(test_expire_set);
     RUN_TEST(test_expire_merge);
     RUN_TEST(test_expire_merge_same);

--- a/tests/test-expire-tiles.cpp
+++ b/tests/test-expire-tiles.cpp
@@ -33,9 +33,9 @@ void run_test(const char* test_name, void (*testfunc)())
 #define ASSERT_EQ(a, b) { if (!((a) == (b))) { throw std::runtime_error((boost::format("Expecting %1% == %2%, but %3% != %4%") % #a % #b % (a) % (b)).str()); } }
 
 struct xyz {
-    int z;
+    uint32_t z;
     int64_t x, y;
-    xyz(int z_, int64_t x_, int64_t y_) : z(z_), x(x_), y(y_) {}
+    xyz(uint32_t z_, int64_t x_, int64_t y_) : z(z_), x(x_), y(y_) {}
     bool operator==(const xyz &other) const
     {
         return ((z == other.z) && (x == other.x) && (y == other.y));
@@ -73,23 +73,23 @@ std::ostream &operator<<(std::ostream &out, const xyz &tile) {
 
 struct tile_output_set
 {
-  tile_output_set(int min) : min_zoom(min) {}
+    tile_output_set(uint32_t min) : min_zoom(min) {}
 
-  ~tile_output_set() = default;
+    ~tile_output_set() = default;
 
-  void output_dirty_tile(int64_t x, int64_t y, int zoom)
-  {
-      m_tiles.insert(xyz(zoom, x, y));
+    void output_dirty_tile(int64_t x, int64_t y, uint32_t zoom)
+    {
+        m_tiles.insert(xyz(zoom, x, y));
   }
 
   std::set<xyz> m_tiles;
-  int min_zoom;
+  uint32_t min_zoom;
 };
 
 void test_xy_to_quadkey_z3()
 {
-    int64_t quadkey_expected = 0b100111;
-    int64_t quadkey2 = expire_tiles::xy_to_quadkey(3, 5, 3);
+    uint64_t quadkey_expected = 0b100111;
+    uint64_t quadkey2 = expire_tiles::xy_to_quadkey(3, 5, 3);
     ASSERT_EQ(quadkey2, quadkey_expected);
     xy_coord_t xy = expire_tiles::quadkey_to_xy(quadkey_expected, 3);
     ASSERT_EQ(xy.x, 3);
@@ -98,8 +98,8 @@ void test_xy_to_quadkey_z3()
 
 void test_xy_to_quadkey_z16()
 {
-    int64_t quadkey_expected = 0b11111111111111111111111111111111;
-    int64_t quadkey2 = expire_tiles::xy_to_quadkey(65535, 65535, 16);
+    uint64_t quadkey_expected = 0b11111111111111111111111111111111;
+    uint64_t quadkey2 = expire_tiles::xy_to_quadkey(65535, 65535, 16);
     ASSERT_EQ(quadkey2, quadkey_expected);
     xy_coord_t xy = expire_tiles::quadkey_to_xy(quadkey_expected, 16);
     ASSERT_EQ(xy.x, 65535);
@@ -112,8 +112,8 @@ void test_xy_to_quadkey_z16()
  */
 void test_xy_to_quadkey_z18()
 {
-    int64_t quadkey_expected = 0b111111111111111111111111111111111111;
-    int64_t quadkey2 = expire_tiles::xy_to_quadkey(262143, 262143, 18);
+    uint64_t quadkey_expected = 0b111111111111111111111111111111111111;
+    uint64_t quadkey2 = expire_tiles::xy_to_quadkey(262143, 262143, 18);
     ASSERT_EQ(quadkey2, quadkey_expected);
     xy_coord_t xy = expire_tiles::quadkey_to_xy(quadkey_expected, 18);
     ASSERT_EQ(xy.x, 262143);
@@ -127,7 +127,7 @@ void test_xy_to_quadkey_z18()
 }
 
 void test_expire_simple_z1() {
-    int minzoom = 1;
+    uint32_t minzoom = 1;
     expire_tiles et(minzoom, 20000, defproj);
     tile_output_set set(minzoom);
 
@@ -149,7 +149,7 @@ void test_expire_simple_z1() {
 }
 
 void test_expire_simple_z3() {
-    int minzoom = 3;
+    uint32_t minzoom = 3;
     expire_tiles et(minzoom, 20000, defproj);
     tile_output_set set(minzoom);
 
@@ -171,7 +171,7 @@ void test_expire_simple_z3() {
 }
 
 void test_expire_simple_z18() {
-    int minzoom = 18;
+    uint32_t minzoom = 18;
     expire_tiles et(18, 20000, defproj);
     tile_output_set set(minzoom);
 
@@ -197,7 +197,7 @@ void test_expire_simple_z18() {
  */
 void test_expire_simple_z17_18()
 {
-    int minzoom = 17;
+    uint32_t minzoom = 17;
     expire_tiles et(18, 20000, defproj);
     tile_output_set set(minzoom);
 
@@ -232,7 +232,7 @@ void test_expire_simple_z17_18()
  */
 void test_expire_simple_z17_18_one_superior_tile()
 {
-    int minzoom = 17;
+    uint32_t minzoom = 17;
     expire_tiles et(18, 20000, defproj);
     tile_output_set set(minzoom);
 
@@ -253,20 +253,21 @@ void test_expire_simple_z17_18_one_superior_tile()
     ++itr;
 }
 
-std::set<xyz> generate_random(int zoom, size_t count) {
-  size_t num = 0;
-  std::set<xyz> set;
-  const int coord_mask = (1 << zoom) - 1;
+std::set<xyz> generate_random(uint32_t zoom, size_t count)
+{
+    size_t num = 0;
+    std::set<xyz> set;
+    const int coord_mask = (1 << zoom) - 1;
 
-  while (num < count) {
-    xyz item(zoom, rand() & coord_mask, rand() & coord_mask);
-    if (set.count(item) == 0) {
-      set.insert(item);
-      ++num;
+    while (num < count) {
+        xyz item(zoom, rand() & coord_mask, rand() & coord_mask);
+        if (set.count(item) == 0) {
+            set.insert(item);
+            ++num;
+        }
     }
-  }
 
-  return set;
+    return set;
 }
 
 void assert_tilesets_equal(const std::set<xyz> &a,
@@ -295,17 +296,17 @@ void expire_centroids(const std::set<xyz> &check_set,
 // tests that expiring a set of tile centroids means that
 // those tiles get expired.
 void test_expire_set() {
-  int zoom = 18;
-  for (int i = 0; i < 100; ++i) {
-    expire_tiles et(zoom, 20000, defproj);
-    tile_output_set set(zoom);
+    uint32_t zoom = 18;
+    for (int i = 0; i < 100; ++i) {
+        expire_tiles et(zoom, 20000, defproj);
+        tile_output_set set(zoom);
 
-    std::set<xyz> check_set = generate_random(zoom, 100);
-    expire_centroids(check_set, et);
+        std::set<xyz> check_set = generate_random(zoom, 100);
+        expire_centroids(check_set, et);
 
-    et.output_and_destroy(set, zoom);
+        et.output_and_destroy(set, zoom);
 
-    assert_tilesets_equal(set.m_tiles, check_set);
+        assert_tilesets_equal(set.m_tiles, check_set);
   }
 }
 
@@ -315,31 +316,31 @@ void test_expire_set() {
 // same as if the union of the sets of tiles had been
 // expired.
 void test_expire_merge() {
-  int zoom = 18;
+    uint32_t zoom = 18;
 
-  for (int i = 0; i < 100; ++i) {
-    expire_tiles et(zoom, 20000, defproj);
-    expire_tiles et1(zoom, 20000, defproj);
-    expire_tiles et2(zoom, 20000, defproj);
-    tile_output_set set(zoom);
+    for (int i = 0; i < 100; ++i) {
+        expire_tiles et(zoom, 20000, defproj);
+        expire_tiles et1(zoom, 20000, defproj);
+        expire_tiles et2(zoom, 20000, defproj);
+        tile_output_set set(zoom);
 
-    std::set<xyz> check_set1 = generate_random(zoom, 100);
-    expire_centroids(check_set1, et1);
+        std::set<xyz> check_set1 = generate_random(zoom, 100);
+        expire_centroids(check_set1, et1);
 
-    std::set<xyz> check_set2 = generate_random(zoom, 100);
-    expire_centroids(check_set2, et2);
+        std::set<xyz> check_set2 = generate_random(zoom, 100);
+        expire_centroids(check_set2, et2);
 
-    et.merge_and_destroy(et1);
-    et.merge_and_destroy(et2);
+        et.merge_and_destroy(et1);
+        et.merge_and_destroy(et2);
 
-    std::set<xyz> check_set;
-    std::set_union(check_set1.begin(), check_set1.end(),
-                   check_set2.begin(), check_set2.end(),
-                   std::inserter(check_set, check_set.end()));
+        std::set<xyz> check_set;
+        std::set_union(check_set1.begin(), check_set1.end(), check_set2.begin(),
+                       check_set2.end(),
+                       std::inserter(check_set, check_set.end()));
 
-    et.output_and_destroy(set, zoom);
+        et.output_and_destroy(set, zoom);
 
-    assert_tilesets_equal(set.m_tiles, check_set);
+        assert_tilesets_equal(set.m_tiles, check_set);
   }
 }
 
@@ -349,62 +350,62 @@ void test_expire_merge() {
 // skipped by the random tile set in the previous
 // test.
 void test_expire_merge_same() {
-  int zoom = 18;
+    uint32_t zoom = 18;
 
-  for (int i = 0; i < 100; ++i) {
-    expire_tiles et(zoom, 20000, defproj);
-    expire_tiles et1(zoom, 20000, defproj);
-    expire_tiles et2(zoom, 20000, defproj);
-    tile_output_set set(zoom);
+    for (int i = 0; i < 100; ++i) {
+        expire_tiles et(zoom, 20000, defproj);
+        expire_tiles et1(zoom, 20000, defproj);
+        expire_tiles et2(zoom, 20000, defproj);
+        tile_output_set set(zoom);
 
-    std::set<xyz> check_set = generate_random(zoom, 100);
-    expire_centroids(check_set, et1);
-    expire_centroids(check_set, et2);
+        std::set<xyz> check_set = generate_random(zoom, 100);
+        expire_centroids(check_set, et1);
+        expire_centroids(check_set, et2);
 
-    et.merge_and_destroy(et1);
-    et.merge_and_destroy(et2);
+        et.merge_and_destroy(et1);
+        et.merge_and_destroy(et2);
 
-    et.output_and_destroy(set, zoom);
+        et.output_and_destroy(set, zoom);
 
-    assert_tilesets_equal(set.m_tiles, check_set);
+        assert_tilesets_equal(set.m_tiles, check_set);
   }
 }
 
 // makes sure that we're testing the case where some
 // tiles are in both.
 void test_expire_merge_overlap() {
-  int zoom = 18;
+    uint32_t zoom = 18;
 
-  for (int i = 0; i < 100; ++i) {
-    expire_tiles et(zoom, 20000, defproj);
-    expire_tiles et1(zoom, 20000, defproj);
-    expire_tiles et2(zoom, 20000, defproj);
-    tile_output_set set(zoom);
+    for (int i = 0; i < 100; ++i) {
+        expire_tiles et(zoom, 20000, defproj);
+        expire_tiles et1(zoom, 20000, defproj);
+        expire_tiles et2(zoom, 20000, defproj);
+        tile_output_set set(zoom);
 
-    std::set<xyz> check_set1 = generate_random(zoom, 100);
-    expire_centroids(check_set1, et1);
+        std::set<xyz> check_set1 = generate_random(zoom, 100);
+        expire_centroids(check_set1, et1);
 
-    std::set<xyz> check_set2 = generate_random(zoom, 100);
-    expire_centroids(check_set2, et2);
+        std::set<xyz> check_set2 = generate_random(zoom, 100);
+        expire_centroids(check_set2, et2);
 
-    std::set<xyz> check_set3 = generate_random(zoom, 100);
-    expire_centroids(check_set3, et1);
-    expire_centroids(check_set3, et2);
+        std::set<xyz> check_set3 = generate_random(zoom, 100);
+        expire_centroids(check_set3, et1);
+        expire_centroids(check_set3, et2);
 
-    et.merge_and_destroy(et1);
-    et.merge_and_destroy(et2);
+        et.merge_and_destroy(et1);
+        et.merge_and_destroy(et2);
 
-    std::set<xyz> check_set;
-    std::set_union(check_set1.begin(), check_set1.end(),
-                   check_set2.begin(), check_set2.end(),
-                   std::inserter(check_set, check_set.end()));
-    std::set_union(check_set1.begin(), check_set1.end(),
-                   check_set3.begin(), check_set3.end(),
-                   std::inserter(check_set, check_set.end()));
+        std::set<xyz> check_set;
+        std::set_union(check_set1.begin(), check_set1.end(), check_set2.begin(),
+                       check_set2.end(),
+                       std::inserter(check_set, check_set.end()));
+        std::set_union(check_set1.begin(), check_set1.end(), check_set3.begin(),
+                       check_set3.end(),
+                       std::inserter(check_set, check_set.end()));
 
-    et.output_and_destroy(set, zoom);
+        et.output_and_destroy(set, zoom);
 
-    assert_tilesets_equal(set.m_tiles, check_set);
+        assert_tilesets_equal(set.m_tiles, check_set);
   }
 }
 
@@ -412,28 +413,28 @@ void test_expire_merge_overlap() {
 // large contiguous areas of tiles (i.e: ensure that we
 // handle the "complete" flag correctly).
 void test_expire_merge_complete() {
-  int zoom = 18;
+    uint32_t zoom = 18;
 
-  for (int i = 0; i < 100; ++i) {
-    expire_tiles et(zoom, 20000, defproj);
-    expire_tiles et0(zoom, 20000, defproj);
-    expire_tiles et1(zoom, 20000, defproj);
-    expire_tiles et2(zoom, 20000, defproj);
-    tile_output_set set(zoom);
-    tile_output_set set0(zoom);
+    for (int i = 0; i < 100; ++i) {
+        expire_tiles et(zoom, 20000, defproj);
+        expire_tiles et0(zoom, 20000, defproj);
+        expire_tiles et1(zoom, 20000, defproj);
+        expire_tiles et2(zoom, 20000, defproj);
+        tile_output_set set(zoom);
+        tile_output_set set0(zoom);
 
-    // et1&2 are two halves of et0's box
-    et0.from_bbox(-10000, -10000, 10000, 10000);
-    et1.from_bbox(-10000, -10000,     0, 10000);
-    et2.from_bbox(     0, -10000, 10000, 10000);
+        // et1&2 are two halves of et0's box
+        et0.from_bbox(-10000, -10000, 10000, 10000);
+        et1.from_bbox(-10000, -10000, 0, 10000);
+        et2.from_bbox(0, -10000, 10000, 10000);
 
-    et.merge_and_destroy(et1);
-    et.merge_and_destroy(et2);
+        et.merge_and_destroy(et1);
+        et.merge_and_destroy(et2);
 
-    et.output_and_destroy(set, zoom);
-    et0.output_and_destroy(set0, zoom);
+        et.output_and_destroy(set, zoom);
+        et0.output_and_destroy(set0, zoom);
 
-    assert_tilesets_equal(set.m_tiles, set0.m_tiles);
+        assert_tilesets_equal(set.m_tiles, set0.m_tiles);
   }
 }
 

--- a/tests/test-expire-tiles.cpp
+++ b/tests/test-expire-tiles.cpp
@@ -86,22 +86,22 @@ struct tile_output_set
   int min_zoom;
 };
 
-void test_xy_to_quadtree_z3()
+void test_xy_to_quadkey_z3()
 {
-    int64_t qt_expected = 0b100111;
-    int64_t qt2 = expire_tiles::xy_to_quadtree(3, 5, 3);
-    ASSERT_EQ(qt2, qt_expected);
-    xy_coord_t xy = expire_tiles::quadtree_to_xy(qt_expected, 3);
+    int64_t quadkey_expected = 0b100111;
+    int64_t quadkey2 = expire_tiles::xy_to_quadkey(3, 5, 3);
+    ASSERT_EQ(quadkey2, quadkey_expected);
+    xy_coord_t xy = expire_tiles::quadkey_to_xy(quadkey_expected, 3);
     ASSERT_EQ(xy.x, 3);
     ASSERT_EQ(xy.y, 5);
 }
 
-void test_xy_to_quadtree_z16()
+void test_xy_to_quadkey_z16()
 {
-    int64_t qt_expected = 0b11111111111111111111111111111111;
-    int64_t qt2 = expire_tiles::xy_to_quadtree(65535, 65535, 16);
-    ASSERT_EQ(qt2, qt_expected);
-    xy_coord_t xy = expire_tiles::quadtree_to_xy(qt_expected, 16);
+    int64_t quadkey_expected = 0b11111111111111111111111111111111;
+    int64_t quadkey2 = expire_tiles::xy_to_quadkey(65535, 65535, 16);
+    ASSERT_EQ(quadkey2, quadkey_expected);
+    xy_coord_t xy = expire_tiles::quadkey_to_xy(quadkey_expected, 16);
     ASSERT_EQ(xy.x, 65535);
     ASSERT_EQ(xy.y, 65535);
 }
@@ -110,18 +110,18 @@ void test_xy_to_quadtree_z16()
  * This test prevents problems which occur if 32-bit integers are used
  * instead of 64-bit integers.
  */
-void test_xy_to_quadtree_z18()
+void test_xy_to_quadkey_z18()
 {
-    int64_t qt_expected = 0b111111111111111111111111111111111111;
-    int64_t qt2 = expire_tiles::xy_to_quadtree(262143, 262143, 18);
-    ASSERT_EQ(qt2, qt_expected);
-    xy_coord_t xy = expire_tiles::quadtree_to_xy(qt_expected, 18);
+    int64_t quadkey_expected = 0b111111111111111111111111111111111111;
+    int64_t quadkey2 = expire_tiles::xy_to_quadkey(262143, 262143, 18);
+    ASSERT_EQ(quadkey2, quadkey_expected);
+    xy_coord_t xy = expire_tiles::quadkey_to_xy(quadkey_expected, 18);
     ASSERT_EQ(xy.x, 262143);
     ASSERT_EQ(xy.y, 262143);
-    qt_expected = 0b001111111111111111111111111111110000;
-    qt2 = expire_tiles::xy_to_quadtree(131068, 131068, 18);
-    ASSERT_EQ(qt2, qt_expected);
-    xy = expire_tiles::quadtree_to_xy(qt_expected, 18);
+    quadkey_expected = 0b001111111111111111111111111111110000;
+    quadkey2 = expire_tiles::xy_to_quadkey(131068, 131068, 18);
+    ASSERT_EQ(quadkey2, quadkey_expected);
+    xy = expire_tiles::quadkey_to_xy(quadkey_expected, 18);
     ASSERT_EQ(xy.x, 131068);
     ASSERT_EQ(xy.y, 131068);
 }
@@ -383,9 +383,9 @@ int main(int argc, char *argv[])
     srand(0);
 
     //try each test if any fail we will exit
-    RUN_TEST(test_xy_to_quadtree_z3);
-    RUN_TEST(test_xy_to_quadtree_z16);
-    RUN_TEST(test_xy_to_quadtree_z18);
+    RUN_TEST(test_xy_to_quadkey_z3);
+    RUN_TEST(test_xy_to_quadkey_z16);
+    RUN_TEST(test_xy_to_quadkey_z18);
     RUN_TEST(test_expire_simple_z1);
     RUN_TEST(test_expire_simple_z3);
     RUN_TEST(test_expire_simple_z18);

--- a/tests/test-expire-tiles.cpp
+++ b/tests/test-expire-tiles.cpp
@@ -88,7 +88,7 @@ struct tile_output_set
 
 void test_xy_to_quadkey_z3()
 {
-    uint64_t quadkey_expected = 0b100111;
+    uint64_t quadkey_expected = 0x27;
     uint64_t quadkey2 = expire_tiles::xy_to_quadkey(3, 5, 3);
     ASSERT_EQ(quadkey2, quadkey_expected);
     xy_coord_t xy = expire_tiles::quadkey_to_xy(quadkey_expected, 3);
@@ -98,7 +98,7 @@ void test_xy_to_quadkey_z3()
 
 void test_xy_to_quadkey_z16()
 {
-    uint64_t quadkey_expected = 0b11111111111111111111111111111111;
+    uint64_t quadkey_expected = 0xffffffff;
     uint64_t quadkey2 = expire_tiles::xy_to_quadkey(65535, 65535, 16);
     ASSERT_EQ(quadkey2, quadkey_expected);
     xy_coord_t xy = expire_tiles::quadkey_to_xy(quadkey_expected, 16);
@@ -112,13 +112,13 @@ void test_xy_to_quadkey_z16()
  */
 void test_xy_to_quadkey_z18()
 {
-    uint64_t quadkey_expected = 0b111111111111111111111111111111111111;
+    uint64_t quadkey_expected = 0xfffffffff;
     uint64_t quadkey2 = expire_tiles::xy_to_quadkey(262143, 262143, 18);
     ASSERT_EQ(quadkey2, quadkey_expected);
     xy_coord_t xy = expire_tiles::quadkey_to_xy(quadkey_expected, 18);
     ASSERT_EQ(xy.x, 262143);
     ASSERT_EQ(xy.y, 262143);
-    quadkey_expected = 0b001111111111111111111111111111110000;
+    quadkey_expected = 0x3fffffff0;
     quadkey2 = expire_tiles::xy_to_quadkey(131068, 131068, 18);
     ASSERT_EQ(quadkey2, quadkey_expected);
     xy = expire_tiles::quadkey_to_xy(quadkey_expected, 18);

--- a/tests/test-options-parse.cpp
+++ b/tests/test-options-parse.cpp
@@ -132,6 +132,40 @@ void test_outputs()
     }
 }
 
+void test_parsing_tile_expiry_zoom_levels()
+{
+    const char *a1[] = {
+        "osm2pgsql",     "-e",
+        "8--12",         "--style",
+        "default.style", "tests/liechtenstein-2013-08-03.osm.pbf"};
+    parse_fail(len(a1), a1, "Invalid maximum zoom level given for tile expiry");
+
+    const char *a2[] = {
+        "osm2pgsql",     "-e",
+        "-8-12",         "--style",
+        "default.style", "tests/liechtenstein-2013-08-03.osm.pbf"};
+    parse_fail(len(a2), a2,
+               "Missing argument for option -e. Zoom levels must be positive.");
+
+    const char *a3[] = {"osm2pgsql", "-e", "--style", "default.style",
+                        "tests/liechtenstein-2013-08-03.osm.pbf"};
+    parse_fail(len(a3), a3,
+               "Missing argument for option -e. Zoom levels must be positive.");
+
+    const char *a4[] = {
+        "osm2pgsql",     "-e",
+        "a-8",           "--style",
+        "default.style", "tests/liechtenstein-2013-08-03.osm.pbf"};
+    parse_fail(len(a4), a4, "Missing zoom level for tile expiry.");
+
+    const char *a5[] = {
+        "osm2pgsql",     "-e",
+        "6:8",           "--style",
+        "default.style", "tests/liechtenstein-2013-08-03.osm.pbf"};
+    parse_fail(len(a5), a5, "Minimum and maximum zoom level for tile expiry "
+                            "must be separated by '-'.");
+}
+
 int get_random_proj(std::vector<std::string>& args)
 {
     int proj = rand() % 3;
@@ -290,6 +324,8 @@ int main(int argc, char *argv[])
     run_test("test_middles", test_middles);
     run_test("test_outputs", test_outputs);
     run_test("test_random_perms", test_random_perms);
+    run_test("test_parsing_tile_expiry_zoom_levels",
+             test_parsing_tile_expiry_zoom_levels);
 
     //passed
     return 0;


### PR DESCRIPTION
This pull request contains the changes announced in #709.

This pull request is the first part of a rewrite of the tile expiry. It is a port of the tile expiry of [my own](https://github.com/Nakaner/Cerepso) PostgreSQL import tool to osm2pgsql which I wrote as part of my master thesis. I needed an importer with a tile expiry which handles relations in much different way than osm2pgsql does and the tile expiry had to be more exact.

Each tile is represented by a 64-bit integer (bits of Y and X index interleaved). The set only contains the tiles at the highest zoom level where the list of expired tiles should be generated. All lower requested zoom levels are calculated during writing the tile IDs to the output file by shifting the bits of the tile IDs.

I did a performance test with an import of the Europe extract by Geofabrik to ensure that it has no negative impact on the performance. Time and memory consumption was measured using `/usr/bin/time -v`. The input data was located on a hard disk, flat nodes file and the database was located on SSDs.

1. Check out the `master` branch.
2. Import using `osm2pgsql --merc --slim --flat-nodes /ssd/michael-flatnodes/michael-flat-nodes.cache -C 40000 --style ../default.style --unlogged --number-processes 2 --database gis europe-170217.osm.pbf` took 24 hours and 35 minutes and needed 26,765,608 kB. During these 24 hours the machine was busy producing a subset of Geofabrik's extracts offered on download.geofabrik.de for internal purposes, i.e. don't take these numbers serious.
4. Save a copy of the flat nodes file.
5. Shut down the PostgreSQL database.
6. Copy the tablespace of the database `gis` to a backup location.
7. Start the database.
8. Apply a diff using `osm2pgsql -d gis --slim --merc -S ../default.style --flat-nodes /ssd/michael-flatnodes/michael-flat-nodes.cache --append --number-processes 2 -C 25000 -o master-433.log --expire-bbox-size 20000 -e 10-16 433.osc.gz`. (56 minutes 28 seconds, 9,143,644 kB RAM)
9. Check out branch `expiry-as-set` and build osm2pgsql. The original import could be reused because the differences between both branches were small.
10. Restore the backup of the flat nodes file.
11. Shut down the PostgreSQL database.
12. Restore the tablespace of the database `gis` from the backup.
13. Start the database.
14. Apply a diff using `osm2pgsql -d gis --slim --merc -S ../default.style --flat-nodes /ssd/michael-flatnodes/michael-flat-nodes.cache --append --number-processes 2 -C 25000 -o master-433.log --expire-bbox-size 20000 -e 10-16 433.osc.gz`. (57 minutes 34 seconds, 9,389,628 kB RAM)

The cronjob which produces the OSM planet extracts day by day on this machine did not run during step 8 and 14. The result is within the measurement accuracy. The code line responsible for writing the expiry file was removed in both test cases to ensure that writing larger output files (see #709) does not influence the measurements.

If you request tile expiry for smaller zoom levels (e.g. 8 to 12), both branches consume about 500 MB RAM.

This is the first part of a large rewrite of the tile expiry. If you are interested in the ongoing work, have a look at the branch [`tile-selection-rewrite`](https://github.com/Nakaner/osm2pgsql/tree/tile-selection-rewrite) at my fork of this repository. That branch will rewrite the selection of the tiles which will be marked as expired.