### PR TITLE
update libosmium

### DIFF
--- a/contrib/libosmium/README.contrib
+++ b/contrib/libosmium/README.contrib
@@ -1,2 +1,2 @@
 Source: https://github.com/osmcode/libosmium
-Revision: e96c20f02b8ffe42efac564f44f4ce3916458035
+Revision: 102d77186e5dfb9993a8087089eb81168c8d2ce7

--- a/contrib/libosmium/osmium/area/detail/basic_assembler.hpp
+++ b/contrib/libosmium/osmium/area/detail/basic_assembler.hpp
@@ -757,6 +757,7 @@ namespace osmium {
                                 }
                                 loc_done.insert(c.stop_location);
                                 find_candidates(candidates, loc_done, xrings, c);
+                                loc_done.erase(c.stop_location);
                                 if (debug()) {
                                     std::cerr << "          ...back\n";
                                 }


### PR DESCRIPTION
Adds a fix in the area assembler which occasionally produced
invalid geometries for complex polygons.

See https://github.com/osmcode/libosmium/issues/208.