### PR TITLE
Finish wkb properly

### DIFF
--- a/osmium-builder.cpp
+++ b/osmium-builder.cpp
@@ -103,6 +103,7 @@ osmium_builder_t::get_wkb_line(osmium::WayNodeList const &nodes, bool do_split)
                     // the next iteration.
                     if (this_pt == ipoint) {
                         dist = 0;
+                        m_writer.linestring_finish(0);
                         m_writer.linestring_start();
                         curlen = 0;
                     } else {
@@ -120,8 +121,9 @@ osmium_builder_t::get_wkb_line(osmium::WayNodeList const &nodes, bool do_split)
         prev_pt = this_pt;
     }
 
+    auto wkb = m_writer.linestring_finish(curlen);
     if (curlen > 1) {
-        ret.push_back(m_writer.linestring_finish(curlen));
+        ret.push_back(wkb);
     }
 
     return ret;
@@ -394,8 +396,9 @@ osmium_builder_t::create_polygons(osmium::Area const &area)
             }
         }
 
+        auto wkb = m_writer.polygon_finish(num_rings);
         if (num_rings > 0) {
-            ret.push_back(m_writer.polygon_finish(num_rings));
+            ret.push_back(wkb);
         }
 
     } catch (osmium::geometry_error) { /* ignored */

--- a/wkb.hpp
+++ b/wkb.hpp
@@ -132,11 +132,6 @@ public:
         m_multigeometry_size_offset = header(m_data, wkb_multi_line, true);
     }
 
-    void multilinestring_line_finish(size_t num_points)
-    {
-        set_size(m_geometry_size_offset, num_points);
-    }
-
     std::string multilinestring_finish(size_t num_lines)
     {
         set_size(m_multigeometry_size_offset, num_lines);
@@ -182,11 +177,6 @@ public:
     void multipolygon_start()
     {
         m_multigeometry_size_offset = header(m_data, wkb_multi_polygon, true);
-    }
-
-    void multipolygon_polygon_finish(size_t num_rings)
-    {
-        set_size(m_geometry_size_offset, num_rings);
     }
 
     std::string multipolygon_finish(size_t num_polygons)


### PR DESCRIPTION
Calling the finish functions clears the internal
buffer of the WKB factory, so always call them even
if the geometry is not used afterwards.

Found while using planet updates on an extract import.

Also removes some unused functions from wkb factory.