### PR TITLE
move builder from processors to output-multi

### DIFF
--- a/geometry-processor.cpp
+++ b/geometry-processor.cpp
@@ -22,8 +22,7 @@ std::shared_ptr<geometry_processor> geometry_processor::create(const std::string
         ptr = std::make_shared<processor_line>(options->projection);
     }
     else if (type == "polygon") {
-        ptr = std::make_shared<processor_polygon>(options->projection,
-                                                  options->enable_multi);
+        ptr = std::make_shared<processor_polygon>(options->projection);
     }
     else {
         throw std::runtime_error((boost::format("Unable to construct geometry processor "
@@ -57,19 +56,22 @@ bool geometry_processor::interests(unsigned int interested) const {
 }
 
 geometry_processor::wkb_t
-geometry_processor::process_node(osmium::Location const &)
+geometry_processor::process_node(osmium::Location const &,
+                                 geom::osmium_builder_t *)
 {
     return wkb_t();
 }
 
-geometry_processor::wkb_t geometry_processor::process_way(osmium::Way const &)
+geometry_processor::wkb_t
+geometry_processor::process_way(osmium::Way const &, geom::osmium_builder_t *)
 {
     return wkb_t();
 }
 
 geometry_processor::wkbs_t
 geometry_processor::process_relation(osmium::Relation const &,
-                                     osmium::memory::Buffer const &)
+                                     osmium::memory::Buffer const &,
+                                     geom::osmium_builder_t *)
 {
     return wkbs_t();
 }

--- a/geometry-processor.hpp
+++ b/geometry-processor.hpp
@@ -47,18 +47,21 @@ struct geometry_processor {
 
     // process a node, optionally returning a WKB string describing
     // geometry to be inserted into the table.
-    virtual wkb_t process_node(osmium::Location const &loc);
+    virtual wkb_t process_node(osmium::Location const &loc,
+                               geom::osmium_builder_t *builder);
 
     // process a way
     // position data and optionally returning WKB-encoded geometry
     // for insertion into the table.
-    virtual wkb_t process_way(osmium::Way const &way);
+    virtual wkb_t process_way(osmium::Way const &way,
+                              geom::osmium_builder_t *builder);
 
     // process a way, taking a middle query object to get way and
     // node position data. optionally returns an array of WKB-encoded geometry
     // for insertion into the table.
     virtual wkbs_t process_relation(osmium::Relation const &rel,
-                                    osmium::memory::Buffer const &ways);
+                                    osmium::memory::Buffer const &ways,
+                                    geom::osmium_builder_t *builder);
 
     // returns the SRID of the output geometry.
     int srid() const;

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -83,6 +83,7 @@ protected:
     expire_tiles m_expire;
     relation_helper m_relation_helper;
     osmium::memory::Buffer buffer;
+    geom::osmium_builder_t m_builder;
     bool m_way_area;
 };
 

--- a/processor-line.cpp
+++ b/processor-line.cpp
@@ -2,21 +2,23 @@
 
 processor_line::processor_line(std::shared_ptr<reprojection> const &proj)
 : geometry_processor(proj->target_srs(), "LINESTRING",
-                     interest_way | interest_relation),
-  m_builder(proj, false)
+                     interest_way | interest_relation)
 {
 }
 
-geometry_processor::wkb_t processor_line::process_way(osmium::Way const &way)
+geometry_processor::wkb_t
+processor_line::process_way(osmium::Way const &way,
+                            geom::osmium_builder_t *builder)
 {
-    auto wkbs = m_builder.get_wkb_line(way.nodes(), 1000000);
+    auto wkbs = builder->get_wkb_line(way.nodes(), 1000000);
 
     return wkbs.empty() ? wkb_t() : wkbs[0];
 }
 
 geometry_processor::wkbs_t
 processor_line::process_relation(osmium::Relation const &,
-                                 osmium::memory::Buffer const &ways)
+                                 osmium::memory::Buffer const &ways,
+                                 geom::osmium_builder_t *builder)
 {
-    return m_builder.get_wkb_multiline(ways, 1000000);
+    return builder->get_wkb_multiline(ways, 1000000);
 }

--- a/processor-line.hpp
+++ b/processor-line.hpp
@@ -8,12 +8,11 @@ class processor_line : public geometry_processor
 public:
     processor_line(std::shared_ptr<reprojection> const &proj);
 
-    wkb_t process_way(osmium::Way const &way) override;
+    wkb_t process_way(osmium::Way const &way,
+                      geom::osmium_builder_t *builder) override;
     wkbs_t process_relation(osmium::Relation const &rel,
-                            osmium::memory::Buffer const &ways) override;
-
-private:
-    geom::osmium_builder_t m_builder;
+                            osmium::memory::Buffer const &ways,
+                            geom::osmium_builder_t *builder) override;
 };
 
 #endif /* PROCESSOR_LINE_HPP */

--- a/processor-point.cpp
+++ b/processor-point.cpp
@@ -6,13 +6,13 @@
 #include "util.hpp"
 
 processor_point::processor_point(std::shared_ptr<reprojection> const &proj)
-: geometry_processor(proj->target_srs(), "POINT", interest_node),
-  m_builder(proj, false)
+: geometry_processor(proj->target_srs(), "POINT", interest_node)
 {
 }
 
 geometry_processor::wkb_t
-processor_point::process_node(osmium::Location const &loc)
+processor_point::process_node(osmium::Location const &loc,
+                              geom::osmium_builder_t *builder)
 {
-    return m_builder.get_wkb_node(loc);
+    return builder->get_wkb_node(loc);
 }

--- a/processor-point.hpp
+++ b/processor-point.hpp
@@ -8,10 +8,8 @@ class processor_point : public geometry_processor
 public:
     processor_point(std::shared_ptr<reprojection> const &proj);
 
-    wkb_t process_node(osmium::Location const &loc) override;
-
-private:
-    geom::osmium_builder_t m_builder;
+    wkb_t process_node(osmium::Location const &loc,
+                       geom::osmium_builder_t *builder) override;
 };
 
 #endif /* PROCESSOR_POINT_HPP */

--- a/processor-polygon.cpp
+++ b/processor-polygon.cpp
@@ -1,21 +1,22 @@
 #include "processor-polygon.hpp"
 
-processor_polygon::processor_polygon(std::shared_ptr<reprojection> const &proj,
-                                     bool enable_multi)
+processor_polygon::processor_polygon(std::shared_ptr<reprojection> const &proj)
 : geometry_processor(proj->target_srs(), "GEOMETRY",
-                     interest_way | interest_relation),
-  m_builder(proj, enable_multi)
+                     interest_way | interest_relation)
 {
 }
 
-geometry_processor::wkb_t processor_polygon::process_way(osmium::Way const &way)
+geometry_processor::wkb_t
+processor_polygon::process_way(osmium::Way const &way,
+                               geom::osmium_builder_t *builder)
 {
-    return m_builder.get_wkb_polygon(way);
+    return builder->get_wkb_polygon(way);
 }
 
 geometry_processor::wkbs_t
 processor_polygon::process_relation(osmium::Relation const &rel,
-                                    osmium::memory::Buffer const &ways)
+                                    osmium::memory::Buffer const &ways,
+                                    geom::osmium_builder_t *builder)
 {
-    return m_builder.get_wkb_multipolygon(rel, ways);
+    return builder->get_wkb_multipolygon(rel, ways);
 }

--- a/processor-polygon.hpp
+++ b/processor-polygon.hpp
@@ -6,15 +6,13 @@
 class processor_polygon : public geometry_processor
 {
 public:
-    processor_polygon(std::shared_ptr<reprojection> const &proj,
-                      bool enable_multi);
+    processor_polygon(std::shared_ptr<reprojection> const &proj);
 
-    wkb_t process_way(osmium::Way const &nodes) override;
+    wkb_t process_way(osmium::Way const &nodes,
+                      geom::osmium_builder_t *builder) override;
     wkbs_t process_relation(osmium::Relation const &rel,
-                            osmium::memory::Buffer const &ways) override;
-
-private:
-    geom::osmium_builder_t m_builder;
+                            osmium::memory::Buffer const &ways,
+                            geom::osmium_builder_t *builder) override;
 };
 
 #endif /* PROCESSOR_POLYGON_HPP */


### PR DESCRIPTION
Processors are shared between threads and therefore
cannot hold the stateful wkb builders. Keep them in
output-multi instead and hand them in when calling
the process functions.

Fixes #773.