### PR TITLE
Fix counter initialisation in wkb_reader

### DIFF
--- a/table.hpp
+++ b/table.hpp
@@ -58,7 +58,7 @@ class table_t
                 }
             private:
                 wkb_reader(pg_result_t &&result)
-                : m_result(std::move(result)), m_count(PQntuples(result.get())),
+                : m_result(std::move(result)), m_count(PQntuples(m_result.get())),
                   m_current(0)
                 {}
 


### PR DESCRIPTION
The counter in wkb_reader was always initialized with 0 (`result` being nullptr after having just been moved to `m_result`). So expiry from_db() has not been doing anything for a long time now.

As a test, import a single way and then append a change which modifies a node on this way.

@Nakaner Would you mind running this change through your setup? It is more extensive then my tests when it comes to expiry.

Fixes #766.