### PR TITLE
Update Fedora build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,17 @@ sudo apt-get install make cmake g++ libboost-dev libboost-system-dev \
 On a Fedora system, use
 
 ```sh
-sudo yum install cmake gcc-c++ boost-devel expat-devel zlib-devel bzip2-devel \
-  postgresql-devel proj-devel proj-epsg lua-devel
+sudo dnf install cmake make gcc-c++ boost-devel expat-devel zlib-devel \
+  bzip2-devel postgresql-devel proj-devel proj-epsg lua-devel
 ```
 
 On RedHat / CentOS first run `sudo yum install epel-release` then install
-dependencies like on Fedora.
+dependencies with:
+
+```sh
+sudo yum install cmake make gcc-c++ boost-devel expat-devel zlib-devel \
+  bzip2-devel postgresql-devel proj-devel proj-epsg lua-devel
+```
 
 On a FreeBSD system, use
 


### PR DESCRIPTION
* Adding additional libraries needed to build to Fedora install command
* Changing `yum` to `dnf`
* Adding specific Fedora versions using GEOS 3.5.1 by default in the package manager
* Adding a note as to why Fedora 26 has incompatible GEOS library, linking issue