### PR TITLE
Allow importing features whose name is missing.

### DIFF
--- a/options.cpp
+++ b/options.cpp
@@ -53,6 +53,7 @@ namespace
         {"hstore-add-index",0,0,211},
         {"multi-geometry", 0, 0, 'G'},
         {"keep-coastlines", 0, 0, 'K'},
+	{"keep-unnamed", 0, 0, 215},
         {"input-reader", 1, 0, 'r'},
         {"version", 0, 0, 'V'},
         {"disable-parallel-indexing", 0, 0, 'I'},
@@ -202,6 +203,7 @@ namespace
        -K|--keep-coastlines Keep coastline data rather than filtering it out.\n\
                         By default natural=coastline tagged data will be discarded\n\
                         because renderers usually have shape files for them.\n\
+          --keep-unnamed Keep unnamed features rather than filtering them out.\n\
           --reproject-area   compute area column using spherical mercator coordinates.\n\
        -h|--help        Help information.\n\
        -v|--verbose     Verbose output.\n");
@@ -270,7 +272,7 @@ options_t::options_t()
   expire_tiles_zoom(0), expire_tiles_zoom_min(0),
   expire_tiles_max_bbox(20000.0), expire_tiles_filename("dirty_tiles"),
   hstore_mode(HSTORE_NONE), enable_hstore_index(false), enable_multi(false),
-  hstore_columns(), keep_coastlines(false), parallel_indexing(true),
+  hstore_columns(), keep_coastlines(false), keep_unnamed(false), parallel_indexing(true),
 #ifdef __amd64__
   alloc_chunkwise(ALLOC_SPARSE | ALLOC_DENSE),
 #else
@@ -326,6 +328,9 @@ options_t::options_t(int argc, char *argv[]): options_t()
             break;
         case 'K':
             keep_coastlines = true;
+            break;
+        case 215:
+            keep_unnamed = true;
             break;
         case 'l':
             projection.reset(reprojection::create_projection(PROJ_LATLONG));

--- a/options.hpp
+++ b/options.hpp
@@ -65,6 +65,7 @@ public:
     bool enable_multi; ///< Output multi-geometries intead of several simple geometries
     std::vector<std::string> hstore_columns; ///< list of columns that should be written into their own hstore column
     bool keep_coastlines;
+    bool keep_unnamed;
     bool parallel_indexing;
     int alloc_chunkwise;
     int num_procs;

--- a/output-gazetteer.cpp
+++ b/output-gazetteer.cpp
@@ -294,7 +294,7 @@ void place_tag_processor::process_tags(osmium::OSMObject const &o)
     }
 
     // skip some tags, if they don't have a proper name (ref doesn't count)
-    if (!isnamed) {
+    if (!m_options.keep_unnamed && !isnamed) {
         if (!places.empty())
             places.erase(std::remove_if(places.begin(), places.end(),
                                         UnnamedPredicate()),
@@ -314,7 +314,7 @@ void place_tag_processor::process_tags(osmium::OSMObject const &o)
             places.emplace_back(place->key(), place->value());
     }
 
-    if (isnamed && places.empty()) {
+    if (m_options.keep_unnamed || (isnamed && places.empty())) {
         if (junction)
             places.emplace_back(junction->key(), junction->value());
         else if (landuse)

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -22,8 +22,9 @@
 class place_tag_processor
 {
 public:
-    place_tag_processor()
-        : single_fmt("%1%\t")
+    place_tag_processor(const options_t &options_)
+        : single_fmt("%1%\t"),
+          m_options(options_)
     {
         places.reserve(4);
         extratags.reserve(15);
@@ -120,6 +121,7 @@ private:
     int admin_level;
 
     boost::format single_fmt;
+    const options_t m_options;
 };
 
 
@@ -127,7 +129,7 @@ class output_gazetteer_t : public output_t {
 public:
     output_gazetteer_t(const middle_query_t *mid_, const options_t &options_)
     : output_t(mid_, options_), Connection(NULL), ConnectionDelete(NULL),
-      ConnectionError(NULL), copy_active(false),
+      ConnectionError(NULL), copy_active(false), places(options_),
       m_builder(options_.projection, true), single_fmt("%1%"),
       osmium_buffer(PLACE_BUFFER_SIZE, osmium::memory::Buffer::auto_grow::yes)
     {
@@ -136,7 +138,7 @@ public:
 
     output_gazetteer_t(const output_gazetteer_t &other)
     : output_t(other.m_mid, other.m_options), Connection(NULL),
-      ConnectionDelete(NULL), ConnectionError(NULL), copy_active(false),
+      ConnectionDelete(NULL), ConnectionError(NULL), copy_active(false), places(options_),
       m_builder(other.m_options.projection, true), single_fmt(other.single_fmt),
       osmium_buffer(PLACE_BUFFER_SIZE, osmium::memory::Buffer::auto_grow::yes)
     {

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -138,7 +138,7 @@ public:
 
     output_gazetteer_t(const output_gazetteer_t &other)
     : output_t(other.m_mid, other.m_options), Connection(NULL),
-      ConnectionDelete(NULL), ConnectionError(NULL), copy_active(false), places(options_),
+      ConnectionDelete(NULL), ConnectionError(NULL), copy_active(false), places(other.m_options),
       m_builder(other.m_options.projection, true), single_fmt(other.single_fmt),
       osmium_buffer(PLACE_BUFFER_SIZE, osmium::memory::Buffer::auto_grow::yes)
     {


### PR DESCRIPTION
Sometimes features with no names are useful to import into the "places" table.