### PR TITLE
simplify ram node cache by removing unused dirty bit support

### DIFF
--- a/node-ram-cache.hpp
+++ b/node-ram-cache.hpp
@@ -34,13 +34,8 @@ class ramNodeBlock
 public:
     ramNodeBlock() : nodes(nullptr), block_offset(-1), _used(0) {}
 
-    void set_dirty() { _used |= 1; }
-    bool dirty() const { return _used & 1; }
-
     void reset_used() { _used = 0; }
     void inc_used() { _used += 2; }
-    void dec_used() { _used -= 2; }
-    void set_used(int used) { _used = (used << 1) || (_used & 1); }
     int used() const { return _used >> 1; }
 
     osmium::Location *nodes;

--- a/node-ram-cache.hpp
+++ b/node-ram-cache.hpp
@@ -35,14 +35,14 @@ public:
     ramNodeBlock() : nodes(nullptr), block_offset(-1), _used(0) {}
 
     void reset_used() { _used = 0; }
-    void inc_used() { _used += 2; }
-    int used() const { return _used >> 1; }
+    void inc_used() { _used += 1; }
+    int used() const { return _used; }
 
     osmium::Location *nodes;
     int32_t block_offset;
 
 private:
-    int32_t _used; // 0-bit indicates dirty
+    int32_t _used;
 };
 
 struct node_ram_cache : public boost::noncopyable


### PR DESCRIPTION
Compiling the current master on F27 gives the warning below. It turns out that the `set_used()` macro and the dirty bit handling is no longer used and can be removed.
<pre>In file included from /home/jburgess/osm2pgsql/options.hpp:4:0,
                 from /home/jburgess/osm2pgsql/expire-tiles.cpp:18:
/home/jburgess/osm2pgsql/node-ram-cache.hpp: In member function ‘void ramNodeBlock::set_used(int)’:
/home/jburgess/osm2pgsql/node-ram-cache.hpp:43:45: warning: ‘<<’ in boolean context, did you mean ‘<’ ? [-Wint-in-bool-context]
     void set_used(int used) { _used = (used << 1) || (_used & 1); }
                                       ~~~~~~^~~~~
</pre>
All the tests pass after making this change.