### PR TITLE
Rework multi-threading during indexing

### DIFF
--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -21,7 +21,7 @@ struct middle_pgsql_t : public slim_middle_t {
     virtual ~middle_pgsql_t();
 
     void start(const options_t *out_options_) override;
-    void stop(void) override;
+    void stop(osmium::thread::Pool &pool) override;
     void analyze(void) override;
     void end(void) override;
     void commit(void) override;

--- a/middle-ram.cpp
+++ b/middle-ram.cpp
@@ -167,7 +167,7 @@ void middle_ram_t::start(const options_t *out_options_)
         new node_ram_cache(out_options->alloc_chunkwise, out_options->cache));
 }
 
-void middle_ram_t::stop(void)
+void middle_ram_t::stop(osmium::thread::Pool &pool)
 {
     cache.reset(nullptr);
 

--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -85,7 +85,7 @@ struct middle_ram_t : public middle_t {
     virtual ~middle_ram_t();
 
     void start(const options_t *out_options_) override;
-    void stop(void) override;
+    void stop(osmium::thread::Pool &pool) override;
     void analyze(void) override;
     void end(void) override;
     void commit(void) override;

--- a/middle.hpp
+++ b/middle.hpp
@@ -12,6 +12,8 @@
 #include <cstddef>
 #include <memory>
 
+#include <osmium/thread/pool.hpp>
+
 #include "osmtypes.hpp"
 #include "reprojection.hpp"
 
@@ -84,7 +86,7 @@ struct middle_t : public middle_query_t {
     virtual ~middle_t() {}
 
     virtual void start(const options_t *out_options_) = 0;
-    virtual void stop(void) = 0;
+    virtual void stop(osmium::thread::Pool &pool) = 0;
     virtual void analyze(void) = 0;
     virtual void end(void) = 0;
     virtual void commit(void) = 0;

--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -6,6 +6,8 @@
 #include <utility>
 #include <vector>
 
+#include <osmium/thread/pool.hpp>
+
 #include "middle.hpp"
 #include "node-ram-cache.hpp"
 #include "osmdata.hpp"
@@ -406,26 +408,34 @@ void osmdata_t::stop() {
         mid->iterate_relations( ptp );
     }
 
-    if (outs[0]->get_options()->droptemp) {
-        // if the temp tables are going to be dropped, we can stop them earlier.
-        mid->stop();
-    }
 
     // Clustering, index creation, and cleanup.
     // All the intensive parts of this are long-running PostgreSQL commands
+    {
+        auto *opts = outs[0]->get_options();
+        osmium::thread::Pool pool(opts->parallel_indexing ? opts->num_procs : 1,
+                                  512);
 
-    std::vector<std::future<void>> futures;
+        if (opts->droptemp) {
+            // When dropping middle tables, make sure they are gone before
+            // indexing starts.
+            mid->stop(pool);
+        }
 
-    // XXX we might get too many parallel processes here
-    //     use osmium worker pool instead
-    for (auto& out: outs) {
-        futures.push_back(std::async(&output_t::stop, out.get()));
-    }
-    if (!outs[0]->get_options()->droptemp) {
-        futures.push_back(std::async(&middle_t::stop, mid.get()));
-    }
+        for (auto &out : outs) {
+            out->stop(&pool);
+        }
 
-    for (auto& f: futures) {
-      f.get();
+        if (!opts->droptemp) {
+            // When keeping middle tables, there is quite a large index created
+            // which is better done after the output tables have been copied.
+            // Note that --disable-parallel-indexing needs to be used to really
+            // force the order.
+            mid->stop(pool);
+        }
+
+        // Waiting here for pool to execute all tasks.
+        // XXX If one of them has an error, all other will finish first,
+        //     which may take a long time.
     }
 }

--- a/output-gazetteer.cpp
+++ b/output-gazetteer.cpp
@@ -588,7 +588,7 @@ int output_gazetteer_t::start()
     return 0;
 }
 
-void output_gazetteer_t::stop()
+void output_gazetteer_t::stop(osmium::thread::Pool *)
 {
    /* Stop any active copy */
    stop_copy();

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -154,7 +154,7 @@ public:
     }
 
     int start() override;
-    void stop() override;
+    void stop(osmium::thread::Pool *pool) override;
     void commit() override {}
 
     void enqueue_ways(pending_queue_t &, osmid_t, size_t, size_t&) override {}

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -178,9 +178,9 @@ int output_multi_t::pending_relation(osmid_t id, int exists) {
     return ret;
 }
 
-void output_multi_t::stop()
+void output_multi_t::stop(osmium::thread::Pool *pool)
 {
-    m_table->stop();
+    pool->submit(std::bind(&table_t::stop, m_table.get()));
     if (m_options.expire_tiles_zoom_min > 0) {
         m_expire.output_and_destroy(m_options.expire_tiles_filename.c_str(),
                                     m_options.expire_tiles_zoom_min);

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -35,7 +35,7 @@ public:
     std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const override;
 
     int start() override;
-    void stop() override;
+    void stop(osmium::thread::Pool *pool) override;
     void commit() override;
 
     void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) override;

--- a/output-null.cpp
+++ b/output-null.cpp
@@ -11,8 +11,7 @@ int output_null_t::start() {
     return 0;
 }
 
-void output_null_t::stop() {
-}
+void output_null_t::stop(osmium::thread::Pool *) {}
 
 void output_null_t::commit() {
 }

--- a/output-null.hpp
+++ b/output-null.hpp
@@ -15,7 +15,7 @@ public:
     std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const override;
 
     int start() override;
-    void stop() override;
+    void stop(osmium::thread::Pool *pool) override;
     void commit() override;
     void cleanup(void);
 

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -29,7 +29,7 @@ public:
     std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const override;
 
     int start() override;
-    void stop() override;
+    void stop(osmium::thread::Pool *pool) override;
     void commit() override;
 
     void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) override;

--- a/output.hpp
+++ b/output.hpp
@@ -13,6 +13,7 @@
 #include <stack>
 
 #include <boost/noncopyable.hpp>
+#include <osmium/thread/pool.hpp>
 
 #include "options.hpp"
 
@@ -40,7 +41,7 @@ public:
     virtual std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const = 0;
 
     virtual int start() = 0;
-    virtual void stop() = 0;
+    virtual void stop(osmium::thread::Pool *pool) = 0;
     virtual void commit() = 0;
 
     virtual void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id, size_t& added) = 0;

--- a/tests/mockups.hpp
+++ b/tests/mockups.hpp
@@ -8,7 +8,7 @@ struct dummy_middle_t : public middle_t {
     virtual ~dummy_middle_t() = default;
 
     void start(const options_t *) override { }
-    void stop(void) override  { }
+    void stop(osmium::thread::Pool &) override {}
     void cleanup(void) { }
     void analyze(void) override  { }
     void end(void) override  { }
@@ -45,7 +45,7 @@ struct dummy_slim_middle_t : public slim_middle_t {
     virtual ~dummy_slim_middle_t() = default;
 
     void start(const options_t *) override  { }
-    void stop(void) override  { }
+    void stop(osmium::thread::Pool &) override {}
     void cleanup(void) { }
     void analyze(void) override  { }
     void end(void) override  { }

--- a/tests/test-middle-flat.cpp
+++ b/tests/test-middle-flat.cpp
@@ -38,8 +38,9 @@ void run_tests(options_t options, const std::string cache_type) {
 
     if (test_node_set(&mid_pgsql) != 0) { throw std::runtime_error("test_node_set failed."); }
 
+    osmium::thread::Pool pool(1);
     mid_pgsql.commit();
-    mid_pgsql.stop();
+    mid_pgsql.stop(pool);
   }
   {
     middle_pgsql_t mid_pgsql;
@@ -49,8 +50,9 @@ void run_tests(options_t options, const std::string cache_type) {
 
     if (test_nodes_comprehensive_set(&mid_pgsql) != 0) { throw std::runtime_error("test_nodes_comprehensive_set failed."); }
 
+    osmium::thread::Pool pool(1);
     mid_pgsql.commit();
-    mid_pgsql.stop();
+    mid_pgsql.stop(pool);
   }
   /* This should work, but doesn't. More tests are needed that look at updates
      without the complication of ways.

--- a/tests/test-middle-pgsql.cpp
+++ b/tests/test-middle-pgsql.cpp
@@ -29,8 +29,9 @@ void run_tests(options_t options, const std::string cache_type) {
 
     if (test_node_set(&mid_pgsql) != 0) { throw std::runtime_error("test_node_set failed."); }
 
+    osmium::thread::Pool pool(1);
     mid_pgsql.commit();
-    mid_pgsql.stop();
+    mid_pgsql.stop(pool);
   }
   {
     middle_pgsql_t mid_pgsql;
@@ -40,24 +41,32 @@ void run_tests(options_t options, const std::string cache_type) {
 
     if (test_nodes_comprehensive_set(&mid_pgsql) != 0) { throw std::runtime_error("test_nodes_comprehensive_set failed."); }
 
+    osmium::thread::Pool pool(1);
     mid_pgsql.commit();
-    mid_pgsql.stop();
+    mid_pgsql.stop(pool);
   }
   {
     middle_pgsql_t mid_pgsql;
     output_null_t out_test(&mid_pgsql, options);
 
     mid_pgsql.start(&options);
-    mid_pgsql.commit();
-    mid_pgsql.stop();
+    {
+        osmium::thread::Pool pool(1);
+        mid_pgsql.commit();
+        mid_pgsql.stop(pool);
+    }
+
     // Switch to append mode because this tests updates
     options.append = true;
     options.create = false;
     mid_pgsql.start(&options);
     if (test_way_set(&mid_pgsql) != 0) { throw std::runtime_error("test_way_set failed."); }
 
-    mid_pgsql.commit();
-    mid_pgsql.stop();
+    {
+        osmium::thread::Pool pool(1);
+        mid_pgsql.commit();
+        mid_pgsql.stop(pool);
+    }
   }
 }
 int main(int argc, char *argv[]) {

--- a/tests/test-middle-ram.cpp
+++ b/tests/test-middle-ram.cpp
@@ -20,8 +20,9 @@ void run_tests(const options_t options, const std::string cache_type) {
     mid_ram.start(&options);
 
     if (test_node_set(&mid_ram) != 0) { throw std::runtime_error("test_node_set failed with " + cache_type + " cache."); }
+    osmium::thread::Pool pool(1);
     mid_ram.commit();
-    mid_ram.stop();
+    mid_ram.stop(pool);
   }
   {
     middle_ram_t mid_ram;
@@ -30,8 +31,9 @@ void run_tests(const options_t options, const std::string cache_type) {
     mid_ram.start(&options);
 
     if (test_nodes_comprehensive_set(&mid_ram) != 0) { throw std::runtime_error("test_nodes_comprehensive_set failed with " + cache_type + " cache."); }
+    osmium::thread::Pool pool(1);
     mid_ram.commit();
-    mid_ram.stop();
+    mid_ram.stop(pool);
   }
   {
     middle_ram_t mid_ram;
@@ -40,8 +42,9 @@ void run_tests(const options_t options, const std::string cache_type) {
     mid_ram.start(&options);
 
     if (test_way_set(&mid_ram) != 0) { throw std::runtime_error("test_way_set failed with " + cache_type + " cache."); }
+    osmium::thread::Pool pool(1);
     mid_ram.commit();
-    mid_ram.stop();
+    mid_ram.stop(pool);
   }
 }
 


### PR DESCRIPTION
Use an Osmium worker pool instead of std::async and restrict the number of parallel instances to the number requested on the command line. Use the same pool for middle and output tables and make sure that the option --disable-parallel-indexing is also respected for middle tables.