### PR TITLE
Skip output for untagged objects

### DIFF
--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -41,9 +41,13 @@ int osmdata_t::node_add(osmium::Node const &node)
     mid->nodes_set(node);
 
     int status = 0;
-    for (auto &out : outs) {
-        status |= out->node_add(node);
+
+    if (!node.tags().empty()) {
+        for (auto &out : outs) {
+            status |= out->node_add(node);
+        }
     }
+
     return status;
 }
 
@@ -52,9 +56,13 @@ int osmdata_t::way_add(osmium::Way *way)
     mid->ways_set(*way);
 
     int status = 0;
-    for (auto& out: outs) {
-        status |= out->way_add(way);
+
+    if (!way->tags().empty()) {
+        for (auto& out: outs) {
+            status |= out->way_add(way);
+        }
     }
+
     return status;
 }
 
@@ -63,9 +71,12 @@ int osmdata_t::relation_add(osmium::Relation const &rel)
     mid->relations_set(rel);
 
     int status = 0;
-    for (auto& out: outs) {
-        status |= out->relation_add(rel);
+    if (!rel.tags().empty()) {
+        for (auto& out: outs) {
+            status |= out->relation_add(rel);
+        }
     }
+
     return status;
 }
 

--- a/tests/test-parse-xml2.cpp
+++ b/tests/test-parse-xml2.cpp
@@ -93,11 +93,11 @@ int main(int argc, char *argv[]) {
 
   parser.stream_file(inputfile, "");
 
-  assert_equal(out_test->sum_ids,       73514L);
-  assert_equal(out_test->num_nodes,       353L);
-  assert_equal(out_test->num_ways,        140L);
+  assert_equal(out_test->sum_ids,        4728L);
+  assert_equal(out_test->num_nodes,         0L);
+  assert_equal(out_test->num_ways,         48L);
   assert_equal(out_test->num_relations,    40L);
-  assert_equal(out_test->num_nds,         495L);
+  assert_equal(out_test->num_nds,         186L);
   assert_equal(out_test->num_members,     146L);
 
   return 0;

--- a/tests/test_output_multi_line_storage.osm
+++ b/tests/test_output_multi_line_storage.osm
@@ -19,15 +19,18 @@
  <node id="6" lat="49.03" lon="-123.00"/>
  <node id="8" lat="49.03" lon="-123.02"/>
  <way id="1">
+  <tag k="highway" v="service" />
   <nd ref="1"/>
   <nd ref="2"/>
   <nd ref="3"/>
  </way>
  <way id="2">
+  <tag k="highway" v="service" />
   <nd ref="4"/>
   <nd ref="5"/>
  </way>
  <way id="3">
+  <tag k="highway" v="service" />
   <nd ref="6"/>
   <nd ref="7"/>
   <nd ref="8"/>

--- a/tests/test_output_multi_poly_trivial.osm
+++ b/tests/test_output_multi_poly_trivial.osm
@@ -19,6 +19,7 @@ which contains both w1 and w2.
   <node id="7" lon="2" lat="1"/>
   <node id="8" lon="3" lat="1"/>
   <way id="1">
+    <tag k="building" v="yes" />
     <nd ref="1"/>
     <nd ref="2"/>
     <nd ref="6"/>
@@ -26,6 +27,7 @@ which contains both w1 and w2.
     <nd ref="1"/>
   </way>
   <way id="2">
+    <tag k="building" v="yes" />
     <nd ref="3"/>
     <nd ref="4"/>
     <nd ref="8"/>
@@ -33,6 +35,7 @@ which contains both w1 and w2.
     <nd ref="3"/>
   </way>
   <relation id="1">
+    <tag k="type" v="site" />
     <member type="way" ref="1" role=""/>
     <member type="way" ref="2" role=""/>
   </relation>


### PR DESCRIPTION
When adding objects call output backends only when there
are any tags. Only works for the initial import. When updating
data, all objects need to be forwarded in case they need to
be deleted. That also means that output backends still must
be able to handle untagged objects.

Fixes #706.