### PR TITLE
make default style configurable and change default for WIN32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,11 @@ project(osm2pgsql)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-set(DATA_DIR \"${CMAKE_INSTALL_PREFIX}/share/osm2pgsql\")
+if (WIN32)
+    set(DEFAULT_STYLE "default.style" CACHE STRING "Default style used unless one is given on the command line")
+else()
+    set(DEFAULT_STYLE "${CMAKE_INSTALL_PREFIX}/share/osm2pgsql/default.style" CACHE STRING "Default style used unless one is given on the command line")
+endif()
 
 option(BUILD_TESTS "Build test suite" OFF)
 option(WITH_LUA    "Build with lua support" ON)
@@ -60,7 +64,7 @@ include (CheckIncludeFiles)
 include (CheckFunctionExists)
 include (CheckTypeSize)
 
-add_definitions( -DOSM2PGSQL_DATADIR=${DATA_DIR} )
+add_definitions( -DDEFAULT_STYLE=\"${DEFAULT_STYLE}\" )
 add_definitions( -DFIXED_POINT )
 
 CHECK_INCLUDE_FILES (termios.h HAVE_TERMIOS_H)

--- a/options.cpp
+++ b/options.cpp
@@ -96,7 +96,7 @@ namespace
                         required if you want to update with --append later.\n\
        -S|--style       Location of the style file. Defaults to\n");
         printf("\
-                        %s/default.style.\n", OSM2PGSQL_DATADIR);
+                        %s.\n", DEFAULT_STYLE);
         printf("%s", "\
        -C|--cache       Use up to this many MB for caching nodes (default: 800)\n\
        -F|--flat-nodes  Specifies the flat file to use to persistently store node \n\
@@ -267,7 +267,7 @@ options_t::options_t()
   projection(reprojection::create_projection(PROJ_SPHERE_MERC)), append(false),
   slim(false), cache(800), tblsmain_index(boost::none),
   tblsslim_index(boost::none), tblsmain_data(boost::none),
-  tblsslim_data(boost::none), style(OSM2PGSQL_DATADIR "/default.style"),
+  tblsslim_data(boost::none), style(DEFAULT_STYLE),
   expire_tiles_zoom(0), expire_tiles_zoom_min(0),
   expire_tiles_max_bbox(20000.0), expire_tiles_filename("dirty_tiles"),
   hstore_mode(HSTORE_NONE), enable_hstore_index(false), enable_multi(false),


### PR DESCRIPTION
On Windows the default is now to look for the style in
the working directory. This can be changed via a cmake
variable if somebody wants to provide a version that
is installed into the system directories.