### PR TITLE
Appveyor artifacts fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,8 @@ environment:
     PGUSER: postgres
     PGPASSWORD: Password12!
   matrix:
-    - platform: x86
-    - platform: x64
+    - arch: x86
+    - arch: x64
 
 os: Visual Studio 2015
 
@@ -33,13 +33,13 @@ clone_depth: 1
 
 init:
   - git config --global core.autocrlf input
-  - if "%platform%"=="x86" (
+  - if "%arch%"=="x86" (
       set vcvarsall_arg=x86&&
       set conda_path=C:\Miniconda36\Scripts&&
       set conda_library_path=C:\Miniconda36\envs\osm2pgsql\Library&&
       set lua_url=https://lonvia.dev.openstreetmap.org/osm2pgsql-winbuild/lua_x86.zip&&
       set build_type=Release)
-  - if "%platform%"=="x64" (
+  - if "%arch%"=="x64" (
       set vcvarsall_arg=amd64&&
       set conda_path=C:\Miniconda36-x64\Scripts&&
       set conda_library_path=C:\Miniconda36-x64\envs\osm2pgsql\Library&&
@@ -54,8 +54,8 @@ install:
   - conda create --name osm2pgsql
   - activate osm2pgsql
   - conda install bzip2=%BZIP2_VER% expat=%EXPAT_VER% proj4=%PROJ4_VER% zlib=%ZLIB_VER% postgresql=%POSTGRESQL_VER%
-  - ps: if (!(Test-Path "C:\lua_$env:platform.zip")){(new-object net.webclient).DownloadFile($env:lua_url, "C:\lua_$env:platform.zip")}
-  - 7z x -y C:\lua_%platform%.zip -oC:\lua
+  - ps: if (!(Test-Path "C:\lua_$env:arch.zip")){(new-object net.webclient).DownloadFile($env:lua_url, "C:\lua_$env:arch.zip")}
+  - 7z x -y C:\lua_%arch%.zip -oC:\lua
   - ps: if (!(Test-Path "C:\postgis.zip")){(new-object net.webclient).DownloadFile($env:POSTGIS_URL, "C:\postgis.zip")}
   - 7z x C:\postgis.zip -oC:\postgis
   - xcopy /e /y /q C:\postgis\postgis-bundle-pg96-2.4.3x64 %TESTS_POSTGRESQL_ROOT%
@@ -92,7 +92,7 @@ after_build:
   - copy /y %conda_library_path%\bin\expat.dll osm2pgsql-bin
   - copy /y %conda_library_path%\bin\libbz2.dll osm2pgsql-bin
   - copy /y %LUA_DLL% osm2pgsql-bin
-  - 7z a c:\osm2pgsql\osm2pgsql_%build_type%_%platform%.zip osm2pgsql-bin -tzip
+  - 7z a c:\osm2pgsql\osm2pgsql_%build_type%_%arch%.zip osm2pgsql-bin -tzip
 
 before_test:
   - cd c:\
@@ -110,8 +110,8 @@ test_script:
   - ctest -VV -LE FlatNodes # enable when Postgis will be available
 
 artifacts:
-  - path: osm2pgsql_%build_type%_%platform%.zip
+  - path: osm2pgsql_%build_type%_%arch%.zip
 
 cache:
-  - C:\lua_%platform%.zip -> appveyor.yml
+  - C:\lua_%arch%.zip -> appveyor.yml
   - C:\postgis.zip -> appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,17 +20,7 @@ environment:
     PGPASSWORD: Password12!
   matrix:
     - platform: x86
-      vcvarsall_arg: x86
-      conda_path: C:\Miniconda36\Scripts
-      conda_library_path: C:\Miniconda36\envs\osm2pgsql\Library
-      lua_url: "https://lonvia.dev.openstreetmap.org/osm2pgsql-winbuild/lua_x86.zip"
-      build_type: Release
     - platform: x64
-      vcvarsall_arg: amd64
-      conda_path: C:\Miniconda36-x64\Scripts
-      conda_library_path: C:\Miniconda36-x64\envs\osm2pgsql\Library
-      lua_url: "https://lonvia.dev.openstreetmap.org/osm2pgsql-winbuild/lua_x64.zip"
-      build_type: Release
 
 os: Visual Studio 2015
 
@@ -43,11 +33,23 @@ clone_depth: 1
 
 init:
   - git config --global core.autocrlf input
+  - if "%platform%"=="x86" (
+      set vcvarsall_arg=x86&&
+      set conda_path=C:\Miniconda36\Scripts&&
+      set conda_library_path=C:\Miniconda36\envs\osm2pgsql\Library&&
+      set lua_url=https://lonvia.dev.openstreetmap.org/osm2pgsql-winbuild/lua_x86.zip&&
+      set build_type=Release)
+  - if "%platform%"=="x64" (
+      set vcvarsall_arg=amd64&&
+      set conda_path=C:\Miniconda36-x64\Scripts&&
+      set conda_library_path=C:\Miniconda36-x64\envs\osm2pgsql\Library&&
+      set lua_url=https://lonvia.dev.openstreetmap.org/osm2pgsql-winbuild/lua_x64.zip&&
+      set build_type=Release)
   - '"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall" %vcvarsall_arg%'
 
 install:
-  - cd c:\
   - set PATH=%TESTS_POSTGRESQL_ROOt%\bin;%PATH%;%conda_path%
+  - cd c:\
   - conda config --set always_yes yes
   - conda create --name osm2pgsql
   - activate osm2pgsql

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
     BOOST_PATH: C:\Libraries\boost_1_63_0
     POSTGRESQL_VER: 9.6.6
     TESTS_POSTGRESQL_ROOT: C:\Progra~1\PostgreSQL\9.6
-    POSTGIS_VER: 2.4.2
+    POSTGIS_VER: 2.4.3
     POSTGIS_URL: "https://lonvia.dev.openstreetmap.org/osm2pgsql-winbuild/postgis-bundle-pg96-2.4.3x64.zip"
     PGUSER: postgres
     PGPASSWORD: Password12!


### PR DESCRIPTION
Fix the issue that mentioned https://github.com/openstreetmap/osm2pgsql/pull/820#issuecomment-368642226

Now the artifacts can be accessed using below URLs:
- x86: [https://ci.appveyor.com/api/projects/openstreetmap/osm2pgsql/artifacts/osm2pgsql_Release_x86.zip?job=Environment%3A%20arch%3Dx86](https://ci.appveyor.com/api/projects/openstreetmap/osm2pgsql/artifacts/osm2pgsql_Release_x86.zip?job=Environment%3A%20arch%3Dx86)
- x64: [https://ci.appveyor.com/api/projects/openstreetmap/osm2pgsql/artifacts/osm2pgsql_Release_x64.zip?job=Environment%3A%20arch%3Dx64](https://ci.appveyor.com/api/projects/openstreetmap/osm2pgsql/artifacts/osm2pgsql_Release_x64.zip?job=Environment%3A%20arch%3Dx64)

Also the "platform" environment variable renamed to "arch" because the collision with VisualStduio's vcvarsall script for x64 platform. By calling vcvarsall script the "platform" environment variable will be changed to "X64" instead of "x64". Because of the issue, the build artifact for x64 was named "osm2pgsql_Release_X64.zip" instead of "osm2pgsql_Release_x64.zip". So changed "platform" to "arch" environment variable. 