### PR TITLE
Return error when Lua tag transform cannot be read

### DIFF
--- a/tagtransform-lua.cpp
+++ b/tagtransform-lua.cpp
@@ -21,8 +21,7 @@ lua_tagtransform_t::lua_tagtransform_t(options_t const *options)
     luaL_openlibs(L);
     if (luaL_dofile(L, options->tag_transform_script->c_str())) {
         throw std::runtime_error(
-            (boost::format(
-                 "Lua tag transform style error: %1%") %
+            (boost::format("Lua tag transform style error: %1%") %
              lua_tostring(L, -1))
                 .str());
     }

--- a/tagtransform-lua.cpp
+++ b/tagtransform-lua.cpp
@@ -19,7 +19,13 @@ lua_tagtransform_t::lua_tagtransform_t(options_t const *options)
   m_extra_attributes(options->extra_attributes)
 {
     luaL_openlibs(L);
-    luaL_dofile(L, options->tag_transform_script->c_str());
+    if (luaL_dofile(L, options->tag_transform_script->c_str())) {
+        throw std::runtime_error(
+            (boost::format(
+                 "Lua tag transform style error: %1%") %
+             lua_tostring(L, -1))
+                .str());
+    }
 
     check_lua_function_exists(m_node_func);
     check_lua_function_exists(m_way_func);

--- a/tests/test-options-parse.cpp
+++ b/tests/test-options-parse.cpp
@@ -135,18 +135,22 @@ void test_outputs()
 void test_lua_styles()
 {
 #ifdef HAVE_LUA  
-    const char* a1[] = {"osm2pgsql", "--tag-transform-script", "non_existing.lua", "tests/liechtenstein-2013-08-03.osm.pbf"};
+    const char *a1[] = {"osm2pgsql", "--tag-transform-script",
+                        "non_existing.lua",
+                        "tests/liechtenstein-2013-08-03.osm.pbf"};
     options_t options = options_t(len(a1), const_cast<char **>(a1));
-  
-    try
-    {
-        std::unique_ptr<tagtransform_t> tagtransform = tagtransform_t::make_tagtransform(&options);
+
+    try {
+        std::unique_ptr<tagtransform_t> tagtransform =
+            tagtransform_t::make_tagtransform(&options);
         throw std::logic_error("Expected 'No such file or directory'");
-    }
-    catch(const std::runtime_error& e)
-    {
-        if(!alg::icontains(e.what(), "No such file or directory"))
-            throw std::logic_error((boost::format("Expected 'No such file or directory' but instead got '%1%'") % e.what()).str());
+    } catch (const std::runtime_error &e) {
+        if (!alg::icontains(e.what(), "No such file or directory"))
+            throw std::logic_error(
+                (boost::format("Expected 'No such file or directory' but "
+                               "instead got '%1%'") %
+                 e.what())
+                    .str());
     }
 #endif
 }

--- a/tests/test-options-parse.cpp
+++ b/tests/test-options-parse.cpp
@@ -132,6 +132,25 @@ void test_outputs()
     }
 }
 
+void test_lua_styles()
+{
+#ifdef HAVE_LUA  
+    const char* a1[] = {"osm2pgsql", "--tag-transform-script", "non_existing.lua", "tests/liechtenstein-2013-08-03.osm.pbf"};
+    options_t options = options_t(len(a1), const_cast<char **>(a1));
+  
+    try
+    {
+        std::unique_ptr<tagtransform_t> tagtransform = tagtransform_t::make_tagtransform(&options);
+        throw std::logic_error("Expected 'No such file or directory'");
+    }
+    catch(const std::runtime_error& e)
+    {
+        if(!alg::icontains(e.what(), "No such file or directory"))
+            throw std::logic_error((boost::format("Expected 'No such file or directory' but instead got '%1%'") % e.what()).str());
+    }
+#endif
+}
+
 void test_parsing_tile_expiry_zoom_levels()
 {
     const char *a1[] = {
@@ -430,6 +449,7 @@ int main(int argc, char *argv[])
     run_test("test_incompatible_args", test_incompatible_args);
     run_test("test_middles", test_middles);
     run_test("test_outputs", test_outputs);
+    run_test("test_lua_styles", test_lua_styles);
     run_test("test_random_perms", test_random_perms);
     run_test("test_parsing_tile_expiry_zoom_levels_fails",
              test_parsing_tile_expiry_zoom_levels_fails);


### PR DESCRIPTION
Fixes #841

Returns new error message:

```
osm2pgsql version 0.95.0-dev (64 bit id space)

Using lua based tag processing pipeline with script openstreetmap-carto2.lua
Lua tag transform style error: cannot open openstreetmap-carto2.lua: No such file or directory
Error: Failed to initialise tag processing.
Error occurred, cleaning up
```
