### PR TITLE
Command line option "-V" to include library versions

### DIFF
--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -1,5 +1,6 @@
 #cmakedefine HAVE_LSEEK64 1
 #cmakedefine HAVE_LUA 1
+#cmakedefine HAVE_LUAJIT 1
 #cmakedefine HAVE_POSIX_FADVISE 1
 #cmakedefine HAVE_POSIX_FALLOCATE 1
 #cmakedefine HAVE_SYNC_FILE_RANGE 1

--- a/options.cpp
+++ b/options.cpp
@@ -13,6 +13,20 @@
 #include <sstream>
 #include <thread> // for number of threads
 #include <boost/format.hpp>
+#include <osmium/version.hpp>
+
+#ifdef HAVE_LUA
+extern "C" {
+#include <lua.h>
+}
+#endif
+
+#ifdef HAVE_LUAJIT
+extern "C" {
+#include <luajit.h>
+}
+#endif
+
 
 namespace
 {
@@ -494,6 +508,17 @@ options_t::options_t(int argc, char *argv[]): options_t()
             reproject_area = true;
             break;
         case 'V':
+            fprintf(stderr, "Compiled using the following library versions:\n");
+            fprintf(stderr, "Libosmium %s\n", LIBOSMIUM_VERSION_STRING);
+#ifdef HAVE_LUA
+            fprintf(stderr, "%s", LUA_RELEASE);
+#ifdef HAVE_LUAJIT
+            fprintf(stderr, " (%s)", LUAJIT_VERSION);
+#endif
+#else
+            fprintf(stderr, "Lua support not included");
+#endif
+            fprintf(stderr, "\n");
             exit (EXIT_SUCCESS);
             break;
         case '?':


### PR DESCRIPTION
Now that we have a number of compile time options, `osm2pgsql -V` should print some more details about used libraries to facilitate future issue analysis.



### Option 1 - default

```
osm2pgsql version 0.96.0-RC1 (64 bit id space)

Compiled using the following library versions:
Libosmium 2.14.0
Lua 5.2.4
```

### Option 2 - LuaJIT

```
osm2pgsql version 0.96.0-RC1 (64 bit id space)

Compiled using the following library versions:
Libosmium 2.14.0
Lua 5.1.4 (LuaJIT 2.0.4)
```

### Option 3 - no Lua at all

```
osm2pgsql version 0.96.0-RC1 (64 bit id space)

Compiled using the following library versions:
Libosmium 2.14.0
Lua support not included
```