### PR TITLE
add DB travis test with tablespaces, clang, gcc versions ( #699 )

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,52 +1,276 @@
-language: cpp
-sudo: false
-addons:
-  apt:
-    sources:
-    - boost-latest
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-4.8
-    - libexpat1-dev
-    - libpq-dev
-    - libbz2-dev
-    - libproj-dev
-    - lua5.2
-    - liblua5.2-dev
-    - libluajit-5.1-dev
-    - libboost1.55-dev
-    - libboost-system1.55-dev
-    - libboost-filesystem1.55-dev
+language: generic
+sudo: required
+git:
+  depth: 1
+services:
+  - postgresql
+
+addons_shortcuts:
+  addons_clang38_pg92: &clang38_pg92
+    postgresql: '9.2'
+    apt:
+      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.8']
+      packages: ['clang-3.8', 'postgresql-9.2-postgis-2.3',
+                      'python-psycopg2', 'libexpat1-dev', 'libpq-dev', 'libbz2-dev', 'libproj-dev',
+                      'lua5.2', 'liblua5.2-dev', 'libluajit-5.1-dev',
+                      'libboost1.55-dev', 'libboost-system1.55-dev', 'libboost-filesystem1.55-dev']
+  addons_clang40_pg93: &clang40_pg93
+    postgresql: '9.3'
+    apt:
+      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
+      packages: ['clang-4.0', 'postgresql-9.3-postgis-2.3',
+                      'python-psycopg2', 'libexpat1-dev', 'libpq-dev', 'libbz2-dev', 'libproj-dev',
+                      'lua5.2', 'liblua5.2-dev', 'libluajit-5.1-dev',
+                      'libboost1.55-dev', 'libboost-system1.55-dev', 'libboost-filesystem1.55-dev']
+  addons_clang50_pg94: &clang50_pg94
+    postgresql: '9.4'
+    apt:
+      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-5.0']
+      packages: ['clang-5.0', 'postgresql-9.4-postgis-2.3',
+                      'python-psycopg2', 'libexpat1-dev', 'libpq-dev', 'libbz2-dev', 'libproj-dev',
+                      'lua5.2', 'liblua5.2-dev', 'libluajit-5.1-dev',
+                      'libboost1.55-dev', 'libboost-system1.55-dev', 'libboost-filesystem1.55-dev']
+  addons_clang60_pg96: &clang60_pg96
+    postgresql: '9.6'
+    apt:
+      update: true
+      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0']
+      packages: ['clang-6.0','postgresql-9.6-postgis-2.3',
+                      'python-psycopg2', 'libexpat1-dev', 'libpq-dev', 'libbz2-dev', 'libproj-dev',
+                      'lua5.2', 'liblua5.2-dev', 'libluajit-5.1-dev',
+                      'libboost1.55-dev', 'libboost-system1.55-dev', 'libboost-filesystem1.55-dev']
+  addons_gcc48_pg96: &gcc48_pg96
+    postgresql: '9.6'
+    apt:
+      sources: ["ubuntu-toolchain-r-test"]
+      packages: ['g++-4.8','postgresql-9.6-postgis-2.3',
+                      'python-psycopg2', 'libexpat1-dev', 'libpq-dev', 'libbz2-dev', 'libproj-dev',
+                      'lua5.2', 'liblua5.2-dev', 'libluajit-5.1-dev',
+                      'libboost1.55-dev', 'libboost-system1.55-dev', 'libboost-filesystem1.55-dev']
+  addons_gcc49_pg96: &gcc49_pg96
+    postgresql: '9.6'
+    apt:
+      sources: ["ubuntu-toolchain-r-test"]
+      packages: ['g++-4.9','postgresql-9.6-postgis-2.3',
+                      'python-psycopg2', 'libexpat1-dev', 'libpq-dev', 'libbz2-dev', 'libproj-dev',
+                      'lua5.2', 'liblua5.2-dev', 'libluajit-5.1-dev',
+                      'libboost1.55-dev', 'libboost-system1.55-dev', 'libboost-filesystem1.55-dev']
+  addons_gcc6_pg96: &gcc6_pg96
+    postgresql: '9.6'
+    apt:
+      sources: ["ubuntu-toolchain-r-test"]
+      packages: ['g++-6','postgresql-9.6-postgis-2.3',
+                      'python-psycopg2', 'libexpat1-dev', 'libpq-dev', 'libbz2-dev', 'libproj-dev',
+                      'lua5.2', 'liblua5.2-dev', 'libluajit-5.1-dev',
+                      'libboost1.55-dev', 'libboost-system1.55-dev', 'libboost-filesystem1.55-dev']
+  addons_gcc7_pg96: &gcc7_pg96
+    postgresql: '9.6'
+    apt:
+      sources: ["ubuntu-toolchain-r-test"]
+      packages: ['g++-7','postgresql-9.6-postgis-2.3',
+                      'python-psycopg2', 'libexpat1-dev', 'libpq-dev', 'libbz2-dev', 'libproj-dev',
+                      'lua5.2', 'liblua5.2-dev', 'libluajit-5.1-dev',
+                      'libboost1.55-dev', 'libboost-system1.55-dev', 'libboost-filesystem1.55-dev']
+  addons_gcc8_pg96: &gcc8_pg96
+    postgresql: '9.6'
+    apt:
+      sources: ["ubuntu-toolchain-r-test"]
+      packages: ['g++-8','postgresql-9.6-postgis-2.3',
+                      'python-psycopg2', 'libexpat1-dev', 'libpq-dev', 'libbz2-dev', 'libproj-dev',
+                      'lua5.2', 'liblua5.2-dev', 'libluajit-5.1-dev',
+                      'libboost1.55-dev', 'libboost-system1.55-dev', 'libboost-filesystem1.55-dev']
+
+
+
+# env: T="...."     //  unique test id, test name
 matrix:
   include:
+  # ---- Linux + CLANG ---------------------------
     - os: linux
-      compiler: clang
-      env: CXXFLAGS="-pedantic -Werror" LUAJIT_OPTION="OFF"
+      compiler: "clang-3.8"
+      env: T="clang38_pg92_dbtest" RUNTEST="#Dbtest" LUAJIT_OPTION="OFF"
+           CXXFLAGS="-pedantic -Werror"
+           CC=clang-3.8 CXX=clang++-3.8
+      addons: *clang38_pg92
+
     - os: linux
-      compiler: gcc
-      env: RUNTEST="-L NoDB" CXXFLAGS="-pedantic -Werror -fsanitize=address" LUAJIT_OPTION="OFF"
+      compiler: "clang-4.0"
+      env: T="clang40_pg93_dbtest" RUNTEST="#Dbtest" LUAJIT_OPTION="OFF"
+           CXXFLAGS="-pedantic -Werror"
+           CC=clang-4.0 CXX=clang++-4.0
+      addons: *clang40_pg93
+
     - os: linux
-      compiler: clang
-      env: CXXFLAGS="-pedantic -Werror" LUAJIT_OPTION="ON"
+      compiler: "clang-5.0"
+      env: T="clang50_pg94_dbtest" RUNTEST="#Dbtest" LUAJIT_OPTION="OFF"
+           CXXFLAGS="-pedantic -Werror"
+           CC=clang-5.0 CXX=clang++-5.0
+      addons: *clang50_pg94
+
     - os: linux
-      compiler: gcc
-      env: RUNTEST="-L NoDB" CXXFLAGS="-pedantic -Werror -fsanitize=address" LUAJIT_OPTION="ON"
+      compiler: "clang-5.0"
+      env: T="clang50_pg94_dbtest_luajit" RUNTEST="#Dbtest" LUAJIT_OPTION="ON"
+           CXXFLAGS="-pedantic -Werror"
+           CC=clang-5.0 CXX=clang++-5.0
+      addons: *clang50_pg94
+
+    - os: linux
+      compiler: "clang-6.0"
+      env: T="clang60_pg96_dbtest" RUNTEST="#Dbtest" LUAJIT_OPTION="OFF"
+           CXXFLAGS="-pedantic -Werror"
+           CC=clang-6.0 CXX=clang++-6.0
+      addons: *clang60_pg96
+
+    - os: linux
+      compiler: "clang-6.0"
+      env: T="clang60_pg96_asan_dbtest" RUNTEST="#Dbtest" LUAJIT_OPTION="OFF"
+           CXXFLAGS="-pedantic -Werror -fsanitize=address"
+           CC=clang-6.0 CXX=clang++-6.0
+           ASAN_OPTIONS="verbosity=1:log_threads=1"
+           LSAN_OPTIONS="verbosity=1:log_threads=1"
+      addons: *clang60_pg96
+
+    - os: linux
+      compiler: "clang-6.0"
+      env: T="clang60_pg96_asan_dbtest_luajit" RUNTEST="#Dbtest" LUAJIT_OPTION="ON"
+           CXXFLAGS="-pedantic -Werror -fsanitize=address"
+           CC=clang-6.0 CXX=clang++-6.0
+           ASAN_OPTIONS="verbosity=1:log_threads=1"
+           LSAN_OPTIONS="verbosity=1:log_threads=1"
+      addons: *clang60_pg96
+
+  # ---- OSX + CLANG ---------------------------
+
     - os: osx
       compiler: clang
-      env: RUNTEST="-L NoDB" CXXFLAGS="-pedantic -Werror -fsanitize=address" LUAJIT_OPTION="OFF"
+      env: T="osx_clang_NoDB" RUNTEST="-L NoDB" LUAJIT_OPTION="OFF"
+           CXXFLAGS="-pedantic -Werror"
+      before_install:
+        - brew install lua;
+      before_script:
+        - xml2-config --version
+        - proj | head -n1
+        - lua -v
+
+
+  # ---- Linux + GCC ---------------------------
+    - os: linux
+      compiler: "gcc-4.8"
+      env: T="gcc48_pg96_asan_NoDB" RUNTEST="-L NoDB" LUAJIT_OPTION="OFF"
+           CXXFLAGS="-pedantic -Werror -fsanitize=address"
+           CC=gcc-4.8 CXX=g++-4.8
+      addons: *gcc48_pg96
+
+    - os: linux
+      compiler: "gcc-4.9"
+      env: T="gcc49_pg96_asan_dbtest" RUNTEST="#Dbtest" LUAJIT_OPTION="OFF"
+           CXXFLAGS="-pedantic -Werror -fsanitize=address"
+           CC=gcc-4.9 CXX=g++-4.9
+      addons: *gcc49_pg96
+
+    - os: linux
+      compiler: "gcc-4.9"
+      env: T="gcc49_pg96_asan_dbtest_luajit" RUNTEST="#Dbtest" LUAJIT_OPTION="ON"
+           CXXFLAGS="-pedantic -Werror -fsanitize=address"
+           CC=gcc-4.9 CXX=g++-4.9
+      addons: *gcc49_pg96
+
+    - os: linux
+      compiler: gcc-6
+      env: T="gcc6_pg96_dbtest_luajit" RUNTEST="#Dbtest" LUAJIT_OPTION="ON"
+           CXXFLAGS="-pedantic -Werror"
+           CC=gcc-6 CXX=g++-6
+      addons: *gcc6_pg96
+
+    - os: linux
+      compiler: gcc-7
+      env: T="gcc7_pg96_dbtest_luajit" RUNTEST="#Dbtest" LUAJIT_OPTION="ON"
+           CXXFLAGS="-pedantic -Werror"
+           CC=gcc-7 CXX=g++-7
+      addons: *gcc7_pg96
+      ## NOW: not working:  gcc-7 + fsanitize=address
+
+    - os: linux
+      compiler: gcc-8
+      env: T="gcc8_pg96_dbtest_luajit" RUNTEST="#Dbtest" LUAJIT_OPTION="ON"
+           CXXFLAGS="-pedantic -Werror"
+           CC=gcc-8 CXX=g++-8
+      addons: *gcc8_pg96
+
+    - os: linux
+      compiler: gcc-8
+      env: T="gcc8_pg96_dbtest_noCCXFLAGS" RUNTEST="#Dbtest" LUAJIT_OPTION="OFF"
+           CC=gcc-8 CXX=g++-8
+      addons: *gcc8_pg96
+
+    - os: linux
+      compiler: gcc-8
+      env: T="gcc8_pg96_dbtest_luajit_noCCXFLAGS" RUNTEST="#Dbtest" LUAJIT_OPTION="ON"
+           CC=gcc-8 CXX=g++-8
+      addons: *gcc8_pg96
+
+
+
+  allow_failures:
+# some problems..  need debugging... [gcc8, luajit, asan test cases]
+    - os: linux
+      env: T="clang50_pg94_dbtest_luajit" RUNTEST="#Dbtest" LUAJIT_OPTION="ON"
+           CXXFLAGS="-pedantic -Werror"
+           CC=clang-5.0 CXX=clang++-5.0
+
+    - os: linux
+      env: T="clang60_pg96_asan_dbtest" RUNTEST="#Dbtest" LUAJIT_OPTION="OFF"
+           CXXFLAGS="-pedantic -Werror -fsanitize=address"
+           CC=clang-6.0 CXX=clang++-6.0
+           ASAN_OPTIONS="verbosity=1:log_threads=1"
+           LSAN_OPTIONS="verbosity=1:log_threads=1"
+
+    - os: linux
+      env: T="clang60_pg96_asan_dbtest_luajit" RUNTEST="#Dbtest" LUAJIT_OPTION="ON"
+           CXXFLAGS="-pedantic -Werror -fsanitize=address"
+           CC=clang-6.0 CXX=clang++-6.0
+           ASAN_OPTIONS="verbosity=1:log_threads=1"
+           LSAN_OPTIONS="verbosity=1:log_threads=1"
+
+    - os: linux
+      env: T="gcc49_pg96_asan_dbtest" RUNTEST="#Dbtest" LUAJIT_OPTION="OFF"
+           CXXFLAGS="-pedantic -Werror -fsanitize=address"
+           CC=gcc-4.9 CXX=g++-4.9
+
+    - os: linux
+      env: T="gcc49_pg96_asan_dbtest_luajit" RUNTEST="#Dbtest" LUAJIT_OPTION="ON"
+           CXXFLAGS="-pedantic -Werror -fsanitize=address"
+           CC=gcc-4.9 CXX=g++-4.9
+
+    - os: linux
+      env: T="gcc6_pg96_dbtest_luajit" RUNTEST="#Dbtest" LUAJIT_OPTION="ON"
+           CXXFLAGS="-pedantic -Werror"
+           CC=gcc-6 CXX=g++-6
+
+    - os: linux
+      env: T="gcc7_pg96_dbtest_luajit" RUNTEST="#Dbtest" LUAJIT_OPTION="ON"
+           CXXFLAGS="-pedantic -Werror"
+           CC=gcc-7 CXX=g++-7
+
+    - os: linux
+      env: T="gcc8_pg96_dbtest_luajit" RUNTEST="#Dbtest" LUAJIT_OPTION="ON"
+           CXXFLAGS="-pedantic -Werror"
+           CC=gcc-8 CXX=g++-8
+
+    - os: linux
+      env: T="gcc8_pg96_dbtest_luajit_noCCXFLAGS" RUNTEST="#Dbtest" LUAJIT_OPTION="ON"
+           CC=gcc-8 CXX=g++-8
+
 before_install:
-  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-      brew install lua;
-    fi
-# update versions
-install:
-  - if [[ $CC == 'gcc' ]]; then
-      export CC=gcc-4.8;
-    fi
-  - if [[ $CXX == 'g++' ]]; then
-      export CXX=g++-4.8;
-    fi
+  - sudo mkdir -p /extra/pg/tablespacetest   # for the database test
+  - sudo chown postgres:postgres /extra/pg/tablespacetest
+  - dpkg -l | grep -E 'lua|proj|xml|bz2|postgis|zlib|boost|expat'  # checking available versions
 before_script:
+  - psql -U postgres -c "SELECT version()"
+  - psql -U postgres -c "CREATE TABLESPACE tablespacetest LOCATION '/extra/pg/tablespacetest'"
+  - psql -U postgres -c "CREATE EXTENSION postgis"
+  - psql -U postgres -c "CREATE EXTENSION hstore"
+  - psql -U postgres -c "SELECT PostGIS_Full_Version()"
   - $CXX --version
   - xml2-config --version
   - proj | head -n1
@@ -55,8 +279,10 @@ script:
   - mkdir build && cd build
   - cmake .. -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DWITH_LUAJIT=$LUAJIT_OPTION
   - make -j2
-  - echo "Running tests that does not require PostgreSQL server"
+  - echo "Running tests ... "
   - if [[ $RUNTEST ]]; then ctest -VV $RUNTEST; fi
 after_failure:
   - # rerun make, but verbosely
     make VERBOSE=1
+
+# end of .travis


### PR DESCRIPTION
First proposal for better .Travis testing.

Now with this patch - all 27 test is running
```
....
100% tests passed, 0 tests failed out of 27
Label Time Summary:
FlatNodes    =  20.97 sec (2 tests)
NoDB         =  14.57 sec (8 tests)
Total Test time (real) = 170.34 sec
...
```

I have added some examples for
- clang3.8, clang4.0, clang5.0, clang6.0  -  with different Postgres version (pg9.2, pg9.3, pg9.4, pg9.6)
- gcc4.8, gcc4.9, gcc6, gcc7, gcc8   - with pg9.6

Current travis testcases  :
```
clang38_pg92_dbtest
clang40_pg93_dbtest
clang50_pg94_dbtest_luajit
clang50_pg94_dbtest
clang60_pg96_asan_dbtest_luajit
clang60_pg96_asan_dbtest
clang60_pg96_dbtest
gcc48_pg96_asan_NoDB
gcc49_pg96_asan_dbtest_luajit
gcc49_pg96_asan_dbtest
gcc6_pg96_dbtest_luajit
gcc7_pg96_dbtest_luajit
gcc8_pg96_dbtest_luajit_noCCXFLAGS
gcc8_pg96_dbtest_luajit
gcc8_pg96_dbtest_noCCXFLAGS
osx_clang_NoDB
```
// `asan` = -fsanitize=address"
// `dbtest` = `cmake -VV`     : **27 testcases**
// `NoDB` = `cmake -VV -L NoDB`   :  **8 testcases**

Testcases with error - added to the "allow_failures" category - so ready to merge this code.

Some issues  (  I can't resolve this problems )
- gcc8 warning: (related #850)  [ see `gcc8_pg96_dbtest_luajit` ]
- luajit: [ see `*_luajit*` testcases ]   `93% tests passed, 2 tests failed out of 27`
- leaks: (related #731)   [  see `*asan_dbtest*` testcases ]  
