### PR TITLE
remove unused middle::end()

### DIFF
--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -819,20 +819,6 @@ void middle_pgsql_t::analyze(void)
     }
 }
 
-void middle_pgsql_t::end(void)
-{
-    for (auto& table: tables) {
-        PGconn *sql_conn = table.sql_conn;
-
-        // Commit transaction */
-        if (table.stop && table.transactionMode) {
-            pgsql_exec(sql_conn, PGRES_COMMAND_OK, "%s", table.stop);
-            table.transactionMode = 0;
-        }
-
-    }
-}
-
 /**
  * Helper to create SQL queries.
  *

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -23,7 +23,6 @@ struct middle_pgsql_t : public slim_middle_t {
     void start(const options_t *out_options_) override;
     void stop(osmium::thread::Pool &pool) override;
     void analyze(void) override;
-    void end(void) override;
     void commit(void) override;
 
     void nodes_set(osmium::Node const &node) override;

--- a/middle-ram.cpp
+++ b/middle-ram.cpp
@@ -155,11 +155,6 @@ void middle_ram_t::analyze(void)
     /* No need */
 }
 
-void middle_ram_t::end(void)
-{
-    /* No need */
-}
-
 void middle_ram_t::start(const options_t *out_options_)
 {
     out_options = out_options_;

--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -87,7 +87,6 @@ struct middle_ram_t : public middle_t {
     void start(const options_t *out_options_) override;
     void stop(osmium::thread::Pool &pool) override;
     void analyze(void) override;
-    void end(void) override;
     void commit(void) override;
 
     void nodes_set(osmium::Node const &node) override;

--- a/middle.hpp
+++ b/middle.hpp
@@ -86,7 +86,6 @@ struct middle_t : public middle_query_t {
     virtual void start(const options_t *out_options_) = 0;
     virtual void stop(osmium::thread::Pool &pool) = 0;
     virtual void analyze(void) = 0;
-    virtual void end(void) = 0;
     virtual void commit(void) = 0;
 
     virtual void nodes_set(osmium::Node const &node) = 0;

--- a/tests/mockups.hpp
+++ b/tests/mockups.hpp
@@ -11,7 +11,6 @@ struct dummy_middle_t : public middle_t {
     void stop(osmium::thread::Pool &) override {}
     void cleanup(void) { }
     void analyze(void) override  { }
-    void end(void) override  { }
     void commit(void) override  { }
 
     void nodes_set(osmium::Node const &) override {}
@@ -49,7 +48,6 @@ struct dummy_slim_middle_t : public slim_middle_t {
     void stop(osmium::thread::Pool &) override {}
     void cleanup(void) { }
     void analyze(void) override  { }
-    void end(void) override  { }
     void commit(void) override  { }
 
     void nodes_set(osmium::Node const &) override {}


### PR DESCRIPTION
commit() does exactly the same and is the one used.