### PR TITLE
middle-pgsql: Flush between type changes

### DIFF
--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -258,7 +258,7 @@ void middle_pgsql_t::local_nodes_set(osmium::Node const &node)
 {
     copy_buffer.reserve(node.tags().byte_size() + 100);
 
-    bool copy = node_table->copyMode;
+    bool copy = tables[NODE_TABLE].copyMode;
     char delim = copy ? '\t' : '\0';
     const char *paramValues[4] = {
         copy_buffer.c_str(),
@@ -276,10 +276,10 @@ void middle_pgsql_t::local_nodes_set(osmium::Node const &node)
 
     if (copy) {
         copy_buffer += '\n';
-        pgsql_CopyData(__FUNCTION__, node_table->sql_conn, copy_buffer);
+        pgsql_CopyData(__FUNCTION__, tables[NODE_TABLE].sql_conn, copy_buffer);
     } else {
         buffer_correct_params(paramValues, 4);
-        pgsql_execPrepared(node_table->sql_conn, "insert_node", 3,
+        pgsql_execPrepared(tables[NODE_TABLE].sql_conn, "insert_node", 3,
                            (const char *const *)paramValues, PGRES_COMMAND_OK);
     }
 }
@@ -312,9 +312,9 @@ size_t middle_pgsql_t::local_nodes_get_list(osmium::WayNodeList *nodes) const
     buffer[buffer.size() - 1] = '}';
 
     // Nodes must have been written back at this point.
-    assert(node_table->copyMode == 0);
+    assert(tables[NODE_TABLE].copyMode == 0);
 
-    PGconn *sql_conn = node_table->sql_conn;
+    PGconn *sql_conn = tables[NODE_TABLE].sql_conn;
 
     char const *paramValues[1];
     paramValues[0] = buffer.c_str();
@@ -366,11 +366,12 @@ void middle_pgsql_t::local_nodes_delete(osmid_t osm_id)
     char const *paramValues[1];
     char buffer[64];
     // Make sure we're out of copy mode */
-    pgsql_endCopy( node_table );
+    pgsql_endCopy(&tables[NODE_TABLE]);
 
     sprintf( buffer, "%" PRIdOSMID, osm_id );
     paramValues[0] = buffer;
-    pgsql_execPrepared(node_table->sql_conn, "delete_node", 1, paramValues, PGRES_COMMAND_OK );
+    pgsql_execPrepared(tables[NODE_TABLE].sql_conn, "delete_node", 1,
+                       paramValues, PGRES_COMMAND_OK);
 }
 
 void middle_pgsql_t::nodes_delete(osmid_t osm_id)
@@ -391,16 +392,17 @@ void middle_pgsql_t::node_changed(osmid_t osm_id)
     char const *paramValues[1];
     char buffer[64];
     // Make sure we're out of copy mode */
-    pgsql_endCopy( way_table );
-    pgsql_endCopy( rel_table );
+    pgsql_endCopy(&tables[WAY_TABLE]);
+    pgsql_endCopy(&tables[REL_TABLE]);
 
     sprintf( buffer, "%" PRIdOSMID, osm_id );
     paramValues[0] = buffer;
 
     //keep track of whatever ways and rels these nodes intersect
     //TODO: dont need to stop the copy above since we are only reading?
-    auto res = pgsql_execPrepared(way_table->sql_conn, "mark_ways_by_node", 1,
-                                  paramValues, PGRES_TUPLES_OK);
+    auto res =
+        pgsql_execPrepared(tables[WAY_TABLE].sql_conn, "mark_ways_by_node", 1,
+                           paramValues, PGRES_TUPLES_OK);
     for (int i = 0; i < PQntuples(res.get()); ++i) {
         char *end;
         osmid_t marked = strtoosmid(PQgetvalue(res.get(), i, 0), &end, 10);
@@ -408,7 +410,8 @@ void middle_pgsql_t::node_changed(osmid_t osm_id)
     }
 
     //do the rels too
-    res = pgsql_execPrepared(rel_table->sql_conn, "mark_rels_by_node", 1, paramValues, PGRES_TUPLES_OK );
+    res = pgsql_execPrepared(tables[REL_TABLE].sql_conn, "mark_rels_by_node", 1,
+                             paramValues, PGRES_TUPLES_OK);
     for (int i = 0; i < PQntuples(res.get()); ++i) {
         char *end;
         osmid_t marked = strtoosmid(PQgetvalue(res.get(), i, 0), &end, 10);
@@ -419,7 +422,7 @@ void middle_pgsql_t::node_changed(osmid_t osm_id)
 void middle_pgsql_t::ways_set(osmium::Way const &way)
 {
     copy_buffer.reserve(way.nodes().size() * 10 + way.tags().byte_size() + 100);
-    bool copy = way_table->copyMode;
+    bool copy = tables[WAY_TABLE].copyMode;
     char delim = copy ? '\t' : '\0';
     // Three params: id, nodes, tags */
     const char *paramValues[4] = { copy_buffer.c_str(), };
@@ -450,21 +453,21 @@ void middle_pgsql_t::ways_set(osmium::Way const &way)
 
     if (copy) {
         copy_buffer += '\n';
-        pgsql_CopyData(__FUNCTION__, way_table->sql_conn, copy_buffer);
+        pgsql_CopyData(__FUNCTION__, tables[WAY_TABLE].sql_conn, copy_buffer);
     } else {
         buffer_correct_params(paramValues, 3);
-        pgsql_execPrepared(way_table->sql_conn, "insert_way", 3,
-                           (const char * const *)paramValues, PGRES_COMMAND_OK);
+        pgsql_execPrepared(tables[WAY_TABLE].sql_conn, "insert_way", 3,
+                           (const char *const *)paramValues, PGRES_COMMAND_OK);
     }
 }
 
 bool middle_pgsql_t::ways_get(osmid_t id, osmium::memory::Buffer &buffer) const
 {
     char const *paramValues[1];
-    PGconn *sql_conn = way_table->sql_conn;
+    PGconn *sql_conn = tables[WAY_TABLE].sql_conn;
 
     // Make sure we're out of copy mode
-    assert(way_table->copyMode == 0);
+    assert(tables[WAY_TABLE].copyMode == 0);
 
     char tmp[16];
     snprintf(tmp, sizeof(tmp), "%" PRIdOSMID, id);
@@ -510,12 +513,12 @@ size_t middle_pgsql_t::rel_way_members_get(osmium::Relation const &rel,
         return 0; // no ways found
     }
     // replace last , with } to complete list of ids
-    tmp2[tmp2.length() - 1] = '}'; 
+    tmp2[tmp2.length() - 1] = '}';
 
     // Make sures all ways have been written back.
-    assert(way_table->copyMode == 0);
+    assert(tables[WAY_TABLE].copyMode == 0);
 
-    PGconn *sql_conn = way_table->sql_conn;
+    PGconn *sql_conn = tables[WAY_TABLE].sql_conn;
 
     paramValues[0] = tmp2.c_str();
     auto res = pgsql_execPrepared(sql_conn, "get_way_list", 1, paramValues,
@@ -567,18 +570,19 @@ void middle_pgsql_t::ways_delete(osmid_t osm_id)
     char const *paramValues[1];
     char buffer[64];
     // Make sure we're out of copy mode */
-    pgsql_endCopy( way_table );
+    pgsql_endCopy(&tables[WAY_TABLE]);
 
     sprintf( buffer, "%" PRIdOSMID, osm_id );
     paramValues[0] = buffer;
-    pgsql_execPrepared(way_table->sql_conn, "delete_way", 1, paramValues, PGRES_COMMAND_OK );
+    pgsql_execPrepared(tables[WAY_TABLE].sql_conn, "delete_way", 1, paramValues,
+                       PGRES_COMMAND_OK);
 }
 
 void middle_pgsql_t::iterate_ways(middle_t::pending_processor& pf)
 {
 
     // Make sure we're out of copy mode */
-    pgsql_endCopy( way_table );
+    pgsql_endCopy(&tables[WAY_TABLE]);
 
     // enqueue the jobs
     osmid_t id;
@@ -598,15 +602,16 @@ void middle_pgsql_t::way_changed(osmid_t osm_id)
     char const *paramValues[1];
     char buffer[64];
     // Make sure we're out of copy mode */
-    pgsql_endCopy( rel_table );
+    pgsql_endCopy(&tables[REL_TABLE]);
 
     sprintf( buffer, "%" PRIdOSMID, osm_id );
     paramValues[0] = buffer;
 
     //keep track of whatever rels this way intersects
     //TODO: dont need to stop the copy above since we are only reading?
-    auto res = pgsql_execPrepared(rel_table->sql_conn, "mark_rels_by_way", 1,
-                                  paramValues, PGRES_TUPLES_OK);
+    auto res =
+        pgsql_execPrepared(tables[REL_TABLE].sql_conn, "mark_rels_by_way", 1,
+                           paramValues, PGRES_TUPLES_OK);
     for (int i = 0; i < PQntuples(res.get()); ++i) {
         char *end;
         osmid_t marked = strtoosmid(PQgetvalue(res.get(), i, 0), &end, 10);
@@ -626,7 +631,7 @@ void middle_pgsql_t::relations_set(osmium::Relation const &rel)
 
     // Params: id, way_off, rel_off, parts, members, tags */
     const char *paramValues[6] = { copy_buffer.c_str(), };
-    bool copy = rel_table->copyMode;
+    bool copy = tables[REL_TABLE].copyMode;
     char delim = copy ? '\t' : '\0';
 
     copy_buffer = std::to_string(rel.id());
@@ -683,11 +688,11 @@ void middle_pgsql_t::relations_set(osmium::Relation const &rel)
 
     if (copy) {
         copy_buffer+= '\n';
-        pgsql_CopyData(__FUNCTION__, rel_table->sql_conn, copy_buffer);
+        pgsql_CopyData(__FUNCTION__, tables[REL_TABLE].sql_conn, copy_buffer);
     } else {
         buffer_correct_params(paramValues, 6);
-        pgsql_execPrepared(rel_table->sql_conn, "insert_rel", 6,
-                           (const char * const *)paramValues, PGRES_COMMAND_OK);
+        pgsql_execPrepared(tables[REL_TABLE].sql_conn, "insert_rel", 6,
+                           (const char *const *)paramValues, PGRES_COMMAND_OK);
     }
 }
 
@@ -695,11 +700,11 @@ bool middle_pgsql_t::relations_get(osmid_t id, osmium::memory::Buffer &buffer) c
 {
     char tmp[16];
     char const *paramValues[1];
-    PGconn *sql_conn = rel_table->sql_conn;
+    PGconn *sql_conn = tables[REL_TABLE].sql_conn;
     taglist_t member_temp;
 
     // Make sure we're out of copy mode
-    assert(rel_table->copyMode == 0);
+    assert(tables[REL_TABLE].copyMode == 0);
 
     snprintf(tmp, sizeof(tmp), "%" PRIdOSMID, id);
     paramValues[0] = tmp;
@@ -730,17 +735,19 @@ void middle_pgsql_t::relations_delete(osmid_t osm_id)
     char const *paramValues[1];
     char buffer[64];
     // Make sure we're out of copy mode */
-    pgsql_endCopy( way_table );
-    pgsql_endCopy( rel_table );
+    pgsql_endCopy(&tables[WAY_TABLE]);
+    pgsql_endCopy(&tables[REL_TABLE]);
 
     sprintf( buffer, "%" PRIdOSMID, osm_id );
     paramValues[0] = buffer;
-    pgsql_execPrepared(rel_table->sql_conn, "delete_rel", 1, paramValues, PGRES_COMMAND_OK );
+    pgsql_execPrepared(tables[REL_TABLE].sql_conn, "delete_rel", 1, paramValues,
+                       PGRES_COMMAND_OK);
 
     //keep track of whatever ways this relation interesects
     //TODO: dont need to stop the copy above since we are only reading?
-    auto res = pgsql_execPrepared(way_table->sql_conn, "mark_ways_by_rel", 1,
-                                  paramValues, PGRES_TUPLES_OK);
+    auto res =
+        pgsql_execPrepared(tables[WAY_TABLE].sql_conn, "mark_ways_by_rel", 1,
+                           paramValues, PGRES_TUPLES_OK);
     for (int i = 0; i < PQntuples(res.get()); ++i) {
         char *end;
         osmid_t marked = strtoosmid(PQgetvalue(res.get(), i, 0), &end, 10);
@@ -751,7 +758,7 @@ void middle_pgsql_t::relations_delete(osmid_t osm_id)
 void middle_pgsql_t::iterate_relations(pending_processor& pf)
 {
     // Make sure we're out of copy mode */
-    pgsql_endCopy( rel_table );
+    pgsql_endCopy(&tables[REL_TABLE]);
 
     // enqueue the jobs
     osmid_t id;
@@ -771,7 +778,7 @@ void middle_pgsql_t::relation_changed(osmid_t osm_id)
     char const *paramValues[1];
     char buffer[64];
     // Make sure we're out of copy mode */
-    pgsql_endCopy( rel_table );
+    pgsql_endCopy(&tables[REL_TABLE]);
 
     sprintf( buffer, "%" PRIdOSMID, osm_id );
     paramValues[0] = buffer;
@@ -779,7 +786,7 @@ void middle_pgsql_t::relation_changed(osmid_t osm_id)
     //keep track of whatever ways and rels these nodes intersect
     //TODO: dont need to stop the copy above since we are only reading?
     //TODO: can we just mark the id without querying? the where clause seems intersect reltable.parts with the id
-    auto res = pgsql_execPrepared(rel_table->sql_conn, "mark_rels", 1,
+    auto res = pgsql_execPrepared(tables[REL_TABLE].sql_conn, "mark_rels", 1,
                                   paramValues, PGRES_TUPLES_OK);
     for (int i = 0; i < PQntuples(res.get()); ++i) {
         char *end;
@@ -793,13 +800,14 @@ idlist_t middle_pgsql_t::relations_using_way(osmid_t way_id) const
     char const *paramValues[1];
     char buffer[64];
     // Make sure we're out of copy mode */
-    assert(rel_table->copyMode == 0);
+    assert(tables[REL_TABLE].copyMode == 0);
 
     sprintf(buffer, "%" PRIdOSMID, way_id);
     paramValues[0] = buffer;
 
-    auto result = pgsql_execPrepared(rel_table->sql_conn, "rels_using_way", 1,
-                                     paramValues, PGRES_TUPLES_OK);
+    auto result =
+        pgsql_execPrepared(tables[REL_TABLE].sql_conn, "rels_using_way", 1,
+                           paramValues, PGRES_TUPLES_OK);
     const int ntuples = PQntuples(result.get());
     idlist_t rel_ids;
     rel_ids.resize((size_t) ntuples);
@@ -948,7 +956,7 @@ void middle_pgsql_t::start(const options_t *out_options_)
     // and pass that via the constructor to middle_t, so that middle_t
     // itself doesn't need to know about details of the output.
     if (out_options->output_backend == "gazetteer") {
-        way_table->array_indexes = nullptr;
+        tables[WAY_TABLE].array_indexes = nullptr;
         mark_pending = false;
     }
 
@@ -1073,24 +1081,22 @@ void middle_pgsql_t::stop(osmium::thread::Pool &pool)
     if (out_options->droptemp) {
         // Dropping the tables is fast, so do it synchronously to guarantee
         // that the space is freed before creating the other indices.
-        for (int i = 0; i < num_tables; ++i) {
-            pgsql_stop_one(&tables[i]);
+        for (auto &t : tables) {
+            pgsql_stop_one(&t);
         }
     } else {
-        for (int i = 0; i < num_tables; ++i) {
-            pool.submit(
-                std::bind(&middle_pgsql_t::pgsql_stop_one, this, &tables[i]));
+        for (auto &t : tables) {
+            pool.submit(std::bind(&middle_pgsql_t::pgsql_stop_one, this, &t));
         }
     }
 }
 
 middle_pgsql_t::middle_pgsql_t()
-: num_tables(0), node_table(nullptr), way_table(nullptr), rel_table(nullptr),
-  append(false), mark_pending(true), build_indexes(true)
+: append(false), mark_pending(true), build_indexes(true)
 {
     // clang-format off
     /*table = t_node,*/
-    tables.push_back(table_desc(
+    tables[NODE_TABLE] = table_desc(
             /*name*/ "%p_nodes",
            /*start*/ "BEGIN;\n",
           /*create*/ "CREATE %m TABLE %p_nodes (id " POSTGRES_OSMID_TYPE " PRIMARY KEY {USING INDEX TABLESPACE %i}, lat int4 not null, lon int4 not null) {TABLESPACE %t};\n",
@@ -1102,8 +1108,8 @@ middle_pgsql_t::middle_pgsql_t()
             /*copy*/ "COPY %p_nodes FROM STDIN;\n",
          /*analyze*/ "ANALYZE %p_nodes;\n",
             /*stop*/ "COMMIT;\n"
-                         ));
-    tables.push_back(table_desc(
+                         );
+    tables[WAY_TABLE] = table_desc(
         /*table t_way,*/
             /*name*/ "%p_ways",
            /*start*/ "BEGIN;\n",
@@ -1121,8 +1127,8 @@ middle_pgsql_t::middle_pgsql_t()
          /*analyze*/ "ANALYZE %p_ways;\n",
             /*stop*/  "COMMIT;\n",
    /*array_indexes*/ "CREATE INDEX %p_ways_nodes ON %p_ways USING gin (nodes) WITH (FASTUPDATE=OFF) {TABLESPACE %i};\n"
-                         ));
-    tables.push_back(table_desc(
+                         );
+    tables[REL_TABLE] = table_desc(
         /*table = t_rel,*/
             /*name*/ "%p_rels",
            /*start*/ "BEGIN;\n",
@@ -1141,20 +1147,12 @@ middle_pgsql_t::middle_pgsql_t()
          /*analyze*/ "ANALYZE %p_rels;\n",
             /*stop*/  "COMMIT;\n",
    /*array_indexes*/ "CREATE INDEX %p_rels_parts ON %p_rels USING gin (parts) WITH (FASTUPDATE=OFF) {TABLESPACE %i};\n"
-                         ));
+                         );
     // clang-format on
-
-    // set up the rest of the variables from the tables.
-    num_tables = tables.size();
-    assert(num_tables == 3);
-
-    node_table = &tables[0];
-    way_table = &tables[1];
-    rel_table = &tables[2];
 }
 
 middle_pgsql_t::~middle_pgsql_t() {
-    for (auto& table: tables) {
+    for (auto &table : tables) {
         if (table.sql_conn) {
             PQfinish(table.sql_conn);
         }
@@ -1180,7 +1178,7 @@ middle_pgsql_t::get_query_instance(std::shared_ptr<middle_t> const &from) const
     mid->persistent_cache = src->persistent_cache;
 
     // We use a connection per table to enable the use of COPY
-    for (int i = 0; i < num_tables; i++) {
+    for (int i = 0; i < NUM_TABLES; i++) {
         mid->connect(mid->tables[i]);
         PGconn* sql_conn = mid->tables[i].sql_conn;
 

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -43,6 +43,8 @@ struct middle_pgsql_t : public slim_middle_t {
     void relations_delete(osmid_t id) override;
     void relation_changed(osmid_t id) override;
 
+    void flush() override;
+
     void iterate_ways(middle_t::pending_processor& pf) override;
     void iterate_relations(pending_processor& pf) override;
 

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -14,7 +14,6 @@
 #include "node-persistent-cache.hpp"
 #include "id-tracker.hpp"
 #include <memory>
-#include <vector>
 
 struct middle_pgsql_t : public slim_middle_t {
     middle_pgsql_t();
@@ -84,6 +83,14 @@ struct middle_pgsql_t : public slim_middle_t {
     get_query_instance(std::shared_ptr<middle_t> const &mid) const override;
 
 private:
+    enum middle_tables
+    {
+        NODE_TABLE = 0,
+        WAY_TABLE,
+        REL_TABLE,
+        NUM_TABLES
+    };
+
     void pgsql_stop_one(table_desc *table);
 
     /**
@@ -94,9 +101,7 @@ private:
     size_t local_nodes_get_list(osmium::WayNodeList *nodes) const;
     void local_nodes_delete(osmid_t osm_id);
 
-    std::vector<table_desc> tables;
-    int num_tables;
-    table_desc *node_table, *way_table, *rel_table;
+    table_desc tables[NUM_TABLES];
 
     bool append;
     bool mark_pending;

--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -107,6 +107,8 @@ struct middle_ram_t : public middle_t {
     int relations_delete(osmid_t id);
     int relation_changed(osmid_t id);
 
+    void flush() override {}
+
     idlist_t relations_using_way(osmid_t way_id) const override;
 
     void iterate_ways(middle_t::pending_processor& pf) override;

--- a/middle.hpp
+++ b/middle.hpp
@@ -92,6 +92,9 @@ struct middle_t : public middle_query_t {
     virtual void ways_set(osmium::Way const &way) = 0;
     virtual void relations_set(osmium::Relation const &rel) = 0;
 
+    /// Write all pending data to permanent storage.
+    virtual void flush() = 0;
+
     struct pending_processor {
         virtual ~pending_processor() {}
         virtual void enqueue_ways(osmid_t id) = 0;

--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -180,6 +180,11 @@ void osmdata_t::start() {
     mid->start(outs[0]->get_options());
 }
 
+void osmdata_t::type_changed()
+{
+    mid->flush();
+}
+
 namespace {
 
 //TODO: have the main thread using the main middle to query the middle for batches of ways (configurable number)

--- a/osmdata.hpp
+++ b/osmdata.hpp
@@ -14,7 +14,8 @@ class output_t;
 struct middle_t;
 class reprojection;
 
-class osmdata_t {
+class osmdata_t
+{
 public:
     osmdata_t(std::shared_ptr<middle_t> mid_,
               std::shared_ptr<output_t> const &out_,
@@ -25,6 +26,7 @@ public:
     ~osmdata_t();
 
     void start();
+    void type_changed();
     void stop();
 
     int node_add(osmium::Node const &node);

--- a/parse-osmium.cpp
+++ b/parse-osmium.cpp
@@ -124,6 +124,7 @@ void parse_osmium_t::stream_file(const std::string &filename, const std::string 
 
     fprintf(stderr, "Using %s parser.\n", osmium::io::as_string(infile.format()));
 
+    m_type = osmium::item_type::node;
     osmium::io::Reader reader(infile);
     osmium::apply(reader, *this);
     reader.close();
@@ -131,6 +132,11 @@ void parse_osmium_t::stream_file(const std::string &filename, const std::string 
 
 void parse_osmium_t::node(osmium::Node const &node)
 {
+    if (m_type != osmium::item_type::node) {
+        m_type = osmium::item_type::node;
+        m_data->type_changed();
+    }
+
     if (node.deleted()) {
         m_data->node_delete(node.id());
     } else {
@@ -159,6 +165,11 @@ void parse_osmium_t::node(osmium::Node const &node)
 
 void parse_osmium_t::way(osmium::Way& way)
 {
+    if (m_type != osmium::item_type::way) {
+        m_type = osmium::item_type::way;
+        m_data->type_changed();
+    }
+
     if (way.deleted()) {
         m_data->way_delete(way.id());
     } else {
@@ -173,6 +184,11 @@ void parse_osmium_t::way(osmium::Way& way)
 
 void parse_osmium_t::relation(osmium::Relation const &rel)
 {
+    if (m_type != osmium::item_type::relation) {
+        m_type = osmium::item_type::relation;
+        m_data->type_changed();
+    }
+
     if (rel.deleted()) {
         m_data->relation_delete(rel.id());
     } else {

--- a/parse-osmium.hpp
+++ b/parse-osmium.hpp
@@ -129,6 +129,8 @@ private:
     bool m_append;
     boost::optional<osmium::Box> m_bbox;
     parse_stats_t m_stats;
+    // Current type being parsed.
+    osmium::item_type m_type;
 };
 
 #endif

--- a/tests/mockups.hpp
+++ b/tests/mockups.hpp
@@ -9,6 +9,7 @@ struct dummy_middle_t : public middle_t {
 
     void start(const options_t *) override { }
     void stop(osmium::thread::Pool &) override {}
+    void flush() override {}
     void cleanup(void) { }
     void analyze(void) override  { }
     void commit(void) override  { }
@@ -46,6 +47,7 @@ struct dummy_slim_middle_t : public slim_middle_t {
 
     void start(const options_t *) override  { }
     void stop(osmium::thread::Pool &) override {}
+    void flush() override {}
     void cleanup(void) { }
     void analyze(void) override  { }
     void commit(void) override  { }


### PR DESCRIPTION
Introduce flush when type of import object changes, which replaces the endCopy operation in the middle_t
read functions. These functions are const and never should have called a function that changes state.
Instead of falling out of copy then, all copy operations are finished, when processing of an OSM type is done. Read functions should never be called when actually processing the same table, so the one-time end-copy is sufficient.

Also remove vector of table_desc and use a fixed sized array instead. Remove the pointer indirections to the vector entries and use index consts into the array.