### PR TITLE
Middle-pgsql: cleanup table access code

### DIFF
--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -991,10 +991,9 @@ void middle_pgsql_t::start(const options_t *out_options_)
     // We use a connection per table to enable the use of COPY */
     for (auto &table : tables) {
         table.connect(out_options);
-        PGconn* sql_conn = table.sql_conn;
 
         if (dropcreate) {
-            pgsql_exec(sql_conn, PGRES_COMMAND_OK,
+            pgsql_exec(table.sql_conn, PGRES_COMMAND_OK,
                        "DROP TABLE IF EXISTS %s CASCADE", table.name());
         }
 

--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -41,10 +41,6 @@ using namespace std;
 #include "pgsql.hpp"
 #include "util.hpp"
 
-enum table_id {
-    t_node, t_way, t_rel
-} ;
-
 /**
  * Helper to create SQL queries.
  *

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -9,11 +9,13 @@
 #ifndef MIDDLE_PGSQL_H
 #define MIDDLE_PGSQL_H
 
-#include "middle.hpp"
-#include "node-ram-cache.hpp"
-#include "node-persistent-cache.hpp"
-#include "id-tracker.hpp"
 #include <memory>
+
+#include "id-tracker.hpp"
+#include "middle.hpp"
+#include "node-persistent-cache.hpp"
+#include "node-ram-cache.hpp"
+#include "pgsql.hpp"
 
 struct middle_pgsql_t : public slim_middle_t {
     middle_pgsql_t();
@@ -72,6 +74,9 @@ struct middle_pgsql_t : public slim_middle_t {
         void create();
         void begin_copy();
         void end_copy();
+        pg_result_t
+        exec_prepared(char const *stmt, char const *param,
+                      ExecStatusType expect = PGRES_TUPLES_OK) const;
         void stop(bool droptemp, bool build_indexes);
         void commit();
 

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -51,7 +51,8 @@ struct middle_pgsql_t : public slim_middle_t {
 
     idlist_t relations_using_way(osmid_t way_id) const override;
 
-    struct table_desc {
+    struct table_desc
+    {
         table_desc(const char *name_ = NULL,
                    const char *start_ = NULL,
                    const char *create_ = NULL,
@@ -71,12 +72,15 @@ struct middle_pgsql_t : public slim_middle_t {
         const char *prepare_intarray;
         const char *copy;
         const char *analyze;
-        const char *stop;
+        const char *commit;
         const char *array_indexes;
 
         int copyMode;    /* True if we are in copy mode */
         int transactionMode;    /* True if we are in an extended transaction */
         struct pg_conn *sql_conn;
+
+        void end_copy();
+        void stop(bool droptemp, bool build_indexes);
     };
 
     std::shared_ptr<middle_query_t>
@@ -90,8 +94,6 @@ private:
         REL_TABLE,
         NUM_TABLES
     };
-
-    void pgsql_stop_one(table_desc *table);
 
     /**
      * Sets up sql_conn for the table
@@ -116,7 +118,6 @@ private:
 
     void buffer_correct_params(char const **param, size_t size);
 
-    bool build_indexes;
     std::string copy_buffer;
 };
 

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -21,8 +21,8 @@ struct middle_pgsql_t : public slim_middle_t {
 
     void start(const options_t *out_options_) override;
     void stop(osmium::thread::Pool &pool) override;
-    void analyze(void) override;
-    void commit(void) override;
+    void analyze() override;
+    void commit() override;
 
     void nodes_set(osmium::Node const &node) override;
     size_t nodes_get_list(osmium::WayNodeList *nodes) const override;
@@ -54,33 +54,30 @@ struct middle_pgsql_t : public slim_middle_t {
     struct table_desc
     {
         table_desc(const char *name_ = NULL,
-                   const char *start_ = NULL,
                    const char *create_ = NULL,
                    const char *create_index_ = NULL,
                    const char *prepare_ = NULL,
                    const char *prepare_intarray_ = NULL,
-                   const char *copy_ = NULL,
-                   const char *analyze_ = NULL,
-                   const char *stop_ = NULL,
                    const char *array_indexes_ = NULL);
 
         const char *name;
-        const char *start;
         const char *create;
         const char *create_index;
         const char *prepare;
         const char *prepare_intarray;
-        const char *copy;
-        const char *analyze;
-        const char *commit;
         const char *array_indexes;
 
         int copyMode;    /* True if we are in copy mode */
-        int transactionMode;    /* True if we are in an extended transaction */
         struct pg_conn *sql_conn;
 
+        void begin();
+        void begin_copy();
         void end_copy();
         void stop(bool droptemp, bool build_indexes);
+        void commit();
+
+    private:
+        int transactionMode; /* True if we are in an extended transaction */
     };
 
     std::shared_ptr<middle_query_t>

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -50,27 +50,26 @@ struct middle_pgsql_t : public slim_middle_t {
 
     idlist_t relations_using_way(osmid_t way_id) const override;
 
-    struct table_desc
+    class table_desc
     {
-        table_desc(const char *name_ = NULL,
-                   const char *create_ = NULL,
-                   const char *prepare_ = NULL,
-                   const char *prepare_intarray_ = NULL,
-                   const char *array_indexes_ = NULL);
+    public:
+        table_desc() : sql_conn(nullptr) {}
+        table_desc(char const *name, char const *create,
+                   char const *prepare = "", char const *prepare_intarray = "",
+                   char const *array_indexes = "");
 
         ~table_desc();
 
-        const char *name;
-        const char *create;
-        const char *prepare;
-        const char *prepare_intarray;
-        const char *array_indexes;
+        char const *name() const { return m_name.c_str(); }
+        void clear_array_indexes() { m_array_indexes.clear(); }
 
         int copyMode;    /* True if we are in copy mode */
         struct pg_conn *sql_conn;
 
         void connect(options_t const *options);
         void begin();
+        void prepare_queries(bool append);
+        void create();
         void begin_copy();
         void end_copy();
         void stop(bool droptemp, bool build_indexes);
@@ -78,6 +77,11 @@ struct middle_pgsql_t : public slim_middle_t {
 
     private:
         int transactionMode; /* True if we are in an extended transaction */
+        std::string m_name;
+        std::string m_create;
+        std::string m_prepare;
+        std::string m_prepare_intarray;
+        std::string m_array_indexes;
     };
 
     std::shared_ptr<middle_query_t>

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -54,7 +54,6 @@ struct middle_pgsql_t : public slim_middle_t {
     {
         table_desc(const char *name_ = NULL,
                    const char *create_ = NULL,
-                   const char *create_index_ = NULL,
                    const char *prepare_ = NULL,
                    const char *prepare_intarray_ = NULL,
                    const char *array_indexes_ = NULL);
@@ -63,7 +62,6 @@ struct middle_pgsql_t : public slim_middle_t {
 
         const char *name;
         const char *create;
-        const char *create_index;
         const char *prepare;
         const char *prepare_intarray;
         const char *array_indexes;

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -77,6 +77,9 @@ struct middle_pgsql_t : public slim_middle_t {
         pg_result_t
         exec_prepared(char const *stmt, char const *param,
                       ExecStatusType expect = PGRES_TUPLES_OK) const;
+        pg_result_t
+        exec_prepared(char const *stmt, osmid_t osm_id,
+                      ExecStatusType expect = PGRES_TUPLES_OK) const;
         void stop(bool droptemp, bool build_indexes);
         void commit();
 

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -17,7 +17,6 @@
 
 struct middle_pgsql_t : public slim_middle_t {
     middle_pgsql_t();
-    virtual ~middle_pgsql_t();
 
     void start(const options_t *out_options_) override;
     void stop(osmium::thread::Pool &pool) override;
@@ -60,6 +59,8 @@ struct middle_pgsql_t : public slim_middle_t {
                    const char *prepare_intarray_ = NULL,
                    const char *array_indexes_ = NULL);
 
+        ~table_desc();
+
         const char *name;
         const char *create;
         const char *create_index;
@@ -70,6 +71,7 @@ struct middle_pgsql_t : public slim_middle_t {
         int copyMode;    /* True if we are in copy mode */
         struct pg_conn *sql_conn;
 
+        void connect(options_t const *options);
         void begin();
         void begin_copy();
         void end_copy();
@@ -95,7 +97,6 @@ private:
     /**
      * Sets up sql_conn for the table
      */
-    void connect(table_desc& table);
     void local_nodes_set(osmium::Node const &node);
     size_t local_nodes_get_list(osmium::WayNodeList *nodes) const;
     void local_nodes_delete(osmid_t osm_id);


### PR DESCRIPTION
* Convert table_desc into a full class that also provides functions for most of the SQL accesses.
* Convert C strings for SQL commands into std::string. Fixes #731 .
* Remove SQL command strings that are fixed for all tables and replace them with wrapper functions. 