### PR TITLE
middle-pgsql: be less eager with ending copy mode

### DIFF
--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -1004,10 +1004,20 @@ void middle_pgsql_t::commit()
     }
 }
 
-void middle_pgsql_t::flush()
+void middle_pgsql_t::flush(osmium::item_type new_type)
 {
-    for (auto &table : tables) {
-        table.end_copy();
+    switch (new_type)
+    {
+        case osmium::item_type::way:
+            tables[NODE_TABLE].end_copy();
+            break;
+        case osmium::item_type::relation:
+            tables[NODE_TABLE].end_copy();
+            tables[WAY_TABLE].end_copy();
+            break;
+        default:
+            // nothing needed
+            break;
     }
 }
 

--- a/middle-pgsql.hpp
+++ b/middle-pgsql.hpp
@@ -43,7 +43,7 @@ struct middle_pgsql_t : public slim_middle_t {
     void relations_delete(osmid_t id) override;
     void relation_changed(osmid_t id) override;
 
-    void flush() override;
+    void flush(osmium::item_type new_type) override;
 
     void iterate_ways(middle_t::pending_processor& pf) override;
     void iterate_relations(pending_processor& pf) override;

--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -107,7 +107,7 @@ struct middle_ram_t : public middle_t {
     int relations_delete(osmid_t id);
     int relation_changed(osmid_t id);
 
-    void flush() override {}
+    void flush(osmium::item_type) override {}
 
     idlist_t relations_using_way(osmid_t way_id) const override;
 

--- a/middle.hpp
+++ b/middle.hpp
@@ -93,7 +93,7 @@ struct middle_t : public middle_query_t {
     virtual void relations_set(osmium::Relation const &rel) = 0;
 
     /// Write all pending data to permanent storage.
-    virtual void flush() = 0;
+    virtual void flush(osmium::item_type new_type) = 0;
 
     struct pending_processor {
         virtual ~pending_processor() {}

--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -180,9 +180,9 @@ void osmdata_t::start() {
     mid->start(outs[0]->get_options());
 }
 
-void osmdata_t::type_changed()
+void osmdata_t::type_changed(osmium::item_type new_type)
 {
-    mid->flush();
+    mid->flush(new_type);
 }
 
 namespace {

--- a/osmdata.hpp
+++ b/osmdata.hpp
@@ -26,7 +26,7 @@ public:
     ~osmdata_t();
 
     void start();
-    void type_changed();
+    void type_changed(osmium::item_type new_type);
     void stop();
 
     int node_add(osmium::Node const &node);

--- a/parse-osmium.cpp
+++ b/parse-osmium.cpp
@@ -134,7 +134,7 @@ void parse_osmium_t::node(osmium::Node const &node)
 {
     if (m_type != osmium::item_type::node) {
         m_type = osmium::item_type::node;
-        m_data->type_changed();
+        m_data->type_changed(osmium::item_type::node);
     }
 
     if (node.deleted()) {
@@ -167,7 +167,7 @@ void parse_osmium_t::way(osmium::Way& way)
 {
     if (m_type != osmium::item_type::way) {
         m_type = osmium::item_type::way;
-        m_data->type_changed();
+        m_data->type_changed(osmium::item_type::way);
     }
 
     if (way.deleted()) {
@@ -186,7 +186,7 @@ void parse_osmium_t::relation(osmium::Relation const &rel)
 {
     if (m_type != osmium::item_type::relation) {
         m_type = osmium::item_type::relation;
-        m_data->type_changed();
+        m_data->type_changed(osmium::item_type::relation);
     }
 
     if (rel.deleted()) {

--- a/tests/mockups.hpp
+++ b/tests/mockups.hpp
@@ -9,7 +9,7 @@ struct dummy_middle_t : public middle_t {
 
     void start(const options_t *) override { }
     void stop(osmium::thread::Pool &) override {}
-    void flush() override {}
+    void flush(osmium::item_type) override {}
     void cleanup(void) { }
     void analyze(void) override  { }
     void commit(void) override  { }
@@ -47,7 +47,7 @@ struct dummy_slim_middle_t : public slim_middle_t {
 
     void start(const options_t *) override  { }
     void stop(osmium::thread::Pool &) override {}
-    void flush() override {}
+    void flush(osmium::item_type) override {}
     void cleanup(void) { }
     void analyze(void) override  { }
     void commit(void) override  { }


### PR DESCRIPTION
#889 moved the end of copy for middle tables away from query functions but did so a little bit to eagerly. The result is that copy mode is never used for ways and relations. This changes the behaviour to only throw tables out of copy mode that may actually be used by the OSM type next being read. 