### PR TITLE
 Hand outputs a shared pointer to the middle query object

### DIFF
--- a/osm2pgsql.cpp
+++ b/osm2pgsql.cpp
@@ -60,11 +60,13 @@ int main(int argc, char *argv[])
 
         if (options.slim) {
             auto mid = std::make_shared<middle_pgsql_t>();
-            outputs = output_t::create_outputs(mid.get(), options);
+            outputs = output_t::create_outputs(
+                std::static_pointer_cast<middle_query_t>(mid), options);
             middle = std::static_pointer_cast<middle_t>(mid);
         } else {
             auto mid = std::make_shared<middle_ram_t>();
-            outputs = output_t::create_outputs(mid.get(), options);
+            outputs = output_t::create_outputs(
+                std::static_pointer_cast<middle_query_t>(mid), options);
             middle = std::static_pointer_cast<middle_t>(mid);
         }
 

--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -253,7 +253,7 @@ struct pending_threaded_processor : public middle_t::pending_processor {
             //clone the outs
             output_vec_t out_clones;
             for (const auto& out: outs) {
-                out_clones.push_back(out->clone(mid_clone.get()));
+                out_clones.push_back(out->clone(mid_clone));
             }
 
             //keep the clones for a specific thread to use

--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -186,8 +186,7 @@ namespace {
 //since the fetching from middle should be faster than the processing in each backend.
 
 struct pending_threaded_processor : public middle_t::pending_processor {
-    typedef std::vector<std::shared_ptr<output_t>> output_vec_t;
-    typedef std::pair<std::shared_ptr<middle_query_t>, output_vec_t> clone_t;
+    using output_vec_t = std::vector<std::shared_ptr<output_t>>;
 
     static void do_jobs(output_vec_t const& outputs, pending_queue_t& queue, size_t& ids_done, std::mutex& mutex, int append, bool ways) {
         while (true) {
@@ -257,7 +256,7 @@ struct pending_threaded_processor : public middle_t::pending_processor {
             }
 
             //keep the clones for a specific thread to use
-            clones.push_back(clone_t(mid_clone, out_clones));
+            clones.push_back(out_clones);
         }
     }
 
@@ -282,11 +281,10 @@ struct pending_threaded_processor : public middle_t::pending_processor {
 
         //make the threads and start them
         std::vector<std::future<void>> workers;
-        for (size_t i = 0; i < clones.size(); ++i) {
-            workers.push_back(std::async(std::launch::async,
-                                         do_jobs, std::cref(clones[i].second),
-                                         std::ref(queue), std::ref(ids_done),
-                                         std::ref(mutex), append, true));
+        for (auto const &clone : clones) {
+            workers.push_back(std::async(
+                std::launch::async, do_jobs, std::cref(clone), std::ref(queue),
+                std::ref(ids_done), std::ref(mutex), append, true));
         }
         workers.push_back(std::async(std::launch::async, print_stats,
                                      std::ref(queue), std::ref(mutex)));
@@ -315,10 +313,12 @@ struct pending_threaded_processor : public middle_t::pending_processor {
 
         //collect all the new rels that became pending from each
         //output in each thread back to their respective main outputs
-        for (const auto& clone: clones) {
+        for (auto const &clone : clones) {
             //for each clone/original output
-            for(output_vec_t::const_iterator original_output = outs.begin(), clone_output = clone.second.begin();
-                original_output != outs.end() && clone_output != clone.second.end(); ++original_output, ++clone_output) {
+            for (output_vec_t::const_iterator original_output = outs.begin(),
+                                              clone_output = clone.begin();
+                 original_output != outs.end() && clone_output != clone.end();
+                 ++original_output, ++clone_output) {
                 //done copying ways for now
                 clone_output->get()->commit();
                 //merge the pending from this threads copy of output back
@@ -344,11 +344,10 @@ struct pending_threaded_processor : public middle_t::pending_processor {
 
         //make the threads and start them
         std::vector<std::future<void>> workers;
-        for (size_t i = 0; i < clones.size(); ++i) {
-            workers.push_back(std::async(std::launch::async,
-                                         do_jobs, std::cref(clones[i].second),
-                                         std::ref(queue), std::ref(ids_done),
-                                         std::ref(mutex), append, false));
+        for (auto const &clone : clones) {
+            workers.push_back(std::async(
+                std::launch::async, do_jobs, std::cref(clone), std::ref(queue),
+                std::ref(ids_done), std::ref(mutex), append, false));
         }
         workers.push_back(std::async(std::launch::async, print_stats,
                                      std::ref(queue), std::ref(mutex)));
@@ -376,10 +375,12 @@ struct pending_threaded_processor : public middle_t::pending_processor {
         ids_done = 0;
 
         //collect all expiry tree informations together into one
-        for (const auto& clone: clones) {
+        for (auto const &clone : clones) {
             //for each clone/original output
-            for(output_vec_t::const_iterator original_output = outs.begin(), clone_output = clone.second.begin();
-                original_output != outs.end() && clone_output != clone.second.end(); ++original_output, ++clone_output) {
+            for (output_vec_t::const_iterator original_output = outs.begin(),
+                                              clone_output = clone.begin();
+                 original_output != outs.end() && clone_output != clone.end();
+                 ++original_output, ++clone_output) {
                 //done copying rels for now
                 clone_output->get()->commit();
                 //merge the expire tree from this threads copy of output back
@@ -389,8 +390,8 @@ struct pending_threaded_processor : public middle_t::pending_processor {
     }
 
 private:
-    //middle and output copies
-    std::vector<clone_t> clones;
+    // output copies, one vector per thread
+    std::vector<output_vec_t> clones;
     output_vec_t outs; //would like to move ownership of outs to osmdata_t and middle passed to output_t instead of owned by it
     //how many jobs do we have in the queue to start with
     size_t ids_queued;

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -23,16 +23,21 @@ struct export_list;
 struct middle_query_t;
 struct options_t;
 
-class output_multi_t : public output_t {
+class output_multi_t : public output_t
+{
+    output_multi_t(output_multi_t const *other,
+                   std::shared_ptr<middle_query_t> const &mid);
+
 public:
-    output_multi_t(const std::string &name,
+    output_multi_t(std::string const &name,
                    std::shared_ptr<geometry_processor> processor_,
-                   const export_list &export_list_,
-                   const middle_query_t* mid_, const options_t &options_);
-    output_multi_t(const output_multi_t& other);
+                   export_list const &export_list_,
+                   std::shared_ptr<middle_query_t> const &mid,
+                   options_t const &options);
     virtual ~output_multi_t();
 
-    std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const override;
+    std::shared_ptr<output_t>
+    clone(std::shared_ptr<middle_query_t> const &mid) const override;
 
     int start() override;
     void stop(osmium::thread::Pool *pool) override;

--- a/output-null.cpp
+++ b/output-null.cpp
@@ -62,17 +62,22 @@ int output_null_t::relation_modify(osmium::Relation const &) {
   return 0;
 }
 
-std::shared_ptr<output_t> output_null_t::clone(const middle_query_t* cloned_middle) const {
-    output_null_t *clone = new output_null_t(*this);
-    clone->m_mid = cloned_middle;
-    return std::shared_ptr<output_t>(clone);
+std::shared_ptr<output_t>
+output_null_t::clone(std::shared_ptr<middle_query_t> const &mid) const
+{
+    return std::shared_ptr<output_t>(new output_null_t(this, mid));
 }
 
-output_null_t::output_null_t(const middle_query_t* mid_, const options_t &options_): output_t(mid_, options_) {
+output_null_t::output_null_t(std::shared_ptr<middle_query_t> const &mid,
+                             options_t const &options)
+: output_t(mid, options)
+{
 }
 
-output_null_t::output_null_t(const output_null_t& other): output_t(other.m_mid, other.m_options) {
+output_null_t::output_null_t(output_null_t const *other,
+                             std::shared_ptr<middle_query_t> const &mid)
+: output_t(mid, other->m_options)
+{
 }
 
-output_null_t::~output_null_t() {
-}
+output_null_t::~output_null_t() = default;

--- a/output-null.hpp
+++ b/output-null.hpp
@@ -7,12 +7,16 @@
 #include "output.hpp"
 
 class output_null_t : public output_t {
+    output_null_t(output_null_t const *other,
+                  std::shared_ptr<middle_query_t> const &mid);
+
 public:
-    output_null_t(const middle_query_t* mid_, const options_t &options);
-    output_null_t(const output_null_t& other);
+    output_null_t(std::shared_ptr<middle_query_t> const &mid,
+                  options_t const &options);
     virtual ~output_null_t();
 
-    std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const override;
+    std::shared_ptr<output_t>
+    clone(std::shared_ptr<middle_query_t> const &mid) const override;
 
     int start() override;
     void stop(osmium::thread::Pool *pool) override;

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -17,16 +17,20 @@
 #include <memory>
 
 class output_pgsql_t : public output_t {
+    output_pgsql_t(output_pgsql_t const *other,
+                   std::shared_ptr<middle_query_t> const &mid);
+
 public:
     enum table_id {
         t_point = 0, t_line, t_poly, t_roads, t_MAX
     };
 
-    output_pgsql_t(const middle_query_t* mid_, const options_t &options_);
+    output_pgsql_t(std::shared_ptr<middle_query_t> const &mid,
+                   options_t const &options);
     virtual ~output_pgsql_t();
-    output_pgsql_t(const output_pgsql_t& other);
 
-    std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const override;
+    std::shared_ptr<output_t>
+    clone(std::shared_ptr<middle_query_t> const &mid) const override;
 
     int start() override;
     void stop(osmium::thread::Pool *pool) override;

--- a/output.hpp
+++ b/output.hpp
@@ -12,7 +12,6 @@
 
 #include <stack>
 
-#include <boost/noncopyable.hpp>
 #include <osmium/thread/pool.hpp>
 
 #include "options.hpp"
@@ -31,14 +30,19 @@ struct pending_job_t {
 
 typedef std::stack<pending_job_t> pending_queue_t;
 
-class output_t : public boost::noncopyable {
+class output_t
+{
 public:
-    static std::vector<std::shared_ptr<output_t> > create_outputs(const middle_query_t *mid, const options_t &options);
+    static std::vector<std::shared_ptr<output_t>>
+    create_outputs(std::shared_ptr<middle_query_t> const &mid,
+                   options_t const &options);
 
-    output_t(const middle_query_t *mid, const options_t &options_);
+    output_t(std::shared_ptr<middle_query_t> const &mid,
+             options_t const &options);
     virtual ~output_t();
 
-    virtual std::shared_ptr<output_t> clone(const middle_query_t* cloned_middle) const = 0;
+    virtual std::shared_ptr<output_t>
+    clone(std::shared_ptr<middle_query_t> const &mid) const = 0;
 
     virtual int start() = 0;
     virtual void stop(osmium::thread::Pool *pool) = 0;
@@ -70,8 +74,7 @@ public:
     virtual void merge_expire_trees(output_t *other);
 
 protected:
-
-    const middle_query_t* m_mid;
+    std::shared_ptr<middle_query_t> m_mid;
     const options_t m_options;
 };
 

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -16,6 +16,23 @@ namespace testing {
         parser.stream_file(filename, format);
         osmdata->stop();
     }
+
+    template <typename MID>
+    void run_osm2pgsql(options_t &options, char const *test_file,
+                       char const *file_format)
+    {
+        //setup the middle
+        auto middle = std::make_shared<MID>();
+
+        //setup the backend (output)
+        auto outputs = output_t::create_outputs(
+            std::static_pointer_cast<middle_query_t>(middle), options);
+
+        //let osmdata orchestrate between the middle and the outs
+        osmdata_t osmdata(std::static_pointer_cast<middle_t>(middle), outputs);
+
+        parse(test_file, file_format, options, &osmdata);
+    }
 }
 
 #endif /* TEST_COMMON_HPP */

--- a/tests/test-hstore-match-only.cpp
+++ b/tests/test-hstore-match-only.cpp
@@ -42,7 +42,6 @@ int main(int argc, char *argv[]) {
     }
 
     try {
-        std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
         options_t options;
         options.database_options = db->database_options;
         options.num_procs = 1;
@@ -53,12 +52,8 @@ int main(int argc, char *argv[]) {
         options.slim = 1;
         options.append = false;
 
-        auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
-
-        osmdata_t osmdata(mid_pgsql, out_test);
-
-        testing::parse("tests/hstore-match-only.osm", "xml",
-                       options, &osmdata);
+        testing::run_osm2pgsql<middle_pgsql_t>(
+            options, "tests/hstore-match-only.osm", "xml");
 
         // tables should not contain any tag columns
         db->check_count(4, "select count(column_name) from information_schema.columns where table_name='osm2pgsql_test_point'");

--- a/tests/test-options-parse.cpp
+++ b/tests/test-options-parse.cpp
@@ -84,8 +84,8 @@ void test_outputs()
 {
     const char* a1[] = {"osm2pgsql", "-O", "pgsql", "--style", "default.style", "tests/liechtenstein-2013-08-03.osm.pbf"};
     options_t options = options_t(len(a1), const_cast<char **>(a1));
-    auto mid = std::make_shared<middle_ram_t>();
-    std::vector<std::shared_ptr<output_t> > outs = output_t::create_outputs(mid.get(), options);
+    std::shared_ptr<middle_query_t> mid(new middle_ram_t());
+    auto outs = output_t::create_outputs(mid, options);
     output_t* out = outs.front().get();
     if(dynamic_cast<output_pgsql_t *>(out) == nullptr)
     {
@@ -94,7 +94,7 @@ void test_outputs()
 
     const char* a2[] = {"osm2pgsql", "-O", "gazetteer", "--style", "tests/gazetteer-test.style", "tests/liechtenstein-2013-08-03.osm.pbf"};
     options = options_t(len(a2), const_cast<char **>(a2));
-    outs = output_t::create_outputs(mid.get(), options);
+    outs = output_t::create_outputs(mid, options);
     out = outs.front().get();
     if(dynamic_cast<output_gazetteer_t *>(out) == nullptr)
     {
@@ -103,7 +103,7 @@ void test_outputs()
 
     const char* a3[] = {"osm2pgsql", "-O", "null", "--style", "default.style", "tests/liechtenstein-2013-08-03.osm.pbf"};
     options = options_t(len(a3), const_cast<char **>(a3));
-    outs = output_t::create_outputs(mid.get(), options);
+    outs = output_t::create_outputs(mid, options);
     out = outs.front().get();
     if(dynamic_cast<output_null_t *>(out) == nullptr)
     {
@@ -114,7 +114,7 @@ void test_outputs()
     options = options_t(len(a4), const_cast<char **>(a4));
     try
     {
-        outs = output_t::create_outputs(mid.get(), options);
+        outs = output_t::create_outputs(mid, options);
         out = outs.front().get();
         throw std::logic_error("Expected 'not recognised'");
     }

--- a/tests/test-options-projection.cpp
+++ b/tests/test-options-projection.cpp
@@ -43,12 +43,9 @@ static void check_tables(pg::tempdb *db, options_t &options,
                         const std::string &expected)
 {
     options.database_options = db->database_options;
-    auto mid_ram = std::make_shared<middle_ram_t>();
-    auto out_test = std::make_shared<output_pgsql_t>(mid_ram.get(), options);
-    osmdata_t osmdata(mid_ram, out_test);
 
-    testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
-                   options, &osmdata);
+    testing::run_osm2pgsql<middle_ram_t>(
+        options, "tests/liechtenstein-2013-08-03.osm.pbf", "pbf");
 
     db->check_string(expected, "select find_srid('public', 'planet_osm_roads', 'way')");
 }

--- a/tests/test-output-multi-line-storage.cpp
+++ b/tests/test-output-multi-line-storage.cpp
@@ -44,17 +44,8 @@ int main(int argc, char *argv[]) {
         options.output_backend = "multi";
         options.style = "tests/test_output_multi_line_trivial.style.json";
 
-        //setup the middle
-        auto middle = std::make_shared<middle_pgsql_t>();
-
-        //setup the backend (output)
-        std::vector<std::shared_ptr<output_t> > outputs = output_t::create_outputs(middle.get(), options);
-
-        //let osmdata orchestrate between the middle and the outs
-        osmdata_t osmdata(middle, outputs);
-
-        testing::parse("tests/test_output_multi_line_storage.osm", "xml",
-                       options, &osmdata);
+        testing::run_osm2pgsql<middle_pgsql_t>(
+            options, "tests/test_output_multi_line_storage.osm", "xml");
 
         db->check_count(1, "select count(*) from pg_catalog.pg_class where relname = 'test_line'");
         db->check_count(3, "select count(*) from test_line");

--- a/tests/test-output-multi-point-multi-table.cpp
+++ b/tests/test-output-multi-point-multi-table.cpp
@@ -34,7 +34,6 @@ int main(int argc, char *argv[]) {
     }
 
     try {
-        std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
         options_t options;
         options.database_options = db->database_options;
         options.num_procs = 1;
@@ -42,8 +41,14 @@ int main(int argc, char *argv[]) {
         options.slim = true;
 
         export_list columns;
-        { taginfo info; info.name = "amenity"; info.type = "text"; columns.add(osmium::item_type::node, info); }
+        {
+            taginfo info;
+            info.name = "amenity";
+            info.type = "text";
+            columns.add(osmium::item_type::node, info);
+        }
 
+        auto mid_pgsql = std::make_shared<middle_pgsql_t>();
         std::vector<std::shared_ptr<output_t> > outputs;
 
         // let's make lots of tables!
@@ -53,12 +58,15 @@ int main(int argc, char *argv[]) {
             std::shared_ptr<geometry_processor> processor =
                 geometry_processor::create("point", &options);
 
-            auto out_test = std::make_shared<output_multi_t>(name, processor, columns, mid_pgsql.get(), options);
+            auto out_test = std::make_shared<output_multi_t>(
+                name, processor, columns,
+                std::static_pointer_cast<middle_query_t>(mid_pgsql), options);
 
             outputs.push_back(out_test);
         }
 
-        osmdata_t osmdata(mid_pgsql, outputs);
+        osmdata_t osmdata(std::static_pointer_cast<middle_t>(mid_pgsql),
+                          outputs);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-multi-point.cpp
+++ b/tests/test-output-multi-point.cpp
@@ -33,7 +33,6 @@ int main(int argc, char *argv[]) {
     }
 
     try {
-        std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
         options_t options;
         options.database_options = db->database_options;
         options.num_procs = 1;
@@ -44,11 +43,20 @@ int main(int argc, char *argv[]) {
             geometry_processor::create("point", &options);
 
         export_list columns;
-        { taginfo info; info.name = "amenity"; info.type = "text"; columns.add(osmium::item_type::node, info); }
+        {
+            taginfo info;
+            info.name = "amenity";
+            info.type = "text";
+            columns.add(osmium::item_type::node, info);
+        }
 
-        auto out_test = std::make_shared<output_multi_t>("foobar_amenities", processor, columns, mid_pgsql.get(), options);
+        auto mid_pgsql = std::make_shared<middle_pgsql_t>();
+        auto out_test = std::make_shared<output_multi_t>(
+            "foobar_amenities", processor, columns,
+            std::static_pointer_cast<middle_query_t>(mid_pgsql), options);
 
-        osmdata_t osmdata(mid_pgsql, out_test);
+        osmdata_t osmdata(std::static_pointer_cast<middle_t>(mid_pgsql),
+                          out_test);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-multi-poly-trivial.cpp
+++ b/tests/test-output-multi-poly-trivial.cpp
@@ -22,20 +22,6 @@
 #include "tests/common-pg.hpp"
 #include "tests/common.hpp"
 
-void run_osm2pgsql(options_t &options) {
-  //setup the middle
-  auto middle = std::make_shared<middle_pgsql_t>();
-
-  //setup the backend (output)
-  std::vector<std::shared_ptr<output_t> > outputs = output_t::create_outputs(middle.get(), options);
-
-  //let osmdata orchestrate between the middle and the outs
-  osmdata_t osmdata(middle, outputs);
-
-  testing::parse("tests/test_output_multi_poly_trivial.osm", "xml",
-                 options, &osmdata);
-}
-
 void check_output_poly_trivial(bool enable_multi, std::shared_ptr<pg::tempdb> db) {
   options_t options;
   options.database_options = db->database_options;
@@ -48,7 +34,8 @@ void check_output_poly_trivial(bool enable_multi, std::shared_ptr<pg::tempdb> db
   options.output_backend = "multi";
   options.style = "tests/test_output_multi_poly_trivial.style.json";
 
-  run_osm2pgsql(options);
+  testing::run_osm2pgsql<middle_pgsql_t>(
+      options, "tests/test_output_multi_poly_trivial.osm", "xml");
 
   // expect that the table exists
   db->check_count(1, "select count(*) from pg_catalog.pg_class where relname = 'test_poly'");

--- a/tests/test-output-multi-polygon.cpp
+++ b/tests/test-output-multi-polygon.cpp
@@ -34,7 +34,6 @@ int main(int argc, char *argv[]) {
     }
 
     try {
-        std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
         options_t options;
         options.database_options = db->database_options;
         options.num_procs = 1;
@@ -44,11 +43,20 @@ int main(int argc, char *argv[]) {
         std::shared_ptr<geometry_processor> processor = geometry_processor::create("polygon", &options);
 
         export_list columns;
-        { taginfo info; info.name = "building"; info.type = "text"; columns.add(osmium::item_type::way, info); }
+        {
+            taginfo info;
+            info.name = "building";
+            info.type = "text";
+            columns.add(osmium::item_type::way, info);
+        }
 
-        auto out_test = std::make_shared<output_multi_t>("foobar_buildings", processor, columns, mid_pgsql.get(), options);
+        auto mid_pgsql = std::make_shared<middle_pgsql_t>();
+        auto out_test = std::make_shared<output_multi_t>(
+            "foobar_buildings", processor, columns,
+            std::static_pointer_cast<middle_query_t>(mid_pgsql), options);
 
-        osmdata_t osmdata(mid_pgsql, out_test);
+        osmdata_t osmdata(std::static_pointer_cast<middle_t>(mid_pgsql),
+                          out_test);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-multi-tags.cpp
+++ b/tests/test-output-multi-tags.cpp
@@ -44,17 +44,8 @@ int main(int argc, char *argv[]) {
         options.output_backend = "multi";
         options.style = "tests/test_output_multi_tags.json";
 
-        //setup the middle
-        auto middle = std::make_shared<middle_pgsql_t>();
-
-        //setup the backend (output)
-        std::vector<std::shared_ptr<output_t> > outputs = output_t::create_outputs(middle.get(), options);
-
-        //let osmdata orchestrate between the middle and the outs
-        osmdata_t osmdata(middle, outputs);
-
-        testing::parse("tests/test_output_multi_tags.osm", "xml",
-                       options, &osmdata);
+        testing::run_osm2pgsql<middle_pgsql_t>(
+            options, "tests/test_output_multi_tags.osm", "xml");
 
         // Check we got the right tables
         db->check_count(1, "select count(*) from pg_catalog.pg_class where relname = 'test_points_1'");

--- a/tests/test-output-pgsql-area.cpp
+++ b/tests/test-output-pgsql-area.cpp
@@ -60,7 +60,6 @@ void test_area_base(bool latlon, bool reproj, double expect_area_poly, double ex
         exit(77);
     }
 
-    std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
     options_t options;
     options.database_options = db->database_options;
     options.num_procs = 1;
@@ -73,11 +72,8 @@ void test_area_base(bool latlon, bool reproj, double expect_area_poly, double ex
         options.reproject_area = true;
     }
 
-    auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
-
-    osmdata_t osmdata(mid_pgsql, out_test);
-    testing::parse("tests/test_output_pgsql_area.osm", "xml",
-                   options, &osmdata);
+    testing::run_osm2pgsql<middle_pgsql_t>(
+        options, "tests/test_output_pgsql_area.osm", "xml");
 
     db->check_count(2, "SELECT COUNT(*) FROM osm2pgsql_test_polygon");
     db->check_number(expect_area_poly, "SELECT way_area FROM osm2pgsql_test_polygon WHERE name='poly'");

--- a/tests/test-output-pgsql-schema.cpp
+++ b/tests/test-output-pgsql-schema.cpp
@@ -68,19 +68,14 @@ void test_other_output_schema() {
     std::string proc_name("test-output-pgsql-schema"), input_file("-");
     char *argv[] = { &proc_name[0], &input_file[0], nullptr };
 
-    std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
     options_t options = options_t(2, argv);
     options.database_options = db->database_options;
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";
     options.style = "default.style";
 
-    auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
-
-    osmdata_t osmdata(mid_pgsql, out_test);
-
-    testing::parse("tests/test_output_pgsql_z_order.osm", "xml",
-                   options, &osmdata);
+    testing::run_osm2pgsql<middle_pgsql_t>(
+        options, "tests/test_output_pgsql_z_order.osm", "xml");
 
     db->assert_has_table("public.osm2pgsql_test_point");
     db->assert_has_table("public.osm2pgsql_test_line");

--- a/tests/test-output-pgsql-tablespace.cpp
+++ b/tests/test-output-pgsql-tablespace.cpp
@@ -65,7 +65,6 @@ void test_regression_simple() {
     std::string proc_name("test-output-pgsql"), input_file("-");
     char *argv[] = { &proc_name[0], &input_file[0], nullptr };
 
-    std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
     options_t options = options_t(2, argv);
     options.database_options = db->database_options;
     options.num_procs = 1;
@@ -76,12 +75,8 @@ void test_regression_simple() {
     options.tblsslim_index = "tablespacetest";
     options.tblsslim_data = "tablespacetest";
 
-    auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
-
-    osmdata_t osmdata(mid_pgsql, out_test);
-
-    testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
-                   options, &osmdata);
+    testing::run_osm2pgsql<middle_pgsql_t>(
+        options, "tests/liechtenstein-2013-08-03.osm.pbf", "pbf");
 
     db->assert_has_table("osm2pgsql_test_point");
     db->assert_has_table("osm2pgsql_test_line");

--- a/tests/test-output-pgsql-validgeom.cpp
+++ b/tests/test-output-pgsql-validgeom.cpp
@@ -64,19 +64,14 @@ void test_z_order() {
     std::string proc_name("test-output-pgsql-validgeom"), input_file("-");
     char *argv[] = { &proc_name[0], &input_file[0], nullptr };
 
-    std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
     options_t options = options_t(2, argv);
     options.database_options = db->database_options;
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";
     options.style = "default.style";
 
-    auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
-
-    osmdata_t osmdata(mid_pgsql, out_test);
-
-    testing::parse("tests/test_output_pgsql_validgeom.osm", "xml",
-                   options, &osmdata);
+    testing::run_osm2pgsql<middle_pgsql_t>(
+        options, "tests/test_output_pgsql_validgeom.osm", "xml");
 
     db->assert_has_table("osm2pgsql_test_point");
     db->assert_has_table("osm2pgsql_test_line");

--- a/tests/test-output-pgsql-z_order.cpp
+++ b/tests/test-output-pgsql-z_order.cpp
@@ -64,19 +64,14 @@ void test_z_order() {
     std::string proc_name("test-output-pgsql-z_order"), input_file("-");
     char *argv[] = { &proc_name[0], &input_file[0], nullptr };
 
-    std::shared_ptr<middle_pgsql_t> mid_pgsql(new middle_pgsql_t());
     options_t options = options_t(2, argv);
     options.database_options = db->database_options;
     options.num_procs = 1;
     options.prefix = "osm2pgsql_test";
     options.style = "default.style";
 
-    auto out_test = std::make_shared<output_pgsql_t>(mid_pgsql.get(), options);
-
-    osmdata_t osmdata(mid_pgsql, out_test);
-
-    testing::parse("tests/test_output_pgsql_z_order.osm", "xml",
-                   options, &osmdata);
+    testing::run_osm2pgsql<middle_pgsql_t>(
+        options, "tests/test_output_pgsql_z_order.osm", "xml");
 
     db->assert_has_table("osm2pgsql_test_point");
     db->assert_has_table("osm2pgsql_test_line");

--- a/tests/test-parse-diff.cpp
+++ b/tests/test-parse-diff.cpp
@@ -35,9 +35,11 @@ struct test_output_t : public dummy_output_t {
 
     virtual ~test_output_t() = default;
 
-    std::shared_ptr<output_t> clone(const middle_query_t *cloned_middle) const override {
+    std::shared_ptr<output_t>
+    clone(std::shared_ptr<middle_query_t> const &mid) const override
+    {
         test_output_t *clone = new test_output_t(m_options);
-        clone->m_mid = cloned_middle;
+        clone->m_mid = mid;
         return std::shared_ptr<output_t>(clone);
     }
 

--- a/tests/test-parse-extra-args.cpp
+++ b/tests/test-parse-extra-args.cpp
@@ -39,10 +39,10 @@ struct test_output_t : public output_null_t
     virtual ~test_output_t() {}
 
     std::shared_ptr<output_t>
-    clone(const middle_query_t *cloned_middle) const override
+    clone(std::shared_ptr<middle_query_t> const &mid) const override
     {
         test_output_t *clone = new test_output_t(*this);
-        clone->m_mid = cloned_middle;
+        clone->m_mid = mid;
         return std::shared_ptr<output_t>(clone);
     }
 

--- a/tests/test-parse-xml2.cpp
+++ b/tests/test-parse-xml2.cpp
@@ -36,9 +36,11 @@ struct test_output_t : public output_null_t {
     virtual ~test_output_t() {
     }
 
-    std::shared_ptr<output_t> clone(const middle_query_t *cloned_middle) const override {
+    std::shared_ptr<output_t>
+    clone(std::shared_ptr<middle_query_t> const &mid) const override
+    {
         test_output_t *clone = new test_output_t(*this);
-        clone->m_mid = cloned_middle;
+        clone->m_mid = mid;
         return std::shared_ptr<output_t>(clone);
     }
 


### PR DESCRIPTION
The great refactoring continues. This PR binds the lifetime of the middle objects to the outputs. As a result it is no longer necessary to keep an explicit reference in osmdata when creating clones for threaded processing.

Once more required some more elaborate refactoring of the tests. There is now a new function `run_osm2pgsql()` that creates middle, output and parses a file.