### PR TITLE
Split pgsql middle into query and insertion class

### DIFF
--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -6,14 +6,8 @@
  * emit the final geometry-enabled output formats
 */
 
-#include "config.h"
-
 #ifdef _WIN32
 using namespace std;
-#endif
-
-#ifdef _MSC_VER
-#define alloca _alloca
 #endif
 
 #include <stdexcept>

--- a/middle-ram.cpp
+++ b/middle-ram.cpp
@@ -155,11 +155,7 @@ void middle_ram_t::analyze(void)
     /* No need */
 }
 
-void middle_ram_t::start(const options_t *options)
-{
-    extra_attributes = options->extra_attributes;
-    cache.reset(new node_ram_cache(options->alloc_chunkwise, options->cache));
-}
+void middle_ram_t::start() {}
 
 void middle_ram_t::stop(osmium::thread::Pool &pool)
 {
@@ -172,8 +168,10 @@ void middle_ram_t::stop(osmium::thread::Pool &pool)
 void middle_ram_t::commit(void) {
 }
 
-middle_ram_t::middle_ram_t():
-    ways(), rels(), cache(), simulate_ways_deleted(false)
+middle_ram_t::middle_ram_t(options_t const *options)
+: ways(), rels(),
+  cache(new node_ram_cache(options->alloc_chunkwise, options->cache)),
+  extra_attributes(options->extra_attributes), simulate_ways_deleted(false)
 {
 }
 

--- a/middle-ram.hpp
+++ b/middle-ram.hpp
@@ -82,10 +82,10 @@ public:
 
 struct middle_ram_t : public middle_t, public middle_query_t
 {
-    middle_ram_t();
+    middle_ram_t(options_t const *options);
     virtual ~middle_ram_t();
 
-    void start(const options_t *options) override;
+    void start() override;
     void stop(osmium::thread::Pool &pool) override;
     void analyze(void) override;
     void commit(void) override;

--- a/middle.hpp
+++ b/middle.hpp
@@ -17,8 +17,6 @@
 #include "osmtypes.hpp"
 #include "reprojection.hpp"
 
-struct options_t;
-
 /**
  * Infterface for returning information about raw OSM input data from a cache.
  */
@@ -84,7 +82,7 @@ struct middle_t
 {
     virtual ~middle_t() = 0;
 
-    virtual void start(options_t const *out_options) = 0;
+    virtual void start() = 0;
     virtual void stop(osmium::thread::Pool &pool) = 0;
     virtual void analyze(void) = 0;
     virtual void commit(void) = 0;

--- a/osm2pgsql.cpp
+++ b/osm2pgsql.cpp
@@ -56,20 +56,17 @@ int main(int argc, char *argv[])
 
         //setup the middle and backend (output)
         std::shared_ptr<middle_t> middle;
-        std::vector<std::shared_ptr<output_t>> outputs;
 
         if (options.slim) {
-            auto mid = std::make_shared<middle_pgsql_t>();
-            outputs = output_t::create_outputs(
-                std::static_pointer_cast<middle_query_t>(mid), options);
-            middle = std::static_pointer_cast<middle_t>(mid);
+            middle = std::shared_ptr<middle_t>(new middle_pgsql_t(&options));
         } else {
-            auto mid = std::make_shared<middle_ram_t>();
-            outputs = output_t::create_outputs(
-                std::static_pointer_cast<middle_query_t>(mid), options);
-            middle = std::static_pointer_cast<middle_t>(mid);
+            middle = std::shared_ptr<middle_t>(new middle_ram_t(&options));
         }
 
+        middle->start();
+
+        auto outputs = output_t::create_outputs(
+            middle->get_query_instance(middle), options);
         //let osmdata orchestrate between the middle and the outs
         osmdata_t osmdata(middle, outputs);
 

--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -171,7 +171,6 @@ void osmdata_t::start() {
     for (auto& out: outs) {
         out->start();
     }
-    mid->start(outs[0]->get_options());
 }
 
 void osmdata_t::type_changed(osmium::item_type new_type)

--- a/tests/common.hpp
+++ b/tests/common.hpp
@@ -22,14 +22,15 @@ namespace testing {
                        char const *file_format)
     {
         //setup the middle
-        auto middle = std::make_shared<MID>();
+        std::shared_ptr<middle_t> middle(new MID(&options));
+        middle->start();
 
         //setup the backend (output)
         auto outputs = output_t::create_outputs(
-            std::static_pointer_cast<middle_query_t>(middle), options);
+            middle->get_query_instance(middle), options);
 
         //let osmdata orchestrate between the middle and the outs
-        osmdata_t osmdata(std::static_pointer_cast<middle_t>(middle), outputs);
+        osmdata_t osmdata(middle, outputs);
 
         parse(test_file, file_format, options, &osmdata);
     }

--- a/tests/mockups.hpp
+++ b/tests/mockups.hpp
@@ -7,7 +7,7 @@
 struct dummy_middle_t : public middle_t {
     virtual ~dummy_middle_t() = default;
 
-    void start(const options_t *) override { }
+    void start() override {}
     void stop(osmium::thread::Pool &) override {}
     void flush(osmium::item_type) override {}
     void cleanup(void) { }
@@ -26,7 +26,7 @@ struct dummy_middle_t : public middle_t {
     virtual size_t pending_count() const override  { return 0; }
 
     std::shared_ptr<middle_query_t>
-    get_query_instance(std::shared_ptr<middle_t> const &mid) const override
+    get_query_instance(std::shared_ptr<middle_t> const &) const override
     {
         return std::shared_ptr<middle_query_t>();
     }
@@ -35,7 +35,7 @@ struct dummy_middle_t : public middle_t {
 struct dummy_slim_middle_t : public slim_middle_t {
     virtual ~dummy_slim_middle_t() = default;
 
-    void start(const options_t *) override  { }
+    void start() override {}
     void stop(osmium::thread::Pool &) override {}
     void flush(osmium::item_type) override {}
     void cleanup(void) { }
@@ -54,7 +54,7 @@ struct dummy_slim_middle_t : public slim_middle_t {
     size_t pending_count() const override  { return 0; }
 
     std::shared_ptr<middle_query_t>
-    get_query_instance(std::shared_ptr<middle_t> const &mid) const override
+    get_query_instance(std::shared_ptr<middle_t> const &) const override
     {
         return std::shared_ptr<middle_query_t>();
     }

--- a/tests/test-middle-flat.cpp
+++ b/tests/test-middle-flat.cpp
@@ -50,14 +50,16 @@ void run_tests(options_t options, const std::string cache_type) {
      without the complication of ways.
   */
   {
-      test_middle_helper<middle_pgsql_t> t(options);
-
-      t.commit_and_stop();
+      // First make sure we have an empty table.
+      { test_middle_helper<middle_pgsql_t> t(options); }
 
       // Switch to append mode because this tests updates
       options.append = true;
       options.create = false;
-      t.start(&options);
+
+      test_middle_helper<middle_pgsql_t> t(options);
+
+      t.commit();
 
       if (t.test_way_set() != 0) {
           throw std::runtime_error("test_way_set failed.");

--- a/tests/test-middle-pgsql.cpp
+++ b/tests/test-middle-pgsql.cpp
@@ -38,14 +38,16 @@ void run_tests(options_t options, const std::string cache_type) {
   }
 
   {
-      test_middle_helper<middle_pgsql_t> t(options);
+      // First make sure we have an empty table.
+      { test_middle_helper<middle_pgsql_t> t(options); }
 
-      t.commit_and_stop();
-
-      // Switch to append mode because this tests updates
+      // Then switch to append mode because this tests updates.
       options.append = true;
       options.create = false;
-      t.start(&options);
+
+      test_middle_helper<middle_pgsql_t> t(options);
+
+      t.commit();
 
       if (t.test_way_set() != 0) {
           throw std::runtime_error("test_way_set failed.");

--- a/tests/test-options-parse.cpp
+++ b/tests/test-options-parse.cpp
@@ -84,7 +84,8 @@ void test_outputs()
 {
     const char* a1[] = {"osm2pgsql", "-O", "pgsql", "--style", "default.style", "tests/liechtenstein-2013-08-03.osm.pbf"};
     options_t options = options_t(len(a1), const_cast<char **>(a1));
-    std::shared_ptr<middle_query_t> mid(new middle_ram_t());
+    auto middle_ram = std::make_shared<middle_ram_t>(&options);
+    auto mid = middle_ram->get_query_instance(middle_ram);
     auto outs = output_t::create_outputs(mid, options);
     output_t* out = outs.front().get();
     if(dynamic_cast<output_pgsql_t *>(out) == nullptr)

--- a/tests/test-output-multi-line.cpp
+++ b/tests/test-output-multi-line.cpp
@@ -50,14 +50,14 @@ int main(int argc, char *argv[]) {
             columns.add(osmium::item_type::way, info);
         }
 
-        auto mid_pgsql = std::make_shared<middle_pgsql_t>();
+        std::shared_ptr<middle_t> mid_pgsql(new middle_pgsql_t(&options));
+        mid_pgsql->start();
+        auto midq = mid_pgsql->get_query_instance(mid_pgsql);
         // This actually uses the multi-backend with C transforms, not Lua transforms. This is unusual and doesn't reflect real practice
         auto out_test = std::make_shared<output_multi_t>(
-            "foobar_highways", processor, columns,
-            std::static_pointer_cast<middle_query_t>(mid_pgsql), options);
+            "foobar_highways", processor, columns, midq, options);
 
-        osmdata_t osmdata(std::static_pointer_cast<middle_t>(mid_pgsql),
-                          out_test);
+        osmdata_t osmdata(mid_pgsql, out_test);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-multi-point-multi-table.cpp
+++ b/tests/test-output-multi-point-multi-table.cpp
@@ -48,7 +48,10 @@ int main(int argc, char *argv[]) {
             columns.add(osmium::item_type::node, info);
         }
 
-        auto mid_pgsql = std::make_shared<middle_pgsql_t>();
+        std::shared_ptr<middle_t> mid_pgsql(new middle_pgsql_t(&options));
+        mid_pgsql->start();
+        auto midq = mid_pgsql->get_query_instance(mid_pgsql);
+
         std::vector<std::shared_ptr<output_t> > outputs;
 
         // let's make lots of tables!
@@ -59,14 +62,12 @@ int main(int argc, char *argv[]) {
                 geometry_processor::create("point", &options);
 
             auto out_test = std::make_shared<output_multi_t>(
-                name, processor, columns,
-                std::static_pointer_cast<middle_query_t>(mid_pgsql), options);
+                name, processor, columns, midq, options);
 
             outputs.push_back(out_test);
         }
 
-        osmdata_t osmdata(std::static_pointer_cast<middle_t>(mid_pgsql),
-                          outputs);
+        osmdata_t osmdata(mid_pgsql, outputs);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-multi-point.cpp
+++ b/tests/test-output-multi-point.cpp
@@ -50,13 +50,14 @@ int main(int argc, char *argv[]) {
             columns.add(osmium::item_type::node, info);
         }
 
-        auto mid_pgsql = std::make_shared<middle_pgsql_t>();
-        auto out_test = std::make_shared<output_multi_t>(
-            "foobar_amenities", processor, columns,
-            std::static_pointer_cast<middle_query_t>(mid_pgsql), options);
+        std::shared_ptr<middle_t> mid_pgsql(new middle_pgsql_t(&options));
+        mid_pgsql->start();
+        auto midq = mid_pgsql->get_query_instance(mid_pgsql);
 
-        osmdata_t osmdata(std::static_pointer_cast<middle_t>(mid_pgsql),
-                          out_test);
+        auto out_test = std::make_shared<output_multi_t>(
+            "foobar_amenities", processor, columns, midq, options);
+
+        osmdata_t osmdata(mid_pgsql, out_test);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-multi-polygon.cpp
+++ b/tests/test-output-multi-polygon.cpp
@@ -50,13 +50,14 @@ int main(int argc, char *argv[]) {
             columns.add(osmium::item_type::way, info);
         }
 
-        auto mid_pgsql = std::make_shared<middle_pgsql_t>();
-        auto out_test = std::make_shared<output_multi_t>(
-            "foobar_buildings", processor, columns,
-            std::static_pointer_cast<middle_query_t>(mid_pgsql), options);
+        std::shared_ptr<middle_t> mid_pgsql(new middle_pgsql_t(&options));
+        mid_pgsql->start();
+        auto midq = mid_pgsql->get_query_instance(mid_pgsql);
 
-        osmdata_t osmdata(std::static_pointer_cast<middle_t>(mid_pgsql),
-                          out_test);
+        auto out_test = std::make_shared<output_multi_t>(
+            "foobar_buildings", processor, columns, midq, options);
+
+        osmdata_t osmdata(mid_pgsql, out_test);
 
         testing::parse("tests/liechtenstein-2013-08-03.osm.pbf", "pbf",
                        options, &osmdata);

--- a/tests/test-output-pgsql.cpp
+++ b/tests/test-output-pgsql.cpp
@@ -238,14 +238,12 @@ void test_clone() {
     options.slim = true;
     options.style = "default.style";
 
-    auto mid_pgsql = std::make_shared<middle_pgsql_t>();
-    output_pgsql_t out_test(std::static_pointer_cast<middle_query_t>(mid_pgsql),
-                            options);
+    auto mid_pgsql = std::make_shared<middle_pgsql_t>(&options);
+    mid_pgsql->start();
+    output_pgsql_t out_test(mid_pgsql->get_query_instance(mid_pgsql), options);
 
-    //TODO: make the middle testable too
-    //std::shared_ptr<middle_t> mid_clone = mid_pgsql->get_instance();
     std::shared_ptr<output_t> out_clone =
-        out_test.clone(std::static_pointer_cast<middle_query_t>(mid_pgsql));
+        out_test.clone(mid_pgsql->get_query_instance(mid_pgsql));
 
     osmdata_t osmdata(std::static_pointer_cast<middle_t>(mid_pgsql), out_clone);
 


### PR DESCRIPTION
This PR changes middle-pgsql to have separate implementations for middle_query_t and middle_slim_t. The main advantage of this setup is that the query class is much more lightweight and opens only one connection to the database. This means that we save 2*num_thread connections in the processing phase (improves on #885).

Given that output now also receive a middle_pgsql_query instance, some structural changes were necessary:
* Tables need to be created before the query instance is created because of prepared queries. They are set up during construction of the query instance and that requires that the table the prepared query references has already been created. Therefore middle::start() has been moved to osm2pgsql.cpp and is now done before output are set up.
* As the data is queried on a different connection, the inserted data needs to be committed in time. There is now an additional commit when switching OSM types during the import phase using the flush() function introduced a couple of PRs ago.

Only small adaptions of the tests this time. In particular adding missing flush() where appropriate.