### PR TITLE
Skip processing stage entirely when no objects are pending

### DIFF
--- a/osmdata.cpp
+++ b/osmdata.cpp
@@ -422,7 +422,13 @@ void osmdata_t::stop() {
     // should be the same for all outputs
     auto *opts = outs[0]->get_options();
 
-    {
+    // are there any objects left pending?
+    bool has_pending = mid->pending_count() > 0;
+    for (auto const &out : outs) {
+        has_pending |= out->pending_count() > 0;
+    }
+
+    if (has_pending) {
         //threaded pending processing
         pending_threaded_processor ptp(mid, outs, opts->num_procs,
                                        opts->append);


### PR DESCRIPTION
The processing stage opens quite a few connections to the database. This can be avoided when no objects are pending (i.e. when importing).

Improves on #885 and also happens to reduce the time for running the tests by 50%.