### PR TITLE
Add support for --extra-attributes to Gazetteer output

### DIFF
--- a/db-copy.hpp
+++ b/db-copy.hpp
@@ -291,6 +291,41 @@ public:
     }
 
     /**
+     * Add a key/value pair to a hash column without escaping.
+     *
+     * Key and value must be strings and will NOT be appropriately escaped.
+     * A separator for the next pair is added at the end.
+     */
+    void add_hash_elem_noescape(char const *k, char const *v)
+    {
+        m_current->buffer += '"';
+        m_current->buffer += k;
+        m_current->buffer += "\"=>\"";
+        m_current->buffer += v;
+        m_current->buffer += "\",";
+    }
+
+    /**
+     * Add a key (unescaped) and a numeric value to a hash column.
+     *
+     * Key must be string and come from a safe source because it will NOT be
+     * escaped! The value should be convertible using std::to_string.
+     * A separator for the next pair is added at the end.
+     *
+     * This method is suitable to insert safe input, e.g. numeric OSM metadata
+     * (eg. uid) but not unsafe input like user names.
+     */
+    template <typename T>
+    void add_hstore_num_noescape(char const *k, T const value)
+    {
+        m_current->buffer += '"';
+        m_current->buffer += k;
+        m_current->buffer += "\"=>\"";
+        m_current->buffer += std::to_string(value);
+        m_current->buffer += "\",";
+    }
+
+    /**
      * Close a hash previously started with new_hash().
      *
      * The hash may be empty. If elements were present, the separator

--- a/gazetteer-style.cpp
+++ b/gazetteer-style.cpp
@@ -128,8 +128,7 @@ gazetteer_style_t::flag_t gazetteer_style_t::parse_flags(std::string const &str)
     return out;
 }
 
-bool gazetteer_style_t::add_metadata_style_entry(std::string const &key,
-                                                 std::string const &value)
+bool gazetteer_style_t::add_metadata_style_entry(std::string const &key)
 {
     if (key == "osm_version") {
         m_metadata_fields.set_version(true);
@@ -190,10 +189,15 @@ void gazetteer_style_t::add_style_entry(std::string const &key,
         }
     }
 
-    if (add_metadata_style_entry(key, value)) {
+    if (add_metadata_style_entry(key)) {
         if (!value.empty()) {
             throw std::runtime_error("Style error. Rules for OSM metadata "
                                      "attributes must have an empty value.\n");
+        }
+        if (flags != SF_EXTRA) {
+            throw std::runtime_error("Style error. Rules for OSM metadata "
+                                     "attributes must have the style flag "
+                                     "\"extra\" and no other flag.\n");
         }
         return;
     }

--- a/gazetteer-style.hpp
+++ b/gazetteer-style.hpp
@@ -14,6 +14,7 @@ class gazetteer_style_t
 {
     using flag_t = uint16_t;
     using ptag_t = std::pair<char const *, char const *>;
+    using ptag_str_t = std::pair<const std::string, const std::string>;
     using pmaintag_t = std::tuple<char const *, char const *, flag_t>;
 
     enum style_flags
@@ -66,11 +67,17 @@ public:
 
     bool has_data() const { return !m_main.empty(); }
 
+    void set_metadata(const bool enabled);
+
 private:
     void add_style_entry(std::string const &key, std::string const &value,
                          flag_t flags);
     flag_t parse_flags(std::string const &str);
     flag_t find_flag(char const *k, char const *v) const;
+    void add_metadata_field(const std::string&& field, const std::string&& value);
+
+    template <typename T>
+    void add_metadata_field_num(const std::string&& field, const T value);
     bool copy_out_maintag(pmaintag_t const &tag, osmium::OSMObject const &o,
                           std::string const &geom, db_copy_mgr_t &buffer);
     void clear();
@@ -88,6 +95,8 @@ private:
     std::vector<ptag_t> m_names;
     /// extratags to include
     std::vector<ptag_t> m_extra;
+    /// metadata fields to include
+    std::vector<ptag_str_t> m_metadata;
     /// addresstags to include
     std::vector<ptag_t> m_address;
     /// value of operator tag
@@ -96,6 +105,11 @@ private:
     int m_admin_level;
     /// True if there is an actual name to the object (not a ref).
     bool m_is_named;
+
+    /// enable writing of metadata as tags (osm_version, osm_timestamp, osm_uid, osm_user, osm_changeset)
+    bool m_metadata_enabled {false};
+
+    boost::format m_single_fmt{"%1%\t"};
 };
 
 #endif

--- a/gazetteer-style.hpp
+++ b/gazetteer-style.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include <boost/format.hpp>
+#include <osmium/osm/metadata_options.hpp>
 
 #include "db-copy.hpp"
 
@@ -14,7 +15,6 @@ class gazetteer_style_t
 {
     using flag_t = uint16_t;
     using ptag_t = std::pair<char const *, char const *>;
-    using ptag_str_t = std::pair<const std::string, const std::string>;
     using pmaintag_t = std::tuple<char const *, char const *, flag_t>;
 
     enum style_flags
@@ -67,17 +67,14 @@ public:
 
     bool has_data() const { return !m_main.empty(); }
 
-    void set_metadata(const bool enabled);
-
 private:
+    bool add_metadata_style_entry(std::string const &key,
+                                  std::string const &value);
     void add_style_entry(std::string const &key, std::string const &value,
                          flag_t flags);
     flag_t parse_flags(std::string const &str);
     flag_t find_flag(char const *k, char const *v) const;
-    void add_metadata_field(const std::string&& field, const std::string&& value);
 
-    template <typename T>
-    void add_metadata_field_num(const std::string&& field, const T value);
     bool copy_out_maintag(pmaintag_t const &tag, osmium::OSMObject const &o,
                           std::string const &geom, db_copy_mgr_t &buffer);
     void clear();
@@ -95,8 +92,6 @@ private:
     std::vector<ptag_t> m_names;
     /// extratags to include
     std::vector<ptag_t> m_extra;
-    /// metadata fields to include
-    std::vector<ptag_str_t> m_metadata;
     /// addresstags to include
     std::vector<ptag_t> m_address;
     /// value of operator tag
@@ -106,8 +101,8 @@ private:
     /// True if there is an actual name to the object (not a ref).
     bool m_is_named;
 
-    /// enable writing of metadata as tags (osm_version, osm_timestamp, osm_uid, osm_user, osm_changeset)
-    bool m_metadata_enabled {false};
+    /// which metadata fields of the OSM objects should be written to the output
+    osmium::metadata_options m_metadata_fields{"none"};
 
     boost::format m_single_fmt{"%1%\t"};
 };

--- a/gazetteer-style.hpp
+++ b/gazetteer-style.hpp
@@ -68,8 +68,7 @@ public:
     bool has_data() const { return !m_main.empty(); }
 
 private:
-    bool add_metadata_style_entry(std::string const &key,
-                                  std::string const &value);
+    bool add_metadata_style_entry(std::string const &key);
     void add_style_entry(std::string const &key, std::string const &value,
                          flag_t flags);
     flag_t parse_flags(std::string const &str);

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -38,7 +38,6 @@ public:
       osmium_buffer(PLACE_BUFFER_SIZE, osmium::memory::Buffer::auto_grow::yes)
     {
         m_style.load_style(options.style);
-        m_style.set_metadata(options.extra_attributes);
     }
 
     virtual ~output_gazetteer_t();

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -15,6 +15,7 @@
 #include "pgsql.hpp"
 #include "util.hpp"
 
+
 class output_gazetteer_t : public output_t
 {
     output_gazetteer_t(output_gazetteer_t const *other,
@@ -37,6 +38,7 @@ public:
       osmium_buffer(PLACE_BUFFER_SIZE, osmium::memory::Buffer::auto_grow::yes)
     {
         m_style.load_style(options.style);
+        m_style.set_metadata(options.extra_attributes);
     }
 
     virtual ~output_gazetteer_t();


### PR DESCRIPTION
`--extra-attributes` is now supported by Gazetteer output. This pull requests writes all metadata fields to as to the `extratags` column.

If an OSM object lacks a metadata field (empty string or 0 as value) which is/will be common with usual OSM planet dumps and extracts, the field will not be written to the output.

Users can control whether they want all metadata fields or only specific ones. If the Nominatim style file (the new one, see #1277) contains a catch-all rule at the end, that catch-all rule will apply on all available metadata fields and they will be written to the `places` table. If one or many of the metadata fields are mentioned in an `extra` rule and no catch-all rule is present, only that field will be written.

**Example 1: write all tags and all metadata fields to the `extratags` column**

Append this to your style file:

```json
{
    "keys" : [""],
    "values" : {
        "" : "extra"
    }
}
```

**Example 2: write all metadata fields to the `extratags` column**

Append this to your style file:

```json
{
    "keys" : ["osm_version", "osm_timestamp", "osm_user", "osm_uid", "osm_changeset"],
    "values" : {
        "" : "extra"
    }
}
```

**Example 3: write timestamps to the `extratags` column**

Append this to your style file:

```json
{
    "keys" : ["osm_timestamp"],
    "values" : {
        "" : "extra"
    }
}
```