### PR TITLE
Fix various unused parameter issues and enable -Wextra on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,14 +57,14 @@ matrix:
     - os: linux
       compiler: "clang-3.8"
       env: T="clang38_pg92_dbtest" LUAJIT_OPTION="OFF"
-           CXXFLAGS="-pedantic -Werror"
+           CXXFLAGS="-pedantic -Wextra -Werror"
            CC=clang-3.8 CXX=clang++-3.8
       addons: *clang38_pg92
 
     - os: linux
       compiler: "clang-7"
       env: T="clang7_pg96_dbtest_luajit" LUAJIT_OPTION="ON"
-           CXXFLAGS="-pedantic -Werror"
+           CXXFLAGS="-pedantic -Wextra -Werror"
            CC=clang-7 CXX=clang++-7
       addons: *clang7_pg96
 
@@ -72,7 +72,7 @@ matrix:
     - os: osx
       compiler: clang
       env: T="osx_clang_NoDB" LUAJIT_OPTION="OFF" TEST_NODB=1
-           CXXFLAGS="-pedantic -Werror"
+           CXXFLAGS="-pedantic -Wextra -Werror"
       before_install:
         - brew install lua; brew install lua
       before_script:
@@ -84,14 +84,14 @@ matrix:
     - os: linux
       compiler: "gcc-4.8"
       env: T="gcc48_pg96_dbtest" LUAJIT_OPTION="OFF"
-           CXXFLAGS="-pedantic -Werror"
+           CXXFLAGS="-pedantic -Wextra -Werror"
            CC=gcc-4.8 CXX=g++-4.8
       addons: *gcc48_pg96
 
     - os: linux
       compiler: gcc-8
       env: T="gcc8_pg96_dbtest_luajit" LUAJIT_OPTION="ON"
-           CXXFLAGS="-pedantic -Werror"
+           CXXFLAGS="-pedantic -Wextra -Werror"
            CC=gcc-8 CXX=g++-8
       addons: *gcc8_pg96
 

--- a/middle-ram.cpp
+++ b/middle-ram.cpp
@@ -157,7 +157,7 @@ void middle_ram_t::analyze(void)
 
 void middle_ram_t::start() {}
 
-void middle_ram_t::stop(osmium::thread::Pool &pool)
+void middle_ram_t::stop(osmium::thread::Pool &)
 {
     cache.reset(nullptr);
 

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -172,7 +172,7 @@ int output_multi_t::pending_relation(osmid_t id, int exists) {
     buffer.clear();
     if (m_mid->relations_get(id, buffer)) {
         auto const &rel = buffer.get<osmium::Relation>(0);
-        ret = process_relation(rel, exists, true);
+        ret = process_relation(rel, exists);
     }
 
     return ret;
@@ -350,9 +350,7 @@ int output_multi_t::process_way(osmium::Way *way) {
     return 0;
 }
 
-
-int output_multi_t::process_relation(osmium::Relation const &rel,
-                                     bool exists, bool pending)
+int output_multi_t::process_relation(osmium::Relation const &rel, bool exists)
 {
     //if it may exist already, delete it first
     if(exists)

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -72,7 +72,7 @@ protected:
     int process_node(osmium::Node const &node);
     int process_way(osmium::Way *way);
     int reprocess_way(osmium::Way *way, bool exists);
-    int process_relation(osmium::Relation const &rel, bool exists, bool pending=false);
+    int process_relation(osmium::Relation const &rel, bool exists);
     void copy_node_to_table(osmid_t id, const std::string &geom, taglist_t &tags);
     void copy_to_table(const osmid_t id, geometry_processor::wkb_t const &geom,
                        taglist_t &tags);

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -226,7 +226,7 @@ int output_pgsql_t::pending_relation(osmid_t id, int exists) {
         }
 
         auto const &rel = rels_buffer.get<osmium::Relation>(0);
-        return pgsql_process_relation(rel, true);
+        return pgsql_process_relation(rel);
     }
 
     return 0;
@@ -288,8 +288,7 @@ int output_pgsql_t::way_add(osmium::Way *way)
 
 
 /* This is the workhorse of pgsql_add_relation, split out because it is used as the callback for iterate relations */
-int output_pgsql_t::pgsql_process_relation(osmium::Relation const &rel,
-                                           bool pending)
+int output_pgsql_t::pgsql_process_relation(osmium::Relation const &rel)
 {
     taglist_t prefiltered_tags;
     if (m_tagtransform->filter_tags(rel, nullptr, nullptr, *m_export_list.get(),
@@ -381,7 +380,7 @@ int output_pgsql_t::relation_add(osmium::Relation const &rel)
         return 0;
     }
 
-    return pgsql_process_relation(rel, false);
+    return pgsql_process_relation(rel);
 }
 
 /* Delete is easy, just remove all traces of this object. We don't need to

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -62,7 +62,7 @@ public:
 protected:
     void pgsql_out_way(osmium::Way const &way, taglist_t *tags, bool polygon,
                        bool roads);
-    int pgsql_process_relation(osmium::Relation const &rel, bool pending);
+    int pgsql_process_relation(osmium::Relation const &rel);
     int pgsql_delete_way_from_output(osmid_t osm_id);
     int pgsql_delete_relation_from_output(osmid_t osm_id);
 

--- a/tagtransform-c.cpp
+++ b/tagtransform-c.cpp
@@ -204,10 +204,9 @@ bool c_tagtransform_t::filter_tags(osmium::OSMObject const &o, int *polygon,
 }
 
 bool c_tagtransform_t::filter_rel_member_tags(
-    taglist_t const &rel_tags, osmium::memory::Buffer const &members,
-    rolelist_t const &member_roles, int *make_boundary, int *make_polygon,
-    int *roads, export_list const &exlist, taglist_t &out_tags,
-    bool allow_typeless)
+    taglist_t const &rel_tags, osmium::memory::Buffer const &,
+    rolelist_t const &, int *make_boundary, int *make_polygon, int *roads,
+    export_list const &, taglist_t &out_tags, bool allow_typeless)
 {
     //if it has a relation figure out what kind it is
     const std::string *type = rel_tags.get("type");

--- a/tests/test-expire-tiles.cpp
+++ b/tests/test-expire-tiles.cpp
@@ -442,6 +442,8 @@ void test_expire_merge_complete() {
 
 int main(int argc, char *argv[])
 {
+    (void)argc;
+    (void)argv;
     srand(0);
 
     //try each test if any fail we will exit

--- a/tests/test-hstore-match-only.cpp
+++ b/tests/test-hstore-match-only.cpp
@@ -32,6 +32,8 @@ The tags of inteest are specified in hstore-match-only.style
 #include "tests/common-pg.hpp"
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     std::unique_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-middle-flat.cpp
+++ b/tests/test-middle-flat.cpp
@@ -23,54 +23,59 @@
 
 /* This is basically the same as test-middle-pgsql, but with flat nodes. */
 
-void run_tests(options_t options, const std::string cache_type) {
-  options.append = false;
-  options.create = true;
-  options.flat_node_cache_enabled = true;
-  // flat nodes truncates the file each time it's started, so we can reuse the same file
-  options.flat_node_file = boost::optional<std::string>(FLAT_NODES_FILE_NAME);
+void run_tests(options_t options)
+{
+    options.append = false;
+    options.create = true;
+    options.flat_node_cache_enabled = true;
+    // flat nodes truncates the file each time it's started, so we can reuse the same file
+    options.flat_node_file = boost::optional<std::string>(FLAT_NODES_FILE_NAME);
 
-  {
-      test_middle_helper<middle_pgsql_t> t(options);
+    {
+        test_middle_helper<middle_pgsql_t> t(options);
 
-      if (t.test_node_set() != 0) {
-          throw std::runtime_error("test_node_set failed.");
-      }
-  }
+        if (t.test_node_set() != 0) {
+            throw std::runtime_error("test_node_set failed.");
+        }
+    }
 
-  {
-      test_middle_helper<middle_pgsql_t> t(options);
+    {
+        test_middle_helper<middle_pgsql_t> t(options);
 
-      if (t.test_nodes_comprehensive_set() != 0) {
-          throw std::runtime_error("test_nodes_comprehensive_set failed.");
-      }
-  }
+        if (t.test_nodes_comprehensive_set() != 0) {
+            throw std::runtime_error("test_nodes_comprehensive_set failed.");
+        }
+    }
 
-  /* This should work, but doesn't. More tests are needed that look at updates
+    /* This should work, but doesn't. More tests are needed that look at updates
      without the complication of ways.
   */
-  {
-      // First make sure we have an empty table.
-      { test_middle_helper<middle_pgsql_t> t(options); }
+    {
+        // First make sure we have an empty table.
+        {
+            test_middle_helper<middle_pgsql_t> t(options);
+        }
 
-      // Switch to append mode because this tests updates
-      options.append = true;
-      options.create = false;
+        // Switch to append mode because this tests updates
+        options.append = true;
+        options.create = false;
 
-      test_middle_helper<middle_pgsql_t> t(options);
+        test_middle_helper<middle_pgsql_t> t(options);
 
-      t.commit();
+        t.commit();
 
-      if (t.test_way_set() != 0) {
-          throw std::runtime_error("test_way_set failed.");
-      }
-  }
+        if (t.test_way_set() != 0) {
+            throw std::runtime_error("test_way_set failed.");
+        }
+    }
 }
 int main(int argc, char *argv[]) {
-  std::unique_ptr<pg::tempdb> db;
+    (void)argc;
+    (void)argv;
+    std::unique_ptr<pg::tempdb> db;
 
-  try {
-    db.reset(new pg::tempdb);
+    try {
+        db.reset(new pg::tempdb);
   } catch (const std::exception &e) {
     std::cerr << "Unable to setup database: " << e.what() << "\n";
     return 77; // <-- code to skip this test.
@@ -89,15 +94,15 @@ int main(int argc, char *argv[]) {
     cleanup::file flat_nodes_file(FLAT_NODES_FILE_NAME);
 
     options.alloc_chunkwise = ALLOC_SPARSE | ALLOC_DENSE; // what you get with optimized
-    run_tests(options, "optimized");
+    run_tests(options);
     options.alloc_chunkwise = ALLOC_SPARSE;
-    run_tests(options, "sparse");
+    run_tests(options);
 
     options.alloc_chunkwise = ALLOC_DENSE;
-    run_tests(options, "dense");
+    run_tests(options);
 
     options.alloc_chunkwise = ALLOC_DENSE | ALLOC_DENSE_CHUNK; // what you get with chunk
-    run_tests(options, "chunk");
+    run_tests(options);
 
   } catch (const std::exception &e) {
     std::cerr << "ERROR: " << e.what() << std::endl;

--- a/tests/test-middle-pgsql.cpp
+++ b/tests/test-middle-pgsql.cpp
@@ -18,47 +18,52 @@
 #include "tests/middle-tests.hpp"
 #include "tests/common-pg.hpp"
 
-void run_tests(options_t options, const std::string cache_type) {
-  options.append = false;
-  options.create = true;
-  {
-      test_middle_helper<middle_pgsql_t> t(options);
+static void run_tests(options_t options)
+{
+    options.append = false;
+    options.create = true;
+    {
+        test_middle_helper<middle_pgsql_t> t(options);
 
-      if (t.test_node_set() != 0) {
-          throw std::runtime_error("test_node_set failed.");
-      }
-  }
+        if (t.test_node_set() != 0) {
+            throw std::runtime_error("test_node_set failed.");
+        }
+    }
 
-  {
-      test_middle_helper<middle_pgsql_t> t(options);
+    {
+        test_middle_helper<middle_pgsql_t> t(options);
 
-      if (t.test_nodes_comprehensive_set() != 0) {
-          throw std::runtime_error("test_nodes_comprehensive_set failed.");
-      }
-  }
+        if (t.test_nodes_comprehensive_set() != 0) {
+            throw std::runtime_error("test_nodes_comprehensive_set failed.");
+        }
+    }
 
-  {
-      // First make sure we have an empty table.
-      { test_middle_helper<middle_pgsql_t> t(options); }
+    {
+        // First make sure we have an empty table.
+        {
+            test_middle_helper<middle_pgsql_t> t(options);
+        }
 
-      // Then switch to append mode because this tests updates.
-      options.append = true;
-      options.create = false;
+        // Then switch to append mode because this tests updates.
+        options.append = true;
+        options.create = false;
 
-      test_middle_helper<middle_pgsql_t> t(options);
+        test_middle_helper<middle_pgsql_t> t(options);
 
-      t.commit();
+        t.commit();
 
-      if (t.test_way_set() != 0) {
-          throw std::runtime_error("test_way_set failed.");
-      }
-  }
+        if (t.test_way_set() != 0) {
+            throw std::runtime_error("test_way_set failed.");
+        }
+    }
 }
 int main(int argc, char *argv[]) {
-  std::unique_ptr<pg::tempdb> db;
+    (void)argc;
+    (void)argv;
+    std::unique_ptr<pg::tempdb> db;
 
-  try {
-    db.reset(new pg::tempdb);
+    try {
+        db.reset(new pg::tempdb);
   } catch (const std::exception &e) {
     std::cerr << "Unable to setup database: " << e.what() << "\n";
     return 77; // <-- code to skip this test.
@@ -73,15 +78,15 @@ int main(int argc, char *argv[]) {
     options.slim = true;
 
     options.alloc_chunkwise = ALLOC_SPARSE | ALLOC_DENSE; // what you get with optimized
-    run_tests(options, "optimized");
+    run_tests(options);
     options.alloc_chunkwise = ALLOC_SPARSE;
-    run_tests(options, "sparse");
+    run_tests(options);
 
     options.alloc_chunkwise = ALLOC_DENSE;
-    run_tests(options, "dense");
+    run_tests(options);
 
     options.alloc_chunkwise = ALLOC_DENSE | ALLOC_DENSE_CHUNK; // what you get with chunk
-    run_tests(options, "chunk");
+    run_tests(options);
   } catch (const std::exception &e) {
     std::cerr << "ERROR: " << e.what() << std::endl;
     return 1;

--- a/tests/test-middle-ram.cpp
+++ b/tests/test-middle-ram.cpp
@@ -44,21 +44,25 @@ void run_tests(const options_t options, const std::string cache_type)
 }
 
 int main(int argc, char *argv[]) {
-  try {
-    options_t options;
-    options.cache = 1; // Non-zero cache is needed to test
+    (void)argc;
+    (void)argv;
+    try {
+        options_t options;
+        options.cache = 1; // Non-zero cache is needed to test
 
-    options.alloc_chunkwise = ALLOC_SPARSE | ALLOC_DENSE; // what you get with optimized
-    run_tests(options, "optimized");
+        options.alloc_chunkwise =
+            ALLOC_SPARSE | ALLOC_DENSE; // what you get with optimized
+        run_tests(options, "optimized");
 
-    options.alloc_chunkwise = ALLOC_SPARSE;
-    run_tests(options, "sparse");
+        options.alloc_chunkwise = ALLOC_SPARSE;
+        run_tests(options, "sparse");
 
-    options.alloc_chunkwise = ALLOC_DENSE;
-    run_tests(options, "dense");
+        options.alloc_chunkwise = ALLOC_DENSE;
+        run_tests(options, "dense");
 
-    options.alloc_chunkwise = ALLOC_DENSE | ALLOC_DENSE_CHUNK; // what you get with chunk
-    run_tests(options, "chunk");
+        options.alloc_chunkwise =
+            ALLOC_DENSE | ALLOC_DENSE_CHUNK; // what you get with chunk
+        run_tests(options, "chunk");
   } catch (const std::exception &e) {
     std::cerr << "ERROR: " << e.what() << std::endl;
     return 1;

--- a/tests/test-options-database.cpp
+++ b/tests/test-options-database.cpp
@@ -81,6 +81,8 @@ void test_conninfo() {
 } // anonymous namespace
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     RUN_TEST(test_conninfo);
 
     return 0;

--- a/tests/test-output-multi-line-storage.cpp
+++ b/tests/test-output-multi-line-storage.cpp
@@ -24,6 +24,8 @@
 #include "tests/common.hpp"
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     std::unique_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-output-multi-line.cpp
+++ b/tests/test-output-multi-line.cpp
@@ -24,6 +24,8 @@
 #include "tests/common.hpp"
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     std::unique_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-output-multi-point-multi-table.cpp
+++ b/tests/test-output-multi-point-multi-table.cpp
@@ -24,6 +24,8 @@
 #include "tests/common.hpp"
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     std::unique_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-output-multi-point.cpp
+++ b/tests/test-output-multi-point.cpp
@@ -23,6 +23,8 @@
 #include "tests/common.hpp"
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     std::unique_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-output-multi-poly-trivial.cpp
+++ b/tests/test-output-multi-poly-trivial.cpp
@@ -64,6 +64,8 @@ void check_output_poly_trivial(bool enable_multi, std::shared_ptr<pg::tempdb> db
 }
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     std::shared_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-output-multi-polygon.cpp
+++ b/tests/test-output-multi-polygon.cpp
@@ -24,6 +24,8 @@
 #include "tests/common.hpp"
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     std::unique_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-output-multi-tags.cpp
+++ b/tests/test-output-multi-tags.cpp
@@ -24,6 +24,8 @@
 #include "tests/common.hpp"
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     std::unique_ptr<pg::tempdb> db;
 
     try {

--- a/tests/test-output-pgsql-area.cpp
+++ b/tests/test-output-pgsql-area.cpp
@@ -95,6 +95,8 @@ void test_area_latlon_with_reprojection() {
 }
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     RUN_TEST(test_area_latlon);
     RUN_TEST(test_area_classic);
     RUN_TEST(test_area_latlon_with_reprojection);

--- a/tests/test-output-pgsql-schema.cpp
+++ b/tests/test-output-pgsql-schema.cpp
@@ -99,6 +99,8 @@ void test_other_output_schema() {
 } // anonymous namespace
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     RUN_TEST(test_other_output_schema);
 
     return 0;

--- a/tests/test-output-pgsql-tablespace.cpp
+++ b/tests/test-output-pgsql-tablespace.cpp
@@ -92,6 +92,8 @@ void test_regression_simple() {
 } // anonymous namespace
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     RUN_TEST(test_regression_simple);
 
     return 0;

--- a/tests/test-output-pgsql-validgeom.cpp
+++ b/tests/test-output-pgsql-validgeom.cpp
@@ -86,6 +86,8 @@ void test_z_order() {
 } // anonymous namespace
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     RUN_TEST(test_z_order);
 
     return 0;

--- a/tests/test-output-pgsql-z_order.cpp
+++ b/tests/test-output-pgsql-z_order.cpp
@@ -90,6 +90,8 @@ void test_z_order() {
 } // anonymous namespace
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     RUN_TEST(test_z_order);
 
     return 0;

--- a/tests/test-output-pgsql.cpp
+++ b/tests/test-output-pgsql.cpp
@@ -264,6 +264,8 @@ void test_clone() {
 } // anonymous namespace
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     // remove flat nodes file  on exit - it's 20GB and bad manners to
     // leave that lying around on the filesystem.
     cleanup::file flat_nodes_file(FLAT_NODES_FILE_NAME);

--- a/tests/test-parse-diff.cpp
+++ b/tests/test-parse-diff.cpp
@@ -43,21 +43,20 @@ struct test_output_t : public dummy_output_t {
         return std::shared_ptr<output_t>(clone);
     }
 
-    int node_add(osmium::Node const &n) override
+    int node_add(osmium::Node const &) override
     {
-        assert(n.id() > 0);
         ++node.added;
         return 0;
     }
 
-    int way_add(osmium::Way *w) override {
-        assert(w->id() > 0);
+    int way_add(osmium::Way *) override
+    {
         ++way.added;
         return 0;
     }
 
-    int relation_add(osmium::Relation const &r) override {
-        assert(r.id() > 0);
+    int relation_add(osmium::Relation const &) override
+    {
         ++rel.added;
         return 0;
     }

--- a/tests/test-parse-extra-args.cpp
+++ b/tests/test-parse-extra-args.cpp
@@ -59,7 +59,6 @@ struct test_output_t : public output_null_t
         assert(way->id() > 0);
         sum_ids += (unsigned)way->id();
         num_ways += 1;
-        assert(way->nodes().size() >= 0);
         num_nds += uint64_t(way->nodes().size());
         return 0;
     }
@@ -69,7 +68,6 @@ struct test_output_t : public output_null_t
         assert(rel.id() > 0);
         sum_ids += (unsigned)rel.id();
         num_relations += 1;
-        assert(rel.members().size() >= 0);
         num_members += uint64_t(rel.members().size());
         return 0;
     }

--- a/tests/test-parse-extra-args.cpp
+++ b/tests/test-parse-extra-args.cpp
@@ -85,6 +85,8 @@ void assert_equal(uint64_t actual, uint64_t expected)
 
 int main(int argc, char *argv[])
 {
+    (void)argc;
+    (void)argv;
 
     std::string inputfile = "tests/test_multipolygon.osm";
 

--- a/tests/test-parse-xml2.cpp
+++ b/tests/test-parse-xml2.cpp
@@ -56,7 +56,6 @@ struct test_output_t : public output_null_t {
         assert(way->id() > 0);
         sum_ids += (unsigned) way->id();
         num_ways += 1;
-        assert(way->nodes().size() >= 0);
         num_nds += uint64_t(way->nodes().size());
         return 0;
     }
@@ -65,7 +64,6 @@ struct test_output_t : public output_null_t {
         assert(rel.id() > 0);
         sum_ids += (unsigned) rel.id();
         num_relations += 1;
-        assert(rel.members().size() >= 0);
         num_members += uint64_t(rel.members().size());
         return 0;
     }

--- a/tests/test-parse-xml2.cpp
+++ b/tests/test-parse-xml2.cpp
@@ -80,27 +80,30 @@ void assert_equal(uint64_t actual, uint64_t expected) {
 }
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
 
-  std::string inputfile = "tests/test_multipolygon.osm";
+    std::string inputfile = "tests/test_multipolygon.osm";
 
-  options_t options;
-  std::shared_ptr<reprojection> projection(reprojection::create_projection(PROJ_SPHERE_MERC));
-  options.projection = projection;
+    options_t options;
+    std::shared_ptr<reprojection> projection(
+        reprojection::create_projection(PROJ_SPHERE_MERC));
+    options.projection = projection;
 
-  auto out_test = std::make_shared<test_output_t>(options);
-  osmdata_t osmdata(std::make_shared<dummy_middle_t>(), out_test);
+    auto out_test = std::make_shared<test_output_t>(options);
+    osmdata_t osmdata(std::make_shared<dummy_middle_t>(), out_test);
 
-  boost::optional<std::string> bbox;
-  parse_osmium_t parser(bbox, false, &osmdata);
+    boost::optional<std::string> bbox;
+    parse_osmium_t parser(bbox, false, &osmdata);
 
-  parser.stream_file(inputfile, "");
+    parser.stream_file(inputfile, "");
 
-  assert_equal(out_test->sum_ids,        4728L);
-  assert_equal(out_test->num_nodes,         0L);
-  assert_equal(out_test->num_ways,         48L);
-  assert_equal(out_test->num_relations,    40L);
-  assert_equal(out_test->num_nds,         186L);
-  assert_equal(out_test->num_members,     146L);
+    assert_equal(out_test->sum_ids, 4728L);
+    assert_equal(out_test->num_nodes, 0L);
+    assert_equal(out_test->num_ways, 48L);
+    assert_equal(out_test->num_relations, 40L);
+    assert_equal(out_test->num_nds, 186L);
+    assert_equal(out_test->num_members, 146L);
 
-  return 0;
+    return 0;
 }

--- a/tests/test-pgsql-escape.cpp
+++ b/tests/test-pgsql-escape.cpp
@@ -11,6 +11,8 @@ void test_escape(const char *in, const char *out) {
 }
 
 int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
     std::string sql;
     test_escape("farmland", "farmland");
     test_escape("", "");


### PR DESCRIPTION
This fixes all -Wextra warnings. Mostly removes unused parameters and a couple of useless asserts. It also removes the randomized parameter test because it contained some bad parameter usage and it was impossible to figure out what the actual intention of the test was.