### PR TITLE
Some cleanup for output-pgsql members

### DIFF
--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -31,7 +31,7 @@ class output_multi_t : public output_t
 public:
     output_multi_t(std::string const &name,
                    std::shared_ptr<geometry_processor> processor_,
-                   export_list const &export_list_,
+                   export_list const &export_list,
                    std::shared_ptr<middle_query_t> const &mid,
                    options_t const &options);
     virtual ~output_multi_t();
@@ -78,7 +78,6 @@ protected:
                        taglist_t &tags);
 
     std::unique_ptr<tagtransform_t> m_tagtransform;
-    std::unique_ptr<export_list> m_export_list;
     std::shared_ptr<geometry_processor> m_processor;
     std::shared_ptr<reprojection> m_proj;
     osmium::item_type const m_osm_type;

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -13,7 +13,7 @@
 #include "table.hpp"
 #include "tagtransform.hpp"
 
-#include <vector>
+#include <array>
 #include <memory>
 
 class output_pgsql_t : public output_t {
@@ -71,7 +71,7 @@ protected:
     //enable output of a generated way_area tag to either hstore or its own column
     int m_enable_way_area;
 
-    std::vector<std::shared_ptr<table_t> > m_tables;
+    std::array<std::unique_ptr<table_t>, t_MAX> m_tables;
 
     std::unique_ptr<export_list> m_export_list;
 

--- a/output-pgsql.hpp
+++ b/output-pgsql.hpp
@@ -73,8 +73,6 @@ protected:
 
     std::array<std::unique_ptr<table_t>, t_MAX> m_tables;
 
-    std::unique_ptr<export_list> m_export_list;
-
     geom::osmium_builder_t m_builder;
     expire_tiles expire;
 

--- a/tagtransform-c.cpp
+++ b/tagtransform-c.cpp
@@ -79,9 +79,16 @@ void add_z_order(taglist_t &tags, int *roads)
 
 } // anonymous namespace
 
-c_tagtransform_t::c_tagtransform_t(options_t const *options)
-: m_options(options)
+c_tagtransform_t::c_tagtransform_t(options_t const *options,
+                                   export_list const &exlist)
+: m_options(options), m_export_list(exlist)
 {
+}
+
+std::unique_ptr<tagtransform_t> c_tagtransform_t::clone() const
+{
+    return std::unique_ptr<tagtransform_t>(
+        new c_tagtransform_t(m_options, m_export_list));
 }
 
 bool c_tagtransform_t::check_key(std::vector<taginfo> const &infos,
@@ -134,8 +141,7 @@ bool c_tagtransform_t::check_key(std::vector<taginfo> const &infos,
 }
 
 bool c_tagtransform_t::filter_tags(osmium::OSMObject const &o, int *polygon,
-                                   int *roads, export_list const &exlist,
-                                   taglist_t &out_tags, bool strict)
+                                   int *roads, taglist_t &out_tags, bool strict)
 {
     //assume we dont like this set of tags
     bool filter = true;
@@ -147,7 +153,7 @@ bool c_tagtransform_t::filter_tags(osmium::OSMObject const &o, int *polygon,
     if (o.type() == osmium::item_type::relation) {
         export_type = osmium::item_type::way;
     }
-    const std::vector<taginfo> &infos = exlist.get(export_type);
+    const std::vector<taginfo> &infos = m_export_list.get(export_type);
 
     /* We used to only go far enough to determine if it's a polygon or not,
        but now we go through and filter stuff we don't need
@@ -205,8 +211,8 @@ bool c_tagtransform_t::filter_tags(osmium::OSMObject const &o, int *polygon,
 
 bool c_tagtransform_t::filter_rel_member_tags(
     taglist_t const &rel_tags, osmium::memory::Buffer const &,
-    rolelist_t const &, int *make_boundary, int *make_polygon, int *roads,
-    export_list const &, taglist_t &out_tags, bool allow_typeless)
+    rolelist_t const &, int *make_boundary, int *make_polygon,
+    int *roads, taglist_t &out_tags, bool allow_typeless)
 {
     //if it has a relation figure out what kind it is
     const std::string *type = rel_tags.get("type");

--- a/tagtransform-c.hpp
+++ b/tagtransform-c.hpp
@@ -7,18 +7,18 @@
 class c_tagtransform_t : public tagtransform_t
 {
 public:
-    c_tagtransform_t(options_t const *options);
+    c_tagtransform_t(options_t const *options, export_list const &exlist);
+
+    std::unique_ptr<tagtransform_t> clone() const override;
 
     bool filter_tags(osmium::OSMObject const &o, int *polygon, int *roads,
-                     export_list const &exlist, taglist_t &out_tags,
-                     bool strict = false) override;
+                     taglist_t &out_tags, bool strict = false) override;
 
     bool filter_rel_member_tags(taglist_t const &rel_tags,
                                 osmium::memory::Buffer const &members,
                                 rolelist_t const &member_roles,
                                 int *make_boundary, int *make_polygon,
-                                int *roads, export_list const &exlist,
-                                taglist_t &out_tags,
+                                int *roads, taglist_t &out_tags,
                                 bool allow_typeless = false) override;
 
 private:
@@ -26,6 +26,7 @@ private:
                    bool *filter, int *flags, bool strict);
 
     options_t const *m_options;
+    export_list m_export_list;
 };
 
 #endif // TAGTRANSFORM_C_H

--- a/tagtransform-lua.hpp
+++ b/tagtransform-lua.hpp
@@ -11,27 +11,31 @@ extern "C" {
 
 class lua_tagtransform_t : public tagtransform_t
 {
+    lua_tagtransform_t(lua_tagtransform_t const &other) = default;
+
 public:
     lua_tagtransform_t(options_t const *options);
     ~lua_tagtransform_t();
 
+    std::unique_ptr<tagtransform_t> clone() const override;
+
     bool filter_tags(osmium::OSMObject const &o, int *polygon, int *roads,
-                     export_list const &exlist, taglist_t &out_tags,
-                     bool strict = false) override;
+                     taglist_t &out_tags, bool strict = false) override;
 
     bool filter_rel_member_tags(taglist_t const &rel_tags,
                                 osmium::memory::Buffer const &members,
                                 rolelist_t const &member_roles,
                                 int *make_boundary, int *make_polygon,
-                                int *roads, export_list const &exlist,
-                                taglist_t &out_tags,
+                                int *roads, taglist_t &out_tags,
                                 bool allow_typeless = false) override;
 
 private:
+    void open_style();
     void check_lua_function_exists(std::string const &func_name);
 
     lua_State *L;
     std::string m_node_func, m_way_func, m_rel_func, m_rel_mem_func;
+    std::string m_lua_file;
     bool m_extra_attributes;
 };
 

--- a/tagtransform.cpp
+++ b/tagtransform.cpp
@@ -8,7 +8,8 @@
 #endif
 
 std::unique_ptr<tagtransform_t>
-tagtransform_t::make_tagtransform(options_t const *options)
+tagtransform_t::make_tagtransform(options_t const *options,
+                                  export_list const &exlist)
 {
     if (options->tag_transform_script) {
 #ifdef HAVE_LUA
@@ -24,7 +25,8 @@ tagtransform_t::make_tagtransform(options_t const *options)
     }
 
     fprintf(stderr, "Using built-in tag processing pipeline\n");
-    return std::unique_ptr<tagtransform_t>(new c_tagtransform_t(options));
+    return std::unique_ptr<tagtransform_t>(
+        new c_tagtransform_t(options, exlist));
 }
 
 tagtransform_t::~tagtransform_t() = default;

--- a/tagtransform.hpp
+++ b/tagtransform.hpp
@@ -14,20 +14,21 @@ class tagtransform_t
 {
 public:
     static std::unique_ptr<tagtransform_t>
-    make_tagtransform(options_t const *options);
+    make_tagtransform(options_t const *options, export_list const &exlist);
 
     virtual ~tagtransform_t() = 0;
 
+    virtual std::unique_ptr<tagtransform_t> clone() const = 0;
+
     virtual bool filter_tags(osmium::OSMObject const &o, int *polygon,
-                             int *roads, export_list const &exlist,
-                             taglist_t &out_tags, bool strict = false) = 0;
+                             int *roads, taglist_t &out_tags,
+                             bool strict = false) = 0;
 
     virtual bool filter_rel_member_tags(taglist_t const &rel_tags,
                                         osmium::memory::Buffer const &members,
                                         rolelist_t const &member_roles,
                                         int *make_boundary, int *make_polygon,
-                                        int *roads, export_list const &exlist,
-                                        taglist_t &out_tags,
+                                        int *roads, taglist_t &out_tags,
                                         bool allow_typeless = false) = 0;
 };
 

--- a/tests/test-options-parse.cpp
+++ b/tests/test-options-parse.cpp
@@ -4,6 +4,7 @@
 #include "output-pgsql.hpp"
 #include "output-gazetteer.hpp"
 #include "output-null.hpp"
+#include "taginfo_impl.hpp"
 
 #include <stdio.h>
 #include <string.h>
@@ -135,8 +136,9 @@ void test_lua_styles()
     options_t options = options_t(len(a1), const_cast<char **>(a1));
 
     try {
+        export_list exlist;
         std::unique_ptr<tagtransform_t> tagtransform =
-            tagtransform_t::make_tagtransform(&options);
+            tagtransform_t::make_tagtransform(&options, exlist);
         throw std::logic_error("Expected 'No such file or directory'");
     } catch (const std::runtime_error &e) {
         if (!alg::icontains(e.what(), "No such file or directory"))


### PR DESCRIPTION
This PR cleans up two things:

* Convert tables member to std::array. The size of the array is known at compile time and does not change, so a vector is not necessary here.
* export_list is moved to the transform classes. The style file is only used by output-pgsql to create the columns. During the actual import it is only handed to the transforms on every filter call. Moving the export_list to transforms makes the filter calls more more readable and also gives us the freedom to change the style description format independently for the transforms.

Have a look at the individual commit for each change.
