### PR TITLE
gazetteer: handle updates of unnamed places

### DIFF
--- a/gazetteer-style.hpp
+++ b/gazetteer-style.hpp
@@ -61,7 +61,7 @@ class gazetteer_style_t
 public:
     void load_style(std::string const &filename);
     void process_tags(osmium::OSMObject const &o);
-    void copy_out(osmium::OSMObject const &o, std::string const &geom,
+    bool copy_out(osmium::OSMObject const &o, std::string const &geom,
                   db_copy_mgr_t &buffer);
     bool has_place(std::string const &cls) const;
 

--- a/output-gazetteer.cpp
+++ b/output-gazetteer.cpp
@@ -146,7 +146,8 @@ int output_gazetteer_t::process_node(osmium::Node const &node)
     /* Are we interested in this item? */
     if (m_style.has_data()) {
         auto wkb = m_builder.get_wkb_node(node.location());
-        m_style.copy_out(node, wkb, m_copy);
+        if (!m_style.copy_out(node, wkb, m_copy))
+            delete_unused_full("N", node.id());
     }
 
     return 0;
@@ -178,7 +179,8 @@ int output_gazetteer_t::process_way(osmium::Way *way)
             geom = wkbs[0];
         }
 
-        m_style.copy_out(*way, geom, m_copy);
+        if (!m_style.copy_out(*way, geom, m_copy))
+            delete_unused_full("W", way->id());
     }
 
     return 0;
@@ -229,7 +231,8 @@ int output_gazetteer_t::process_relation(osmium::Relation const &rel)
                      : m_builder.get_wkb_multipolygon(rel, osmium_buffer);
 
     if (!geoms.empty()) {
-        m_style.copy_out(rel, geoms[0], m_copy);
+        if (!m_style.copy_out(rel, geoms[0], m_copy))
+            delete_unused_full("R", rel.id());
     }
 
     return 0;


### PR DESCRIPTION
When downgrading an unnamed object from SF_MAIN to SF_MAIN_NAMED,
the object needs to be deleted. Finding that condition in has_data()
is a bit expecsive, so instead catch the condition when copying
the data out. If there are multiple main tags, then
delete_unused_classes() needs to remove the instance as well.
Adapt has_place() for that.

Fixes #933.