### PR TITLE
Avoid crashing on out-of-range inputs for int4 columns

### DIFF
--- a/table.cpp
+++ b/table.cpp
@@ -457,12 +457,21 @@ void table_t::escape_type(const string &value, ColumnType flags)
     switch (flags) {
     case COLUMN_TYPE_INT: {
         // For integers we take the first number, or the average if it's a-b
-        long from, to;
-        int items = sscanf(value.c_str(), "%ld-%ld", &from, &to);
-        if (items == 1) {
+        int64_t from, to;
+        // limit number of digits parsed to avoid undefined behaviour in sscanf
+        int items = sscanf(value.c_str(), "%18ld-%18ld", &from, &to);
+        if (items == 1 && from <= std::numeric_limits<int32_t>::max() &&
+            from >= std::numeric_limits<int32_t>::min()) {
             m_copy.add_column(from);
         } else if (items == 2) {
-            m_copy.add_column((from + to) / 2);
+            // calculate mean while avoiding overflows
+            int64_t mean = (from / 2) + (to / 2) + ((from % 2 + to % 2) / 2);
+            if (mean <= std::numeric_limits<int32_t>::max() &&
+                mean >= std::numeric_limits<int32_t>::min()) {
+                m_copy.add_column(mean);
+            } else {
+                m_copy.add_null_column();
+            }
         } else {
             m_copy.add_null_column();
         }

--- a/table.cpp
+++ b/table.cpp
@@ -459,7 +459,7 @@ void table_t::escape_type(const string &value, ColumnType flags)
         // For integers we take the first number, or the average if it's a-b
         long long from, to;
         // limit number of digits parsed to avoid undefined behaviour in sscanf
-        int items = sscanf(value.c_str(), "%18Ld-%18Ld", &from, &to);
+        int items = sscanf(value.c_str(), "%18lld-%18lld", &from, &to);
         if (items == 1 && from <= std::numeric_limits<int32_t>::max() &&
             from >= std::numeric_limits<int32_t>::min()) {
             m_copy.add_column(from);

--- a/table.cpp
+++ b/table.cpp
@@ -457,9 +457,9 @@ void table_t::escape_type(const string &value, ColumnType flags)
     switch (flags) {
     case COLUMN_TYPE_INT: {
         // For integers we take the first number, or the average if it's a-b
-        int64_t from, to;
+        long long from, to;
         // limit number of digits parsed to avoid undefined behaviour in sscanf
-        int items = sscanf(value.c_str(), "%18ld-%18ld", &from, &to);
+        int items = sscanf(value.c_str(), "%18Ld-%18Ld", &from, &to);
         if (items == 1 && from <= std::numeric_limits<int32_t>::max() &&
             from >= std::numeric_limits<int32_t>::min()) {
             m_copy.add_column(from);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(TESTS
   test-output-multi-tags.cpp
   test-output-pgsql-area.cpp
   test-output-pgsql-schema.cpp
+  test-output-pgsql-int4.cpp
   test-output-pgsql-tablespace.cpp
   test-output-pgsql-validgeom.cpp
   test-output-pgsql-z_order.cpp

--- a/tests/test-output-pgsql-int4.cpp
+++ b/tests/test-output-pgsql-int4.cpp
@@ -1,0 +1,117 @@
+#include <iostream>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <cassert>
+#include <sstream>
+#include <stdexcept>
+#include <memory>
+
+#include "osmtypes.hpp"
+#include "osmdata.hpp"
+#include "output-pgsql.hpp"
+#include "options.hpp"
+#include "middle-pgsql.hpp"
+#include "middle-ram.hpp"
+#include "taginfo_impl.hpp"
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <boost/lexical_cast.hpp>
+
+#include "tests/middle-tests.hpp"
+#include "tests/common-pg.hpp"
+#include "tests/common.hpp"
+
+namespace {
+
+struct skip_test : public std::exception {
+    const char *what() const noexcept { return "Test skipped."; }
+};
+
+void run_test(const char* test_name, void (*testfunc)()) {
+    try {
+        fprintf(stderr, "%s\n", test_name);
+        testfunc();
+
+    } catch (const skip_test &) {
+        exit(77); // <-- code to skip this test.
+
+    } catch (const std::exception& e) {
+        fprintf(stderr, "%s\n", e.what());
+        fprintf(stderr, "FAIL\n");
+        exit(EXIT_FAILURE);
+    }
+
+    fprintf(stderr, "PASS\n");
+}
+#define RUN_TEST(x) run_test(#x, &(x))
+
+// "simple" test modeled on the basic regression test from
+// the python script. this is just to check everything is
+// working as expected before we start the complex stuff.
+void test_int4() {
+    std::unique_ptr<pg::tempdb> db;
+
+    try {
+        db.reset(new pg::tempdb);
+    } catch (const std::exception &e) {
+        std::cerr << "Unable to setup database: " << e.what() << "\n";
+        throw skip_test();
+    }
+
+    std::string proc_name("test-output-pgsql-int4"), input_file("-");
+    char *argv[] = { &proc_name[0], &input_file[0], nullptr };
+
+    options_t options = options_t(2, argv);
+    options.database_options = db->database_options;
+    options.num_procs = 1;
+    options.slim = 1;
+    options.prefix = "osm2pgsql_test";
+    options.style = "tests/test_output_pgsql_int4.style";
+
+    testing::run_osm2pgsql(options, "tests/test_output_pgsql_int4.osm",
+                           "xml");
+
+    db->assert_has_table("osm2pgsql_test_point");
+    db->assert_has_table("osm2pgsql_test_line");
+    db->assert_has_table("osm2pgsql_test_polygon");
+    db->assert_has_table("osm2pgsql_test_roads");
+
+    // First three nodes have population values that are out of range for int4 columns
+    db->check_string("", "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 1");
+    db->check_string("", "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 2");
+    db->check_string("", "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 3");
+    // Check values that are valid for int4 columns, including limits
+    db->check_count(2147483647, "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 4");
+    db->check_count(10000, "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 5");
+    db->check_count(-10000, "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 6");
+    db->check_count(-2147483648, "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 7");
+    // More out of range negative values
+    db->check_string("", "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 8");
+    db->check_string("", "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 9");
+    db->check_string("", "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 10");
+
+    // Ranges are also parsed into int4 columns
+    db->check_string("", "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 11");
+    db->check_string("", "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 12");
+    // Check values that are valid for int4 columns, including limits
+    db->check_count(2147483647, "SELECT population FROM osm2pgsql_test_point WHERE osm_id =13");
+    db->check_count(15000, "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 14");
+    db->check_count(-15000, "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 15");
+    db->check_count(-2147483648, "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 16");
+    // More out of range negative values
+    db->check_string("", "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 17");
+    db->check_string("", "SELECT population FROM osm2pgsql_test_point WHERE osm_id = 18");
+}
+
+} // anonymous namespace
+
+int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
+    RUN_TEST(test_int4);
+
+    return 0;
+}

--- a/tests/test_output_pgsql_int4.osm
+++ b/tests/test_output_pgsql_int4.osm
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6">
+ <node id="1" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="10000000000000000000" />
+   <tag k="name" v="longer than long" />
+ </node>
+ <node id="2" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="10000000000" />
+   <tag k="name" v="long (ten billion)" />
+ </node>
+ <node id="3" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="2147483648" />
+   <tag k="name" v="postgresql one more than int4 type" />
+ </node>
+ <node id="4" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="2147483647" />
+   <tag k="name" v="postgresql max int4 type" />
+ </node>
+ <node id="5" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="10000" />
+   <tag k="name" v="ten thousand" />
+ </node>
+ <node id="6" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="-10000" />
+   <tag k="name" v="minus ten thousand" />
+ </node>
+ <node id="7" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="-2147483648" />
+   <tag k="name" v="postgresql min int4 type" />
+ </node>
+ <node id="8" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="-2147483649" />
+   <tag k="name" v="postgresql one less than min int4 type" />
+ </node>
+ <node id="9" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="-10000000000" />
+   <tag k="name" v="minus long (minus ten billion)" />
+ </node>
+ <node id="10" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="-10000000000000000000" />
+   <tag k="name" v="minus longer than long" />
+ </node>
+ <node id="11" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="10000000000000000000-20000000000000000000" />
+   <tag k="name" v="range, longer than long" />
+ </node>
+ <node id="12" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="10000000000-20000000000" />
+   <tag k="name" v="range, 15 billion" />
+ </node>
+ <node id="13" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="2147483646-2147483648" />
+   <tag k="name" v="range, mean is max int4" />
+ </node>
+ <node id="14" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="10000-20000" />
+   <tag k="name" v="range, 15 thousand" />
+ </node>
+ <node id="15" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="-10000--20000" />
+   <tag k="name" v="range, negative 15 thousand" />
+ </node>
+ <node id="16" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="-2147483647--2147483649" />
+   <tag k="name" v="range, mean is min int4" />
+ </node>
+ <node id="17" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="-10000000000--20000000000" />
+   <tag k="name" v="range, negative 15 billion" />
+ </node>
+ <node id="18" visible="true" version="1" changeset="1" timestamp="2018-10-31T10:20:19Z" user="a" uid="1" lat="51.4779481" lon="-0.0014863">
+   <tag k="population" v="-10000000000000000000--20000000000000000000" />
+   <tag k="name" v="range, negative longer than long" />
+ </node>
+</osm>

--- a/tests/test_output_pgsql_int4.style
+++ b/tests/test_output_pgsql_int4.style
@@ -1,0 +1,3 @@
+# OsmType  Tag          DataType     Flags
+node,way   population      int4      linear
+node,way   name            text      linear


### PR DESCRIPTION
Fixes #955

This approach also avoids undefined behaviour when using sscanf, and changes the mean calculation to avoid overflows.

As part of the development of this patch I made [a sample osm.xml file with a variety of numbers and ranges](https://gist.github.com/gravitystorm/409b5f651f013ac5a49ff71f84b82d37), to check that everything was working properly. 