### PR TITLE
Reduce max number of default parallel threads to 4

### DIFF
--- a/options.cpp
+++ b/options.cpp
@@ -8,6 +8,7 @@
 #define basename /*SKIP IT*/
 #endif
 #include <boost/format.hpp>
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <osmium/version.hpp>
@@ -299,7 +300,7 @@ options_t::options_t()
   output_backend("pgsql"), input_reader("auto"), bbox(boost::none),
   extra_attributes(false), verbose(false)
 {
-    num_procs = std::thread::hardware_concurrency();
+    num_procs = (int) std::min(4U, std::thread::hardware_concurrency());
     if (num_procs < 1) {
         fprintf(stderr, "WARNING: unable to detect number of hardware threads supported!\n");
         num_procs = 1;


### PR DESCRIPTION
Parallel processing is used only when indexes are created and
in the second processing stage of updates. In both cases the
number of parallel threads should not be too high. Indexing
requires a lot of memory and having too many in parallel running
actually slows down the process. Updates are generally run in
parallel with other load (like rendering) and should therefore
also not take up too many CPUs.

Fixes #885.