### PR TITLE
Remove use of boost::noncopyable

### DIFF
--- a/id-tracker.cpp
+++ b/id-tracker.cpp
@@ -139,8 +139,7 @@ id_tracker::id_tracker(): impl() {
     impl.reset(new pimpl());
 }
 
-id_tracker::~id_tracker() {
-}
+id_tracker::~id_tracker() = default;
 
 void id_tracker::mark(osmid_t id) {
     //setting returns true if the id wasn't already marked

--- a/id-tracker.hpp
+++ b/id-tracker.hpp
@@ -2,7 +2,6 @@
 #define ID_TRACKER_HPP
 
 #include "osmtypes.hpp"
-#include <boost/noncopyable.hpp>
 #include <memory>
 
 /**
@@ -19,8 +18,16 @@
   * These details aren't exposed in the public interface, which just has
   * pop_mark.
   */
-struct id_tracker : public boost::noncopyable {
+struct id_tracker
+{
     id_tracker();
+
+    id_tracker(id_tracker const &) = delete;
+    id_tracker &operator=(id_tracker const &) = delete;
+
+    id_tracker(id_tracker &&) = delete;
+    id_tracker &operator=(id_tracker &&) = delete;
+
     ~id_tracker();
 
     void mark(osmid_t id);

--- a/node-ram-cache.hpp
+++ b/node-ram-cache.hpp
@@ -12,8 +12,6 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <boost/noncopyable.hpp>
-
 #include <osmium/osm/location.hpp>
 
 #include "osmtypes.hpp"
@@ -44,9 +42,16 @@ private:
     int32_t _used = 0;
 };
 
-struct node_ram_cache : public boost::noncopyable
+struct node_ram_cache
 {
     node_ram_cache(int strategy, int cacheSizeMB);
+
+    node_ram_cache(node_ram_cache const &) = delete;
+    node_ram_cache &operator=(node_ram_cache const &) = delete;
+
+    node_ram_cache(node_ram_cache &&) = delete;
+    node_ram_cache &operator=(node_ram_cache &&) = delete;
+
     ~node_ram_cache();
 
     void set(osmid_t id, const osmium::Location &coord);

--- a/reprojection.hpp
+++ b/reprojection.hpp
@@ -8,16 +8,22 @@
 #ifndef REPROJECTION_H
 #define REPROJECTION_H
 
-#include <boost/noncopyable.hpp>
-
 #include <osmium/geom/projection.hpp>
 #include <osmium/osm/location.hpp>
 
 enum Projection { PROJ_LATLONG = 4326, PROJ_SPHERE_MERC = 3857 };
 
-class reprojection : public boost::noncopyable
+class reprojection
 {
 public:
+    reprojection() = default;
+
+    reprojection(reprojection const &) = delete;
+    reprojection &operator=(reprojection const &) = delete;
+
+    reprojection(reprojection &&) = delete;
+    reprojection &operator=(reprojection &&) = delete;
+
     virtual ~reprojection() = default;
 
     /**


### PR DESCRIPTION
In C++11 we can express this in better way.