### PR TITLE
Fixed some include names and re-order some includes

### DIFF
--- a/db-copy.cpp
+++ b/db-copy.cpp
@@ -1,8 +1,9 @@
-#include <boost/format.hpp>
 #include <cassert>
 #include <cstdio>
 #include <future>
 #include <thread>
+
+#include <boost/format.hpp>
 
 #include "db-copy.hpp"
 #include "pgsql.hpp"

--- a/expire-tiles.cpp
+++ b/expire-tiles.cpp
@@ -8,10 +8,10 @@
  * http://subversion.nexusuk.org/projects/openpistemap/trunk/scripts/expire_tiles.py
  */
 
+#include <cerrno>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
-#include <cerrno>
 #include <string>
 
 #include <boost/format.hpp>

--- a/gazetteer-style.cpp
+++ b/gazetteer-style.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 
 #include <boost/property_tree/json_parser.hpp>
+
 #include <osmium/osm.hpp>
 
 #include "gazetteer-style.hpp"

--- a/geometry-processor.cpp
+++ b/geometry-processor.cpp
@@ -1,15 +1,16 @@
 #include "geometry-processor.hpp"
+#include "middle.hpp"
+#include "options.hpp"
 #include "processor-line.hpp"
 #include "processor-point.hpp"
 #include "processor-polygon.hpp"
-#include "middle.hpp"
-#include "options.hpp"
 #include "reprojection.hpp"
+
+#include <memory>
+#include <stdexcept>
 
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
-#include <stdexcept>
-#include <memory>
 
 std::shared_ptr<geometry_processor> geometry_processor::create(const std::string &type,
                                                                  const options_t *options) {

--- a/geometry-processor.hpp
+++ b/geometry-processor.hpp
@@ -2,9 +2,9 @@
 #define OSM2PGSQL_GEOMETRY_PROCESSOR_HPP
 
 #include <cstddef>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
 #include <osmium/memory/buffer.hpp>
 

--- a/id-tracker.cpp
+++ b/id-tracker.cpp
@@ -1,9 +1,9 @@
 #include "id-tracker.hpp"
 
+#include <algorithm>
+#include <limits>
 #include <map>
 #include <vector>
-#include <limits>
-#include <algorithm>
 
 #include <boost/optional.hpp>
 

--- a/id-tracker.hpp
+++ b/id-tracker.hpp
@@ -2,6 +2,7 @@
 #define OSM2PGSQL_ID_TRACKER_HPP
 
 #include "osmtypes.hpp"
+
 #include <memory>
 
 /**

--- a/middle-pgsql.cpp
+++ b/middle-pgsql.cpp
@@ -6,21 +6,21 @@
  * emit the final geometry-enabled output formats
 */
 
-#include <stdexcept>
-#include <unordered_map>
-
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <functional>
-
-#include <boost/format.hpp>
-#include <osmium/memory/buffer.hpp>
-#include <osmium/builder/osm_object_builder.hpp>
+#include <stdexcept>
+#include <unordered_map>
 
 #include <libpq-fe.h>
+
+#include <boost/format.hpp>
+
+#include <osmium/builder/osm_object_builder.hpp>
+#include <osmium/memory/buffer.hpp>
 
 #include "middle-pgsql.hpp"
 #include "node-persistent-cache.hpp"

--- a/middle-ram.cpp
+++ b/middle-ram.cpp
@@ -7,10 +7,9 @@
  * emit the final geometry-enabled output formats
 */
 
-#include <stdexcept>
-
 #include <cassert>
 #include <cstdio>
+#include <stdexcept>
 
 #include <osmium/builder/attr.hpp>
 

--- a/middle.hpp
+++ b/middle.hpp
@@ -7,11 +7,10 @@
  * storing and retrieving node and way data.
  */
 
-#include <osmium/memory/buffer.hpp>
-
 #include <cstddef>
 #include <memory>
 
+#include <osmium/memory/buffer.hpp>
 #include <osmium/thread/pool.hpp>
 
 #include "osmtypes.hpp"

--- a/node-ram-cache.cpp
+++ b/node-ram-cache.cpp
@@ -5,11 +5,10 @@
 
 #include "config.h"
 
-#include <new>
-#include <stdexcept>
-
 #include <cstdio>
 #include <cstdlib>
+#include <new>
+#include <stdexcept>
 
 #include <boost/format.hpp>
 

--- a/options.cpp
+++ b/options.cpp
@@ -1,15 +1,18 @@
 #include "options.hpp"
 #include "sprompt.hpp"
 
-#include <getopt.h>
-#include <boost/format.hpp>
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
-#include <osmium/version.hpp>
 #include <sstream>
 #include <stdexcept>
 #include <thread> // for number of threads
+
+#include <getopt.h>
+
+#include <boost/format.hpp>
+
+#include <osmium/version.hpp>
 
 #ifdef HAVE_LUA
 extern "C" {

--- a/options.hpp
+++ b/options.hpp
@@ -4,9 +4,10 @@
 #include "node-ram-cache.hpp"
 #include "reprojection.hpp"
 
-#include <vector>
-#include <string>
 #include <memory>
+#include <string>
+#include <vector>
+
 #include <boost/optional.hpp>
 
 /* Variants for generation of hstore column */

--- a/osm2pgsql.cpp
+++ b/osm2pgsql.cpp
@@ -35,14 +35,15 @@
 #include "reprojection.hpp"
 #include "util.hpp"
 
-#include <time.h>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <cstdio>
-#include <cstdlib>
 
 #include <libpq-fe.h>
+
 #include <boost/format.hpp>
 
 int main(int argc, char *argv[])

--- a/osmdata.hpp
+++ b/osmdata.hpp
@@ -5,8 +5,8 @@
 // to get the print format specifiers in the inttypes.h header.
 #include "config.h"
 
-#include <vector>
 #include <memory>
+#include <vector>
 
 #include "osmtypes.hpp"
 

--- a/osmtypes.hpp
+++ b/osmtypes.hpp
@@ -3,15 +3,16 @@
 
 /* Data types to hold OSM node, segment, way data */
 
+#include "config.h"
+
 // when __cplusplus is defined, we need to define this macro as well
 // to get the print format specifiers in the inttypes.h header.
 #define __STDC_FORMAT_MACROS
-#include <inttypes.h>
-#include "config.h"
 
+#include <cinttypes>
+#include <cmath>
 #include <string>
 #include <vector>
-#include <cmath>
 
 #include <osmium/builder/attr.hpp>
 #include <osmium/geom/coordinates.hpp>

--- a/output-gazetteer.cpp
+++ b/output-gazetteer.cpp
@@ -1,6 +1,3 @@
-#include <libpq-fe.h>
-#include <boost/format.hpp>
-
 #include "middle.hpp"
 #include "options.hpp"
 #include "osmtypes.hpp"
@@ -12,6 +9,10 @@
 #include <cstring>
 #include <iostream>
 #include <memory>
+
+#include <boost/format.hpp>
+
+#include <libpq-fe.h>
 
 void output_gazetteer_t::delete_unused_classes(char const *osm_type,
                                                osmid_t osm_id)

--- a/output-gazetteer.hpp
+++ b/output-gazetteer.hpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include <boost/format.hpp>
+
 #include <osmium/memory/buffer.hpp>
 
 #include "db-copy.hpp"

--- a/output-multi.cpp
+++ b/output-multi.cpp
@@ -8,8 +8,9 @@
 #include "tagtransform.hpp"
 #include "wkb.hpp"
 
-#include <boost/algorithm/string/predicate.hpp>
 #include <vector>
+
+#include <boost/algorithm/string/predicate.hpp>
 
 output_multi_t::output_multi_t(
     std::string const &name, std::shared_ptr<geometry_processor> processor_,

--- a/output-multi.hpp
+++ b/output-multi.hpp
@@ -14,8 +14,8 @@
 #include "geometry-processor.hpp"
 
 #include <cstddef>
-#include <string>
 #include <memory>
+#include <string>
 
 class table_t;
 class tagtransform_t;

--- a/output-pgsql.cpp
+++ b/output-pgsql.cpp
@@ -6,6 +6,12 @@
  * emit the final geometry-enabled output formats
 */
 
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <future>
 #include <iostream>
 #include <limits>
@@ -13,12 +19,6 @@
 #include <stdexcept>
 #include <string>
 
-#include <cassert>
-#include <cerrno>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
 #include <unistd.h>
 
 #include "expire-tiles.hpp"

--- a/output.cpp
+++ b/output.cpp
@@ -10,8 +10,8 @@
 #include <stdexcept>
 
 #include <boost/format.hpp>
-#include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 namespace pt = boost::property_tree;
 

--- a/parse-osmium.cpp
+++ b/parse-osmium.cpp
@@ -22,14 +22,14 @@
 
 #include <boost/format.hpp>
 
+#include "osmdata.hpp"
 #include "parse-osmium.hpp"
 #include "reprojection.hpp"
-#include "osmdata.hpp"
 
-#include <osmium/io/any_input.hpp>
 #include <osmium/handler.hpp>
-#include <osmium/visitor.hpp>
+#include <osmium/io/any_input.hpp>
 #include <osmium/osm.hpp>
+#include <osmium/visitor.hpp>
 
 void parse_stats_t::update(const parse_stats_t &other)
 {

--- a/parse-osmium.hpp
+++ b/parse-osmium.hpp
@@ -3,8 +3,9 @@
 
 #include "config.h"
 
-#include <boost/optional.hpp>
 #include <ctime>
+
+#include <boost/optional.hpp>
 
 #include "osmtypes.hpp"
 

--- a/pgsql.cpp
+++ b/pgsql.cpp
@@ -1,10 +1,11 @@
 /* Helper functions for the postgresql connections */
 #include "pgsql.hpp"
 
+#include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
-#include <cstdarg>
 #include <memory>
+
 #include <boost/format.hpp>
 
 pg_result_t pgsql_exec_simple(PGconn *sql_conn, const ExecStatusType expect,

--- a/pgsql.hpp
+++ b/pgsql.hpp
@@ -6,10 +6,11 @@
 /* Current middle and output-pgsql do a lot of things similarly, this should
  * be used to abstract to commonalities */
 
-#include <string>
 #include <cstring>
-#include <libpq-fe.h>
 #include <memory>
+#include <string>
+
+#include <libpq-fe.h>
 
 struct pg_result_deleter_t
 {

--- a/table.cpp
+++ b/table.cpp
@@ -1,9 +1,9 @@
-#include <exception>
 #include <algorithm>
-#include <cstring>
 #include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <exception>
 #include <utility>
-#include <time.h>
 
 #include <boost/format.hpp>
 

--- a/table.hpp
+++ b/table.hpp
@@ -7,10 +7,10 @@
 #include "taginfo.hpp"
 
 #include <cstddef>
-#include <string>
-#include <vector>
-#include <utility>
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <boost/optional.hpp>
 

--- a/taginfo.cpp
+++ b/taginfo.cpp
@@ -2,11 +2,12 @@
 #include "util.hpp"
 
 #include <cassert>
+#include <cerrno>
 #include <cstring>
 #include <map>
 #include <stdexcept>
+
 #include <boost/format.hpp>
-#include <errno.h>
 
 #ifdef _WIN32
 #ifndef strtok_r

--- a/taginfo_impl.hpp
+++ b/taginfo_impl.hpp
@@ -1,11 +1,12 @@
 #ifndef OSM2PGSQL_TAGINFO_IMPL_HPP
 #define OSM2PGSQL_TAGINFO_IMPL_HPP
 
-#include "taginfo.hpp"
 #include "osmtypes.hpp"
+#include "taginfo.hpp"
+
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 enum column_flags {
   FLAG_POLYGON = 1,   /* For polygon table */

--- a/tagtransform-c.cpp
+++ b/tagtransform-c.cpp
@@ -1,6 +1,7 @@
-#include <boost/algorithm/string/predicate.hpp>
 #include <cstdlib>
 #include <cstring>
+
+#include <boost/algorithm/string/predicate.hpp>
 
 #include "options.hpp"
 #include "taginfo_impl.hpp"

--- a/util.cpp
+++ b/util.cpp
@@ -1,7 +1,7 @@
 #include "util.hpp"
 
-#include <iostream>
 #include <cstdlib>
+#include <iostream>
 
 namespace util {
 


### PR DESCRIPTION
* C includes like <time.h> changed to C++ includes like <ctime>
* Split up includes from different groups (std lib vs. boost etc.)
* Ordered includes inside there groups alphabetically

This mostly doesn't touch the order of the groups, this is left for another day, because it would probably break the build in a few places.