### PR TITLE
Make test execution of catch tests independent of working directory

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,9 +9,7 @@ function(set_test test_name)
 
     add_executable(${test_name} ${test_name}.cpp)
     target_link_libraries(${test_name} osm2pgsql_lib catch_main_lib)
-    add_test(NAME ${test_name}
-             COMMAND ${test_name}
-             WORKING_DIRECTORY ${osm2pgsql_SOURCE_DIR})
+    add_test(NAME ${test_name} COMMAND ${test_name})
 
     set_tests_properties(${test_name} PROPERTIES TIMEOUT ${TESTING_TIMEOUT})
 

--- a/tests/test-options-projection.cpp
+++ b/tests/test-options-projection.cpp
@@ -9,7 +9,8 @@ static testing::db::import_t db;
 TEST_CASE("Projection setup")
 {
     std::vector<char const *> option_params = {
-        "osm2pgsql", "-S", "default.style", "--number-processes", "1"};
+        "osm2pgsql", "-S", OSM2PGSQLDATA_DIR "default.style",
+        "--number-processes", "1"};
 
     char const *proj_name = nullptr;
     char const *srid = "";


### PR DESCRIPTION
Removes the last relative style location from the projection tests and removes the working directory for catch tests from the ctest configuration.

This means that now all tests except the regression test can be executed directly from the build directory.

Fixes #540.