### PR TITLE
Use fmt library instead of boost::format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ matrix:
       env: T="clang38_pg92_dbtest"
            BUILD_TYPE="Debug" LUAJIT_OPTION="OFF"
            CXXFLAGS="-pedantic -Wextra -Werror"
-           CC=clang-3.8 CXX=clang++-3.8
+           CC=clang-3.8 CXX=clang++-3.8 CPPVERSION=11
       addons: *clang38_pg92
 
     - os: linux
@@ -75,7 +75,7 @@ matrix:
       env: T="clang7_pg96_dbtest_luajit"
            BUILD_TYPE="Debug" LUAJIT_OPTION="ON"
            CXXFLAGS="-pedantic -Wextra -Werror"
-           CC=clang-7 CXX=clang++-7
+           CC=clang-7 CXX=clang++-7 CPPVERSION=11
       addons: *clang7_pg96
 
     - os: linux
@@ -84,7 +84,7 @@ matrix:
       env: T="bionic_clang7_pg96_dbtest"
            BUILD_TYPE="Debug" LUAJIT_OPTION="OFF"
            CXXFLAGS="-pedantic -Wextra -Werror"
-           CC=clang-7 CXX=clang++-7
+           CC=clang-7 CXX=clang++-7 CPPVERSION=14
       addons: *bionic_clang7_pg96
 
   # ---- OSX + CLANG ---------------------------
@@ -92,7 +92,7 @@ matrix:
       compiler: clang
       env: T="osx_clang_NoDB"
            BUILD_TYPE="Debug" LUAJIT_OPTION="OFF" TEST_NODB=1
-           CXXFLAGS="-pedantic -Wextra -Werror"
+           CXXFLAGS="-pedantic -Wextra -Werror" CPPVERSION=11
       before_install:
         - brew install lua; brew install lua
       before_script:
@@ -106,7 +106,7 @@ matrix:
       env: T="gcc48_pg96_dbtest"
            BUILD_TYPE="Debug" LUAJIT_OPTION="OFF"
            CXXFLAGS="-pedantic -Wextra -Werror"
-           CC=gcc-4.8 CXX=g++-4.8
+           CC=gcc-4.8 CXX=g++-4.8 CPPVERSION=11
       addons: *gcc48_pg96
 
     - os: linux
@@ -115,7 +115,7 @@ matrix:
       env: T="bionic_gcc8_pg96_dbtest_luajit"
            BUILD_TYPE="Debug" LUAJIT_OPTION="ON"
            CXXFLAGS="-pedantic -Wextra -Werror"
-           CC=gcc-8 CXX=g++-8
+           CC=gcc-8 CXX=g++-8 CPPVERSION=14
       addons: *bionic_gcc8_pg96
 
     - os: linux
@@ -124,7 +124,7 @@ matrix:
       env: T="bionic_gcc8_pg96_dbtest_luajit_release"
            BUILD_TYPE="Release" LUAJIT_OPTION="ON"
            CXXFLAGS="-pedantic -Wextra -Werror"
-           CC=gcc-8 CXX=g++-8
+           CC=gcc-8 CXX=g++-8 CPPVERSION=14
       addons: *bionic_gcc8_pg96
 
 
@@ -142,7 +142,7 @@ before_script:
 
 script:
   - mkdir build && cd build
-  - cmake .. -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DWITH_LUAJIT=${LUAJIT_OPTION}
+  - cmake .. -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_STANDARD=${CPPVERSION} -DWITH_LUAJIT=${LUAJIT_OPTION}
   - make -j2
   - echo "Running tests ... "
   - if [[ $TEST_NODB ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,12 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_EXTENSIONS Off)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+if (NOT "${CMAKE_CXX_STANDARD}")
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+message(STATUS "Building in C++${CMAKE_CXX_STANDARD} mode")
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS -DNOMINMAX -wd4996)
@@ -54,6 +57,7 @@ endif()
 
 option(EXTERNAL_LIBOSMIUM "Do not use the bundled libosmium" OFF)
 option(EXTERNAL_PROTOZERO "Do not use the bundled protozero" OFF)
+option(EXTERNAL_FMT       "Do not use the bundled fmt"       OFF)
 
 #############################################################
 # Detect available headers and set global compiler options
@@ -78,10 +82,14 @@ if (NOT EXTERNAL_PROTOZERO)
     set(PROTOZERO_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/contrib/protozero/include")
 endif()
 
+if (NOT EXTERNAL_FMT)
+    set(FMT_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/contrib/fmt/include")
+endif()
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_BINARY_DIR})
 
 find_package(Osmium 2.14 REQUIRED COMPONENTS io proj)
-include_directories(SYSTEM ${OSMIUM_INCLUDE_DIRS} ${PROTOZERO_INCLUDE_DIR})
+include_directories(SYSTEM ${OSMIUM_INCLUDE_DIRS} ${PROTOZERO_INCLUDE_DIR} ${FMT_INCLUDE_DIR})
 
 if (WITH_LUA)
     if (WITH_LUAJIT)

--- a/contrib/fmt/LICENSE.rst
+++ b/contrib/fmt/LICENSE.rst
@@ -1,0 +1,27 @@
+Copyright (c) 2012 - present, Victor Zverovich
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--- Optional exception to the license ---
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into a machine-executable object form of such
+source code, you may redistribute such embedded portions in such object form
+without including the above copyright and permission notices.

--- a/contrib/fmt/README.contrib
+++ b/contrib/fmt/README.contrib
@@ -1,0 +1,2 @@
+Source: https://github.com/fmtlib/fmt
+Revision: v6.0.0

--- a/contrib/fmt/README.rst
+++ b/contrib/fmt/README.rst
@@ -1,0 +1,501 @@
+{fmt}
+=====
+
+.. image:: https://travis-ci.org/fmtlib/fmt.png?branch=master
+   :target: https://travis-ci.org/fmtlib/fmt
+
+.. image:: https://ci.appveyor.com/api/projects/status/ehjkiefde6gucy1v
+   :target: https://ci.appveyor.com/project/vitaut/fmt
+
+.. image:: https://img.shields.io/badge/stackoverflow-fmt-blue.svg
+   :alt: Ask questions at StackOverflow with the tag fmt
+   :target: http://stackoverflow.com/questions/tagged/fmt
+
+.. image:: https://oss-fuzz-build-logs.storage.googleapis.com/badges/libfmt.svg
+   :alt: fmt is continuously fuzzed att oss-fuzz
+   :target: https://bugs.chromium.org/p/oss-fuzz/issues/list?colspec=ID%20Type%20Component%20Status%20Proj%20Reported%20Owner%20Summary&q=proj%3Dlibfmt&can=1
+
+**{fmt}** is an open-source formatting library for C++.
+It can be used as a safe and fast alternative to (s)printf and iostreams.
+
+`Documentation <https://fmt.dev/latest/>`__
+
+Q&A: ask questions on `StackOverflow with the tag fmt <http://stackoverflow.com/questions/tagged/fmt>`_.
+
+Features
+--------
+
+* Replacement-based `format API <https://fmt.dev/dev/api.html>`_ with
+  positional arguments for localization.
+* `Format string syntax <https://fmt.dev/dev/syntax.html>`_ similar to the one
+  of `str.format <https://docs.python.org/3/library/stdtypes.html#str.format>`_
+  in Python.
+* Safe `printf implementation
+  <https://fmt.dev/latest/api.html#printf-formatting>`_ including
+  the POSIX extension for positional arguments.
+* Implementation of `C++20 std::format <https://fmt.dev/Text%20Formatting.html>`__.
+* Support for user-defined types.
+* High performance: faster than common standard library implementations of
+  `printf <http://en.cppreference.com/w/cpp/io/c/fprintf>`_ and
+  iostreams. See `Speed tests`_ and `Fast integer to string conversion in C++
+  <http://zverovich.net/2013/09/07/integer-to-string-conversion-in-cplusplus.html>`_.
+* Small code size both in terms of source code (the minimum configuration
+  consists of just three header files, ``core.h``, ``format.h`` and
+  ``format-inl.h``) and compiled code. See `Compile time and code bloat`_.
+* Reliability: the library has an extensive set of `unit tests
+  <https://github.com/fmtlib/fmt/tree/master/test>`_ and is continuously fuzzed.
+* Safety: the library is fully type safe, errors in format strings can be
+  reported at compile time, automatic memory management prevents buffer overflow
+  errors.
+* Ease of use: small self-contained code base, no external dependencies,
+  permissive MIT `license
+  <https://github.com/fmtlib/fmt/blob/master/LICENSE.rst>`_
+* `Portability <https://fmt.dev/latest/index.html#portability>`_ with
+  consistent output across platforms and support for older compilers.
+* Clean warning-free codebase even on high warning levels
+  (``-Wall -Wextra -pedantic``).
+* Support for wide strings.
+* Optional header-only configuration enabled with the ``FMT_HEADER_ONLY`` macro.
+
+See the `documentation <https://fmt.dev/latest/>`_ for more details.
+
+Examples
+--------
+
+Print ``Hello, world!`` to ``stdout``:
+
+.. code:: c++
+
+    fmt::print("Hello, {}!", "world");  // Python-like format string syntax
+    fmt::printf("Hello, %s!", "world"); // printf format string syntax
+
+Format a string and use positional arguments:
+
+.. code:: c++
+
+    std::string s = fmt::format("I'd rather be {1} than {0}.", "right", "happy");
+    // s == "I'd rather be happy than right."
+
+Check a format string at compile time:
+
+.. code:: c++
+
+    // test.cc
+    #include <fmt/format.h>
+    std::string s = format(FMT_STRING("{2}"), 42);
+
+.. code::
+
+    $ c++ -Iinclude -std=c++14 test.cc
+    ...
+    test.cc:4:17: note: in instantiation of function template specialization 'fmt::v5::format<S, int>' requested here
+    std::string s = format(FMT_STRING("{2}"), 42);
+                    ^
+    include/fmt/core.h:778:19: note: non-constexpr function 'on_error' cannot be used in a constant expression
+        ErrorHandler::on_error(message);
+                      ^
+    include/fmt/format.h:2226:16: note: in call to '&checker.context_->on_error(&"argument index out of range"[0])'
+          context_.on_error("argument index out of range");
+                   ^
+
+Use {fmt} as a safe portable replacement for ``itoa``
+(`godbolt <https://godbolt.org/g/NXmpU4>`_):
+
+.. code:: c++
+
+    fmt::memory_buffer buf;
+    format_to(buf, "{}", 42);    // replaces itoa(42, buffer, 10)
+    format_to(buf, "{:x}", 42);  // replaces itoa(42, buffer, 16)
+    // access the string with to_string(buf) or buf.data()
+
+Format objects of user-defined types via a simple `extension API
+<https://fmt.dev/latest/api.html#formatting-user-defined-types>`_:
+
+.. code:: c++
+
+    #include "fmt/format.h"
+
+    struct date {
+      int year, month, day;
+    };
+
+    template <>
+    struct fmt::formatter<date> {
+      constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+      template <typename FormatContext>
+      auto format(const date& d, FormatContext& ctx) {
+        return format_to(ctx.out(), "{}-{}-{}", d.year, d.month, d.day);
+      }
+    };
+
+    std::string s = fmt::format("The date is {}", date{2012, 12, 9});
+    // s == "The date is 2012-12-9"
+
+Create your own functions similar to `format
+<https://fmt.dev/latest/api.html#format>`_ and
+`print <https://fmt.dev/latest/api.html#print>`_
+which take arbitrary arguments (`godbolt <https://godbolt.org/g/MHjHVf>`_):
+
+.. code:: c++
+
+    // Prints formatted error message.
+    void vreport_error(const char* format, fmt::format_args args) {
+      fmt::print("Error: ");
+      fmt::vprint(format, args);
+    }
+    template <typename... Args>
+    void report_error(const char* format, const Args & ... args) {
+      vreport_error(format, fmt::make_format_args(args...));
+    }
+
+    report_error("file not found: {}", path);
+
+Note that ``vreport_error`` is not parameterized on argument types which can
+improve compile times and reduce code size compared to a fully parameterized
+version.
+
+Benchmarks
+----------
+
+Speed tests
+~~~~~~~~~~~
+
+================= ============= ===========
+Library           Method        Run Time, s
+================= ============= ===========
+libc              printf          1.03
+libc++            std::ostream    2.98
+{fmt} 4de41a      fmt::print      0.76
+Boost Format 1.67 boost::format   7.24
+Folly Format      folly::format   2.23
+================= ============= ===========
+
+{fmt} is the fastest of the benchmarked methods, ~35% faster than ``printf``.
+
+The above results were generated by building ``tinyformat_test.cpp`` on macOS
+10.14.3 with ``clang++ -O3 -DSPEED_TEST -DHAVE_FORMAT``, and taking the best of
+three runs. In the test, the format string ``"%0.10f:%04d:%+g:%s:%p:%c:%%\n"``
+or equivalent is filled 2,000,000 times with output sent to ``/dev/null``; for
+further details refer to the `source
+<https://github.com/fmtlib/format-benchmark/blob/master/tinyformat_test.cpp>`_.
+
+{fmt} is 10x faster than ``std::ostringstream`` and ``sprintf`` on floating-point
+formatting (`dtoa-benchmark <https://github.com/fmtlib/dtoa-benchmark>`_)
+and as fast as `double-conversion <https://github.com/google/double-conversion>`_:
+
+.. image:: https://user-images.githubusercontent.com/576385/54883977-9fe8c000-4e28-11e9-8bde-272d122e7c52.jpg
+   :target: https://fmt.dev/unknown_mac64_clang10.0.html
+
+Compile time and code bloat
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The script `bloat-test.py
+<https://github.com/fmtlib/format-benchmark/blob/master/bloat-test.py>`_
+from `format-benchmark <https://github.com/fmtlib/format-benchmark>`_
+tests compile time and code bloat for nontrivial projects.
+It generates 100 translation units and uses ``printf()`` or its alternative
+five times in each to simulate a medium sized project.  The resulting
+executable size and compile time (Apple LLVM version 8.1.0 (clang-802.0.42),
+macOS Sierra, best of three) is shown in the following tables.
+
+**Optimized build (-O3)**
+
+============= =============== ==================== ==================
+Method        Compile Time, s Executable size, KiB Stripped size, KiB
+============= =============== ==================== ==================
+printf                    2.6                   29                 26
+printf+string            16.4                   29                 26
+iostreams                31.1                   59                 55
+{fmt}                    19.0                   37                 34
+Boost Format             91.9                  226                203
+Folly Format            115.7                  101                 88
+============= =============== ==================== ==================
+
+As you can see, {fmt} has 60% less overhead in terms of resulting binary code
+size compared to iostreams and comes pretty close to ``printf``. Boost Format
+and Folly Format have the largest overheads.
+
+``printf+string`` is the same as ``printf`` but with extra ``<string>``
+include to measure the overhead of the latter.
+
+**Non-optimized build**
+
+============= =============== ==================== ==================
+Method        Compile Time, s Executable size, KiB Stripped size, KiB
+============= =============== ==================== ==================
+printf                    2.2                   33                 30
+printf+string            16.0                   33                 30
+iostreams                28.3                   56                 52
+{fmt}                    18.2                   59                 50
+Boost Format             54.1                  365                303
+Folly Format             79.9                  445                430
+============= =============== ==================== ==================
+
+``libc``, ``lib(std)c++`` and ``libfmt`` are all linked as shared libraries to
+compare formatting function overhead only. Boost Format is a
+header-only library so it doesn't provide any linkage options.
+
+Running the tests
+~~~~~~~~~~~~~~~~~
+
+Please refer to `Building the library`__ for the instructions on how to build
+the library and run the unit tests.
+
+__ https://fmt.dev/latest/usage.html#building-the-library
+
+Benchmarks reside in a separate repository,
+`format-benchmarks <https://github.com/fmtlib/format-benchmark>`_,
+so to run the benchmarks you first need to clone this repository and
+generate Makefiles with CMake::
+
+    $ git clone --recursive https://github.com/fmtlib/format-benchmark.git
+    $ cd format-benchmark
+    $ cmake .
+
+Then you can run the speed test::
+
+    $ make speed-test
+
+or the bloat test::
+
+    $ make bloat-test
+
+Projects using this library
+---------------------------
+
+* `0 A.D. <http://play0ad.com/>`_: A free, open-source, cross-platform real-time
+  strategy game
+
+* `AMPL/MP <https://github.com/ampl/mp>`_:
+  An open-source library for mathematical programming
+  
+* `AvioBook <https://www.aviobook.aero/en>`_: A comprehensive aircraft
+  operations suite
+  
+* `Celestia <https://celestia.space/>`_: Real-time 3D visualization of space
+
+* `Ceph <https://ceph.com/>`_: A scalable distributed storage system
+
+* `ccache <https://ccache.dev/>`_: A compiler cache
+
+* `CUAUV <http://cuauv.org/>`_: Cornell University's autonomous underwater
+  vehicle
+
+* `HarpyWar/pvpgn <https://github.com/pvpgn/pvpgn-server>`_:
+  Player vs Player Gaming Network with tweaks
+
+* `KBEngine <http://kbengine.org/>`_: An open-source MMOG server engine
+
+* `Keypirinha <http://keypirinha.com/>`_: A semantic launcher for Windows
+
+* `Kodi <https://kodi.tv/>`_ (formerly xbmc): Home theater software
+
+* `Lifeline <https://github.com/peter-clark/lifeline>`_: A 2D game
+
+* `Drake <http://drake.mit.edu/>`_: A planning, control, and analysis toolbox
+  for nonlinear dynamical systems (MIT)
+
+* `Envoy <https://lyft.github.io/envoy/>`_: C++ L7 proxy and communication bus
+  (Lyft)
+
+* `FiveM <https://fivem.net/>`_: a modification framework for GTA V
+
+* `MongoDB <https://mongodb.com/>`_: Distributed document database
+
+* `MongoDB Smasher <https://github.com/duckie/mongo_smasher>`_: A small tool to
+  generate randomized datasets
+
+* `OpenSpace <http://openspaceproject.com/>`_: An open-source astrovisualization
+  framework
+
+* `PenUltima Online (POL) <http://www.polserver.com/>`_:
+  An MMO server, compatible with most Ultima Online clients
+
+* `quasardb <https://www.quasardb.net/>`_: A distributed, high-performance,
+  associative database
+
+* `readpe <https://bitbucket.org/sys_dev/readpe>`_: Read Portable Executable
+
+* `redis-cerberus <https://github.com/HunanTV/redis-cerberus>`_: A Redis cluster
+  proxy
+
+* `rpclib <http://rpclib.net/>`_: A modern C++ msgpack-RPC server and client
+  library
+
+* `Saddy <https://github.com/mamontov-cpp/saddy-graphics-engine-2d>`_:
+  Small crossplatform 2D graphic engine
+
+* `Salesforce Analytics Cloud <http://www.salesforce.com/analytics-cloud/overview/>`_:
+  Business intelligence software
+
+* `Scylla <http://www.scylladb.com/>`_: A Cassandra-compatible NoSQL data store
+  that can handle 1 million transactions per second on a single server
+
+* `Seastar <http://www.seastar-project.org/>`_: An advanced, open-source C++
+  framework for high-performance server applications on modern hardware
+
+* `spdlog <https://github.com/gabime/spdlog>`_: Super fast C++ logging library
+
+* `Stellar <https://www.stellar.org/>`_: Financial platform
+
+* `Touch Surgery <https://www.touchsurgery.com/>`_: Surgery simulator
+
+* `TrinityCore <https://github.com/TrinityCore/TrinityCore>`_: Open-source
+  MMORPG framework
+
+`More... <https://github.com/search?q=fmtlib&type=Code>`_
+
+If you are aware of other projects using this library, please let me know
+by `email <mailto:victor.zverovich@gmail.com>`_ or by submitting an
+`issue <https://github.com/fmtlib/fmt/issues>`_.
+
+Motivation
+----------
+
+So why yet another formatting library?
+
+There are plenty of methods for doing this task, from standard ones like
+the printf family of function and iostreams to Boost Format and FastFormat
+libraries. The reason for creating a new library is that every existing
+solution that I found either had serious issues or didn't provide
+all the features I needed.
+
+printf
+~~~~~~
+
+The good thing about ``printf`` is that it is pretty fast and readily available
+being a part of the C standard library. The main drawback is that it
+doesn't support user-defined types. ``printf`` also has safety issues although
+they are somewhat mitigated with `__attribute__ ((format (printf, ...))
+<http://gcc.gnu.org/onlinedocs/gcc/Function-Attributes.html>`_ in GCC.
+There is a POSIX extension that adds positional arguments required for
+`i18n <https://en.wikipedia.org/wiki/Internationalization_and_localization>`_
+to ``printf`` but it is not a part of C99 and may not be available on some
+platforms.
+
+iostreams
+~~~~~~~~~
+
+The main issue with iostreams is best illustrated with an example:
+
+.. code:: c++
+
+    std::cout << std::setprecision(2) << std::fixed << 1.23456 << "\n";
+
+which is a lot of typing compared to printf:
+
+.. code:: c++
+
+    printf("%.2f\n", 1.23456);
+
+Matthew Wilson, the author of FastFormat, called this "chevron hell". iostreams
+don't support positional arguments by design.
+
+The good part is that iostreams support user-defined types and are safe although
+error handling is awkward.
+
+Boost Format
+~~~~~~~~~~~~
+
+This is a very powerful library which supports both ``printf``-like format
+strings and positional arguments. Its main drawback is performance. According to
+various benchmarks it is much slower than other methods considered here. Boost
+Format also has excessive build times and severe code bloat issues (see
+`Benchmarks`_).
+
+FastFormat
+~~~~~~~~~~
+
+This is an interesting library which is fast, safe and has positional
+arguments. However it has significant limitations, citing its author:
+
+    Three features that have no hope of being accommodated within the
+    current design are:
+
+    * Leading zeros (or any other non-space padding)
+    * Octal/hexadecimal encoding
+    * Runtime width/alignment specification
+
+It is also quite big and has a heavy dependency, STLSoft, which might be
+too restrictive for using it in some projects.
+
+Boost Spirit.Karma
+~~~~~~~~~~~~~~~~~~
+
+This is not really a formatting library but I decided to include it here for
+completeness. As iostreams, it suffers from the problem of mixing verbatim text
+with arguments. The library is pretty fast, but slower on integer formatting
+than ``fmt::format_int`` on Karma's own benchmark,
+see `Fast integer to string conversion in C++
+<http://zverovich.net/2013/09/07/integer-to-string-conversion-in-cplusplus.html>`_.
+
+FAQ
+---
+
+Q: how can I capture formatting arguments and format them later?
+
+A: use ``std::tuple``:
+
+.. code:: c++
+
+   template <typename... Args>
+   auto capture(const Args&... args) {
+     return std::make_tuple(args...);
+   }
+
+   auto print_message = [](const auto&... args) {
+     fmt::print(args...);
+   };
+
+   // Capture and store arguments:
+   auto args = capture("{} {}", 42, "foo");
+   // Do formatting:
+   std::apply(print_message, args);
+
+License
+-------
+
+{fmt} is distributed under the MIT `license
+<https://github.com/fmtlib/fmt/blob/master/LICENSE.rst>`_.
+
+The `Format String Syntax
+<https://fmt.dev/latest/syntax.html>`_
+section in the documentation is based on the one from Python `string module
+documentation <https://docs.python.org/3/library/string.html#module-string>`_
+adapted for the current library. For this reason the documentation is
+distributed under the Python Software Foundation license available in
+`doc/python-license.txt
+<https://raw.github.com/fmtlib/fmt/master/doc/python-license.txt>`_.
+It only applies if you distribute the documentation of fmt.
+
+Acknowledgments
+---------------
+
+The {fmt} library is maintained by Victor Zverovich (`vitaut
+<https://github.com/vitaut>`_) and Jonathan Müller (`foonathan
+<https://github.com/foonathan>`_) with contributions from many other people.
+See `Contributors <https://github.com/fmtlib/fmt/graphs/contributors>`_ and
+`Releases <https://github.com/fmtlib/fmt/releases>`_ for some of the names.
+Let us know if your contribution is not listed or mentioned incorrectly and
+we'll make it right.
+
+The benchmark section of this readme file and the performance tests are taken
+from the excellent `tinyformat <https://github.com/c42f/tinyformat>`_ library
+written by Chris Foster.  Boost Format library is acknowledged transitively
+since it had some influence on tinyformat.
+Some ideas used in the implementation are borrowed from `Loki
+<http://loki-lib.sourceforge.net/>`_ SafeFormat and `Diagnostic API
+<http://clang.llvm.org/doxygen/classclang_1_1Diagnostic.html>`_ in
+`Clang <http://clang.llvm.org/>`_.
+Format string syntax and the documentation are based on Python's `str.format
+<https://docs.python.org/3/library/stdtypes.html#str.format>`_.
+Thanks `Doug Turnbull <https://github.com/softwaredoug>`_ for his valuable
+comments and contribution to the design of the type-safe API and
+`Gregory Czajkowski <https://github.com/gcflymoto>`_ for implementing binary
+formatting. Thanks `Ruslan Baratov <https://github.com/ruslo>`_ for comprehensive
+`comparison of integer formatting algorithms <https://github.com/ruslo/int-dec-format-tests>`_
+and useful comments regarding performance, `Boris Kaul <https://github.com/localvoid>`_ for
+`C++ counting digits benchmark <https://github.com/localvoid/cxx-benchmark-count-digits>`_.
+Thanks to `CarterLi <https://github.com/CarterLi>`_ for contributing various
+improvements to the code.

--- a/contrib/fmt/include/fmt/chrono.h
+++ b/contrib/fmt/include/fmt/chrono.h
@@ -1,0 +1,829 @@
+// Formatting library for C++ - chrono support
+//
+// Copyright (c) 2012 - present, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_CHRONO_H_
+#define FMT_CHRONO_H_
+
+#include "format.h"
+#include "locale.h"
+
+#include <chrono>
+#include <ctime>
+#include <locale>
+#include <sstream>
+
+// enable safe chrono durations, unless explicitly disabled
+#ifndef FMT_SAFE_DURATION_CAST
+#  define FMT_SAFE_DURATION_CAST 1
+#endif
+
+#if FMT_SAFE_DURATION_CAST
+#  include "safe-duration-cast.h"
+#endif
+
+FMT_BEGIN_NAMESPACE
+
+// Prevents expansion of a preceding token as a function-style macro.
+// Usage: f FMT_NOMACRO()
+#define FMT_NOMACRO
+
+namespace internal {
+inline null<> localtime_r FMT_NOMACRO(...) { return null<>(); }
+inline null<> localtime_s(...) { return null<>(); }
+inline null<> gmtime_r(...) { return null<>(); }
+inline null<> gmtime_s(...) { return null<>(); }
+}  // namespace internal
+
+// Thread-safe replacement for std::localtime
+inline std::tm localtime(std::time_t time) {
+  struct dispatcher {
+    std::time_t time_;
+    std::tm tm_;
+
+    dispatcher(std::time_t t) : time_(t) {}
+
+    bool run() {
+      using namespace fmt::internal;
+      return handle(localtime_r(&time_, &tm_));
+    }
+
+    bool handle(std::tm* tm) { return tm != nullptr; }
+
+    bool handle(internal::null<>) {
+      using namespace fmt::internal;
+      return fallback(localtime_s(&tm_, &time_));
+    }
+
+    bool fallback(int res) { return res == 0; }
+
+#if !FMT_MSC_VER
+    bool fallback(internal::null<>) {
+      using namespace fmt::internal;
+      std::tm* tm = std::localtime(&time_);
+      if (tm) tm_ = *tm;
+      return tm != nullptr;
+    }
+#endif
+  };
+  dispatcher lt(time);
+  // Too big time values may be unsupported.
+  if (!lt.run()) FMT_THROW(format_error("time_t value out of range"));
+  return lt.tm_;
+}
+
+// Thread-safe replacement for std::gmtime
+inline std::tm gmtime(std::time_t time) {
+  struct dispatcher {
+    std::time_t time_;
+    std::tm tm_;
+
+    dispatcher(std::time_t t) : time_(t) {}
+
+    bool run() {
+      using namespace fmt::internal;
+      return handle(gmtime_r(&time_, &tm_));
+    }
+
+    bool handle(std::tm* tm) { return tm != nullptr; }
+
+    bool handle(internal::null<>) {
+      using namespace fmt::internal;
+      return fallback(gmtime_s(&tm_, &time_));
+    }
+
+    bool fallback(int res) { return res == 0; }
+
+#if !FMT_MSC_VER
+    bool fallback(internal::null<>) {
+      std::tm* tm = std::gmtime(&time_);
+      if (tm) tm_ = *tm;
+      return tm != nullptr;
+    }
+#endif
+  };
+  dispatcher gt(time);
+  // Too big time values may be unsupported.
+  if (!gt.run()) FMT_THROW(format_error("time_t value out of range"));
+  return gt.tm_;
+}
+
+namespace internal {
+inline std::size_t strftime(char* str, std::size_t count, const char* format,
+                            const std::tm* time) {
+  return std::strftime(str, count, format, time);
+}
+
+inline std::size_t strftime(wchar_t* str, std::size_t count,
+                            const wchar_t* format, const std::tm* time) {
+  return std::wcsftime(str, count, format, time);
+}
+}  // namespace internal
+
+template <typename Char> struct formatter<std::tm, Char> {
+  template <typename ParseContext>
+  auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
+    auto it = ctx.begin();
+    if (it != ctx.end() && *it == ':') ++it;
+    auto end = it;
+    while (end != ctx.end() && *end != '}') ++end;
+    tm_format.reserve(internal::to_unsigned(end - it + 1));
+    tm_format.append(it, end);
+    tm_format.push_back('\0');
+    return end;
+  }
+
+  template <typename FormatContext>
+  auto format(const std::tm& tm, FormatContext& ctx) -> decltype(ctx.out()) {
+    basic_memory_buffer<Char> buf;
+    std::size_t start = buf.size();
+    for (;;) {
+      std::size_t size = buf.capacity() - start;
+      std::size_t count =
+          internal::strftime(&buf[start], size, &tm_format[0], &tm);
+      if (count != 0) {
+        buf.resize(start + count);
+        break;
+      }
+      if (size >= tm_format.size() * 256) {
+        // If the buffer is 256 times larger than the format string, assume
+        // that `strftime` gives an empty result. There doesn't seem to be a
+        // better way to distinguish the two cases:
+        // https://github.com/fmtlib/fmt/issues/367
+        break;
+      }
+      const std::size_t MIN_GROWTH = 10;
+      buf.reserve(buf.capacity() + (size > MIN_GROWTH ? size : MIN_GROWTH));
+    }
+    return std::copy(buf.begin(), buf.end(), ctx.out());
+  }
+
+  basic_memory_buffer<Char> tm_format;
+};
+
+namespace internal {
+template <typename Period> FMT_CONSTEXPR const char* get_units() {
+  return nullptr;
+}
+template <> FMT_CONSTEXPR const char* get_units<std::atto>() { return "as"; }
+template <> FMT_CONSTEXPR const char* get_units<std::femto>() { return "fs"; }
+template <> FMT_CONSTEXPR const char* get_units<std::pico>() { return "ps"; }
+template <> FMT_CONSTEXPR const char* get_units<std::nano>() { return "ns"; }
+template <> FMT_CONSTEXPR const char* get_units<std::micro>() { return "µs"; }
+template <> FMT_CONSTEXPR const char* get_units<std::milli>() { return "ms"; }
+template <> FMT_CONSTEXPR const char* get_units<std::centi>() { return "cs"; }
+template <> FMT_CONSTEXPR const char* get_units<std::deci>() { return "ds"; }
+template <> FMT_CONSTEXPR const char* get_units<std::ratio<1>>() { return "s"; }
+template <> FMT_CONSTEXPR const char* get_units<std::deca>() { return "das"; }
+template <> FMT_CONSTEXPR const char* get_units<std::hecto>() { return "hs"; }
+template <> FMT_CONSTEXPR const char* get_units<std::kilo>() { return "ks"; }
+template <> FMT_CONSTEXPR const char* get_units<std::mega>() { return "Ms"; }
+template <> FMT_CONSTEXPR const char* get_units<std::giga>() { return "Gs"; }
+template <> FMT_CONSTEXPR const char* get_units<std::tera>() { return "Ts"; }
+template <> FMT_CONSTEXPR const char* get_units<std::peta>() { return "Ps"; }
+template <> FMT_CONSTEXPR const char* get_units<std::exa>() { return "Es"; }
+template <> FMT_CONSTEXPR const char* get_units<std::ratio<60>>() {
+  return "m";
+}
+template <> FMT_CONSTEXPR const char* get_units<std::ratio<3600>>() {
+  return "h";
+}
+
+enum class numeric_system {
+  standard,
+  // Alternative numeric system, e.g. 十二 instead of 12 in ja_JP locale.
+  alternative
+};
+
+// Parses a put_time-like format string and invokes handler actions.
+template <typename Char, typename Handler>
+FMT_CONSTEXPR const Char* parse_chrono_format(const Char* begin,
+                                              const Char* end,
+                                              Handler&& handler) {
+  auto ptr = begin;
+  while (ptr != end) {
+    auto c = *ptr;
+    if (c == '}') break;
+    if (c != '%') {
+      ++ptr;
+      continue;
+    }
+    if (begin != ptr) handler.on_text(begin, ptr);
+    ++ptr;  // consume '%'
+    if (ptr == end) FMT_THROW(format_error("invalid format"));
+    c = *ptr++;
+    switch (c) {
+    case '%':
+      handler.on_text(ptr - 1, ptr);
+      break;
+    case 'n': {
+      const char newline[] = "\n";
+      handler.on_text(newline, newline + 1);
+      break;
+    }
+    case 't': {
+      const char tab[] = "\t";
+      handler.on_text(tab, tab + 1);
+      break;
+    }
+    // Day of the week:
+    case 'a':
+      handler.on_abbr_weekday();
+      break;
+    case 'A':
+      handler.on_full_weekday();
+      break;
+    case 'w':
+      handler.on_dec0_weekday(numeric_system::standard);
+      break;
+    case 'u':
+      handler.on_dec1_weekday(numeric_system::standard);
+      break;
+    // Month:
+    case 'b':
+      handler.on_abbr_month();
+      break;
+    case 'B':
+      handler.on_full_month();
+      break;
+    // Hour, minute, second:
+    case 'H':
+      handler.on_24_hour(numeric_system::standard);
+      break;
+    case 'I':
+      handler.on_12_hour(numeric_system::standard);
+      break;
+    case 'M':
+      handler.on_minute(numeric_system::standard);
+      break;
+    case 'S':
+      handler.on_second(numeric_system::standard);
+      break;
+    // Other:
+    case 'c':
+      handler.on_datetime(numeric_system::standard);
+      break;
+    case 'x':
+      handler.on_loc_date(numeric_system::standard);
+      break;
+    case 'X':
+      handler.on_loc_time(numeric_system::standard);
+      break;
+    case 'D':
+      handler.on_us_date();
+      break;
+    case 'F':
+      handler.on_iso_date();
+      break;
+    case 'r':
+      handler.on_12_hour_time();
+      break;
+    case 'R':
+      handler.on_24_hour_time();
+      break;
+    case 'T':
+      handler.on_iso_time();
+      break;
+    case 'p':
+      handler.on_am_pm();
+      break;
+    case 'Q':
+      handler.on_duration_value();
+      break;
+    case 'q':
+      handler.on_duration_unit();
+      break;
+    case 'z':
+      handler.on_utc_offset();
+      break;
+    case 'Z':
+      handler.on_tz_name();
+      break;
+    // Alternative representation:
+    case 'E': {
+      if (ptr == end) FMT_THROW(format_error("invalid format"));
+      c = *ptr++;
+      switch (c) {
+      case 'c':
+        handler.on_datetime(numeric_system::alternative);
+        break;
+      case 'x':
+        handler.on_loc_date(numeric_system::alternative);
+        break;
+      case 'X':
+        handler.on_loc_time(numeric_system::alternative);
+        break;
+      default:
+        FMT_THROW(format_error("invalid format"));
+      }
+      break;
+    }
+    case 'O':
+      if (ptr == end) FMT_THROW(format_error("invalid format"));
+      c = *ptr++;
+      switch (c) {
+      case 'w':
+        handler.on_dec0_weekday(numeric_system::alternative);
+        break;
+      case 'u':
+        handler.on_dec1_weekday(numeric_system::alternative);
+        break;
+      case 'H':
+        handler.on_24_hour(numeric_system::alternative);
+        break;
+      case 'I':
+        handler.on_12_hour(numeric_system::alternative);
+        break;
+      case 'M':
+        handler.on_minute(numeric_system::alternative);
+        break;
+      case 'S':
+        handler.on_second(numeric_system::alternative);
+        break;
+      default:
+        FMT_THROW(format_error("invalid format"));
+      }
+      break;
+    default:
+      FMT_THROW(format_error("invalid format"));
+    }
+    begin = ptr;
+  }
+  if (begin != ptr) handler.on_text(begin, ptr);
+  return ptr;
+}
+
+struct chrono_format_checker {
+  FMT_NORETURN void report_no_date() { FMT_THROW(format_error("no date")); }
+
+  template <typename Char> void on_text(const Char*, const Char*) {}
+  FMT_NORETURN void on_abbr_weekday() { report_no_date(); }
+  FMT_NORETURN void on_full_weekday() { report_no_date(); }
+  FMT_NORETURN void on_dec0_weekday(numeric_system) { report_no_date(); }
+  FMT_NORETURN void on_dec1_weekday(numeric_system) { report_no_date(); }
+  FMT_NORETURN void on_abbr_month() { report_no_date(); }
+  FMT_NORETURN void on_full_month() { report_no_date(); }
+  void on_24_hour(numeric_system) {}
+  void on_12_hour(numeric_system) {}
+  void on_minute(numeric_system) {}
+  void on_second(numeric_system) {}
+  FMT_NORETURN void on_datetime(numeric_system) { report_no_date(); }
+  FMT_NORETURN void on_loc_date(numeric_system) { report_no_date(); }
+  FMT_NORETURN void on_loc_time(numeric_system) { report_no_date(); }
+  FMT_NORETURN void on_us_date() { report_no_date(); }
+  FMT_NORETURN void on_iso_date() { report_no_date(); }
+  void on_12_hour_time() {}
+  void on_24_hour_time() {}
+  void on_iso_time() {}
+  void on_am_pm() {}
+  void on_duration_value() {}
+  void on_duration_unit() {}
+  FMT_NORETURN void on_utc_offset() { report_no_date(); }
+  FMT_NORETURN void on_tz_name() { report_no_date(); }
+};
+
+template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
+inline bool isnan(T) {
+  return false;
+}
+template <typename T, FMT_ENABLE_IF(std::is_floating_point<T>::value)>
+inline bool isnan(T value) {
+  return std::isnan(value);
+}
+
+template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
+inline bool isfinite(T) {
+  return true;
+}
+template <typename T, FMT_ENABLE_IF(std::is_floating_point<T>::value)>
+inline bool isfinite(T value) {
+  return std::isfinite(value);
+}
+
+// Convers value to int and checks that it's in the range [0, upper).
+template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
+inline int to_nonnegative_int(T value, int upper) {
+  FMT_ASSERT(value >= 0 && value <= upper, "invalid value");
+  (void)upper;
+  return static_cast<int>(value);
+}
+template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
+inline int to_nonnegative_int(T value, int upper) {
+  FMT_ASSERT(
+      std::isnan(value) || (value >= 0 && value <= static_cast<T>(upper)),
+      "invalid value");
+  (void)upper;
+  return static_cast<int>(value);
+}
+
+template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
+inline T mod(T x, int y) {
+  return x % y;
+}
+template <typename T, FMT_ENABLE_IF(std::is_floating_point<T>::value)>
+inline T mod(T x, int y) {
+  return std::fmod(x, static_cast<T>(y));
+}
+
+// If T is an integral type, maps T to its unsigned counterpart, otherwise
+// leaves it unchanged (unlike std::make_unsigned).
+template <typename T, bool INTEGRAL = std::is_integral<T>::value>
+struct make_unsigned_or_unchanged {
+  using type = T;
+};
+
+template <typename T> struct make_unsigned_or_unchanged<T, true> {
+  using type = typename std::make_unsigned<T>::type;
+};
+
+#if FMT_SAFE_DURATION_CAST
+// throwing version of safe_duration_cast
+template <typename To, typename FromRep, typename FromPeriod>
+To fmt_safe_duration_cast(std::chrono::duration<FromRep, FromPeriod> from) {
+  int ec;
+  To to = safe_duration_cast::safe_duration_cast<To>(from, ec);
+  if (ec) FMT_THROW(format_error("cannot format duration"));
+  return to;
+}
+#endif
+
+template <typename Rep, typename Period,
+          FMT_ENABLE_IF(std::is_integral<Rep>::value)>
+inline std::chrono::duration<Rep, std::milli> get_milliseconds(
+    std::chrono::duration<Rep, Period> d) {
+  // this may overflow and/or the result may not fit in the
+  // target type.
+#if FMT_SAFE_DURATION_CAST
+  using CommonSecondsType =
+      typename std::common_type<decltype(d), std::chrono::seconds>::type;
+  const auto d_as_common = fmt_safe_duration_cast<CommonSecondsType>(d);
+  const auto d_as_whole_seconds =
+      fmt_safe_duration_cast<std::chrono::seconds>(d_as_common);
+  // this conversion should be nonproblematic
+  const auto diff = d_as_common - d_as_whole_seconds;
+  const auto ms =
+      fmt_safe_duration_cast<std::chrono::duration<Rep, std::milli>>(diff);
+  return ms;
+#else
+  auto s = std::chrono::duration_cast<std::chrono::seconds>(d);
+  return std::chrono::duration_cast<std::chrono::milliseconds>(d - s);
+#endif
+}
+
+template <typename Rep, typename Period,
+          FMT_ENABLE_IF(std::is_floating_point<Rep>::value)>
+inline std::chrono::duration<Rep, std::milli> get_milliseconds(
+    std::chrono::duration<Rep, Period> d) {
+  using common_type = typename std::common_type<Rep, std::intmax_t>::type;
+  auto ms = mod(d.count() * static_cast<common_type>(Period::num) /
+                    static_cast<common_type>(Period::den) * 1000,
+                1000);
+  return std::chrono::duration<Rep, std::milli>(static_cast<Rep>(ms));
+}
+
+template <typename Rep, typename OutputIt>
+OutputIt format_chrono_duration_value(OutputIt out, Rep val, int precision) {
+  if (precision >= 0) return format_to(out, "{:.{}f}", val, precision);
+  return format_to(out, std::is_floating_point<Rep>::value ? "{:g}" : "{}",
+                   val);
+}
+
+template <typename Period, typename OutputIt>
+static OutputIt format_chrono_duration_unit(OutputIt out) {
+  if (const char* unit = get_units<Period>()) return format_to(out, "{}", unit);
+  if (Period::den == 1) return format_to(out, "[{}]s", Period::num);
+  return format_to(out, "[{}/{}]s", Period::num, Period::den);
+}
+
+template <typename FormatContext, typename OutputIt, typename Rep,
+          typename Period>
+struct chrono_formatter {
+  FormatContext& context;
+  OutputIt out;
+  int precision;
+  // rep is unsigned to avoid overflow.
+  using rep =
+      conditional_t<std::is_integral<Rep>::value && sizeof(Rep) < sizeof(int),
+                    unsigned, typename make_unsigned_or_unchanged<Rep>::type>;
+  rep val;
+  using seconds = std::chrono::duration<rep>;
+  seconds s;
+  using milliseconds = std::chrono::duration<rep, std::milli>;
+  bool negative;
+
+  using char_type = typename FormatContext::char_type;
+
+  explicit chrono_formatter(FormatContext& ctx, OutputIt o,
+                            std::chrono::duration<Rep, Period> d)
+      : context(ctx), out(o), val(d.count()), negative(false) {
+    if (d.count() < 0) {
+      val = 0 - val;
+      negative = true;
+    }
+
+    // this may overflow and/or the result may not fit in the
+    // target type.
+#if FMT_SAFE_DURATION_CAST
+    // might need checked conversion (rep!=Rep)
+    auto tmpval = std::chrono::duration<rep, Period>(val);
+    s = fmt_safe_duration_cast<seconds>(tmpval);
+#else
+    s = std::chrono::duration_cast<seconds>(
+        std::chrono::duration<rep, Period>(val));
+#endif
+  }
+
+  // returns true if nan or inf, writes to out.
+  bool handle_nan_inf() {
+    if (isfinite(val)) {
+      return false;
+    }
+    if (isnan(val)) {
+      write_nan();
+      return true;
+    }
+    // must be +-inf
+    if (val > 0) {
+      write_pinf();
+    } else {
+      write_ninf();
+    }
+    return true;
+  }
+
+  Rep hour() const { return static_cast<Rep>(mod((s.count() / 3600), 24)); }
+
+  Rep hour12() const {
+    Rep hour = static_cast<Rep>(mod((s.count() / 3600), 12));
+    return hour <= 0 ? 12 : hour;
+  }
+
+  Rep minute() const { return static_cast<Rep>(mod((s.count() / 60), 60)); }
+  Rep second() const { return static_cast<Rep>(mod(s.count(), 60)); }
+
+  std::tm time() const {
+    auto time = std::tm();
+    time.tm_hour = to_nonnegative_int(hour(), 24);
+    time.tm_min = to_nonnegative_int(minute(), 60);
+    time.tm_sec = to_nonnegative_int(second(), 60);
+    return time;
+  }
+
+  void write_sign() {
+    if (negative) {
+      *out++ = '-';
+      negative = false;
+    }
+  }
+
+  void write(Rep value, int width) {
+    write_sign();
+    if (isnan(value)) return write_nan();
+    uint32_or_64_t<int> n = to_unsigned(
+        to_nonnegative_int(value, (std::numeric_limits<int>::max)()));
+    int num_digits = internal::count_digits(n);
+    if (width > num_digits) out = std::fill_n(out, width - num_digits, '0');
+    out = format_decimal<char_type>(out, n, num_digits);
+  }
+
+  void write_nan() { std::copy_n("nan", 3, out); }
+  void write_pinf() { std::copy_n("inf", 3, out); }
+  void write_ninf() { std::copy_n("-inf", 4, out); }
+
+  void format_localized(const tm& time, const char* format) {
+    if (isnan(val)) return write_nan();
+    auto locale = context.locale().template get<std::locale>();
+    auto& facet = std::use_facet<std::time_put<char_type>>(locale);
+    std::basic_ostringstream<char_type> os;
+    os.imbue(locale);
+    facet.put(os, os, ' ', &time, format, format + std::strlen(format));
+    auto str = os.str();
+    std::copy(str.begin(), str.end(), out);
+  }
+
+  void on_text(const char_type* begin, const char_type* end) {
+    std::copy(begin, end, out);
+  }
+
+  // These are not implemented because durations don't have date information.
+  void on_abbr_weekday() {}
+  void on_full_weekday() {}
+  void on_dec0_weekday(numeric_system) {}
+  void on_dec1_weekday(numeric_system) {}
+  void on_abbr_month() {}
+  void on_full_month() {}
+  void on_datetime(numeric_system) {}
+  void on_loc_date(numeric_system) {}
+  void on_loc_time(numeric_system) {}
+  void on_us_date() {}
+  void on_iso_date() {}
+  void on_utc_offset() {}
+  void on_tz_name() {}
+
+  void on_24_hour(numeric_system ns) {
+    if (handle_nan_inf()) return;
+
+    if (ns == numeric_system::standard) return write(hour(), 2);
+    auto time = tm();
+    time.tm_hour = to_nonnegative_int(hour(), 24);
+    format_localized(time, "%OH");
+  }
+
+  void on_12_hour(numeric_system ns) {
+    if (handle_nan_inf()) return;
+
+    if (ns == numeric_system::standard) return write(hour12(), 2);
+    auto time = tm();
+    time.tm_hour = to_nonnegative_int(hour12(), 12);
+    format_localized(time, "%OI");
+  }
+
+  void on_minute(numeric_system ns) {
+    if (handle_nan_inf()) return;
+
+    if (ns == numeric_system::standard) return write(minute(), 2);
+    auto time = tm();
+    time.tm_min = to_nonnegative_int(minute(), 60);
+    format_localized(time, "%OM");
+  }
+
+  void on_second(numeric_system ns) {
+    if (handle_nan_inf()) return;
+
+    if (ns == numeric_system::standard) {
+      write(second(), 2);
+#if FMT_SAFE_DURATION_CAST
+      // convert rep->Rep
+      using duration_rep = std::chrono::duration<rep, Period>;
+      using duration_Rep = std::chrono::duration<Rep, Period>;
+      auto tmpval = fmt_safe_duration_cast<duration_Rep>(duration_rep{val});
+#else
+      auto tmpval = std::chrono::duration<Rep, Period>(val);
+#endif
+      auto ms = get_milliseconds(tmpval);
+      if (ms != std::chrono::milliseconds(0)) {
+        *out++ = '.';
+        write(ms.count(), 3);
+      }
+      return;
+    }
+    auto time = tm();
+    time.tm_sec = to_nonnegative_int(second(), 60);
+    format_localized(time, "%OS");
+  }
+
+  void on_12_hour_time() {
+    if (handle_nan_inf()) return;
+
+    format_localized(time(), "%r");
+  }
+
+  void on_24_hour_time() {
+    if (handle_nan_inf()) {
+      *out++ = ':';
+      handle_nan_inf();
+      return;
+    }
+
+    write(hour(), 2);
+    *out++ = ':';
+    write(minute(), 2);
+  }
+
+  void on_iso_time() {
+    on_24_hour_time();
+    *out++ = ':';
+    if (handle_nan_inf()) return;
+    write(second(), 2);
+  }
+
+  void on_am_pm() {
+    if (handle_nan_inf()) return;
+    format_localized(time(), "%p");
+  }
+
+  void on_duration_value() {
+    if (handle_nan_inf()) return;
+    write_sign();
+    out = format_chrono_duration_value(out, val, precision);
+  }
+
+  void on_duration_unit() { out = format_chrono_duration_unit<Period>(out); }
+};
+}  // namespace internal
+
+template <typename Rep, typename Period, typename Char>
+struct formatter<std::chrono::duration<Rep, Period>, Char> {
+ private:
+  basic_format_specs<Char> specs;
+  int precision;
+  using arg_ref_type = internal::arg_ref<Char>;
+  arg_ref_type width_ref;
+  arg_ref_type precision_ref;
+  mutable basic_string_view<Char> format_str;
+  using duration = std::chrono::duration<Rep, Period>;
+
+  struct spec_handler {
+    formatter& f;
+    basic_parse_context<Char>& context;
+    basic_string_view<Char> format_str;
+
+    template <typename Id> FMT_CONSTEXPR arg_ref_type make_arg_ref(Id arg_id) {
+      context.check_arg_id(arg_id);
+      return arg_ref_type(arg_id);
+    }
+
+    FMT_CONSTEXPR arg_ref_type make_arg_ref(basic_string_view<Char> arg_id) {
+      context.check_arg_id(arg_id);
+      const auto str_val = internal::string_view_metadata(format_str, arg_id);
+      return arg_ref_type(str_val);
+    }
+
+    FMT_CONSTEXPR arg_ref_type make_arg_ref(internal::auto_id) {
+      return arg_ref_type(context.next_arg_id());
+    }
+
+    void on_error(const char* msg) { FMT_THROW(format_error(msg)); }
+    void on_fill(Char fill) { f.specs.fill[0] = fill; }
+    void on_align(align_t align) { f.specs.align = align; }
+    void on_width(unsigned width) { f.specs.width = width; }
+    void on_precision(unsigned precision) { f.precision = precision; }
+    void end_precision() {}
+
+    template <typename Id> void on_dynamic_width(Id arg_id) {
+      f.width_ref = make_arg_ref(arg_id);
+    }
+
+    template <typename Id> void on_dynamic_precision(Id arg_id) {
+      f.precision_ref = make_arg_ref(arg_id);
+    }
+  };
+
+  using iterator = typename basic_parse_context<Char>::iterator;
+  struct parse_range {
+    iterator begin;
+    iterator end;
+  };
+
+  FMT_CONSTEXPR parse_range do_parse(basic_parse_context<Char>& ctx) {
+    auto begin = ctx.begin(), end = ctx.end();
+    if (begin == end || *begin == '}') return {begin, begin};
+    spec_handler handler{*this, ctx, format_str};
+    begin = internal::parse_align(begin, end, handler);
+    if (begin == end) return {begin, begin};
+    begin = internal::parse_width(begin, end, handler);
+    if (begin == end) return {begin, begin};
+    if (*begin == '.') {
+      if (std::is_floating_point<Rep>::value)
+        begin = internal::parse_precision(begin, end, handler);
+      else
+        handler.on_error("precision not allowed for this argument type");
+    }
+    end = parse_chrono_format(begin, end, internal::chrono_format_checker());
+    return {begin, end};
+  }
+
+ public:
+  formatter() : precision(-1) {}
+
+  FMT_CONSTEXPR auto parse(basic_parse_context<Char>& ctx)
+      -> decltype(ctx.begin()) {
+    auto range = do_parse(ctx);
+    format_str = basic_string_view<Char>(
+        &*range.begin, internal::to_unsigned(range.end - range.begin));
+    return range.end;
+  }
+
+  template <typename FormatContext>
+  auto format(const duration& d, FormatContext& ctx) -> decltype(ctx.out()) {
+    auto begin = format_str.begin(), end = format_str.end();
+    // As a possible future optimization, we could avoid extra copying if width
+    // is not specified.
+    basic_memory_buffer<Char> buf;
+    auto out = std::back_inserter(buf);
+    using range = internal::output_range<decltype(ctx.out()), Char>;
+    internal::basic_writer<range> w(range(ctx.out()));
+    internal::handle_dynamic_spec<internal::width_checker>(
+        specs.width, width_ref, ctx, format_str.begin());
+    internal::handle_dynamic_spec<internal::precision_checker>(
+        precision, precision_ref, ctx, format_str.begin());
+    if (begin == end || *begin == '}') {
+      out = internal::format_chrono_duration_value(out, d.count(), precision);
+      internal::format_chrono_duration_unit<Period>(out);
+    } else {
+      internal::chrono_formatter<FormatContext, decltype(out), Rep, Period> f(
+          ctx, out, d);
+      f.precision = precision;
+      parse_chrono_format(begin, end, f);
+    }
+    w.write(buf.data(), buf.size(), specs);
+    return w.out();
+  }
+};
+
+FMT_END_NAMESPACE
+
+#endif  // FMT_CHRONO_H_

--- a/contrib/fmt/include/fmt/color.h
+++ b/contrib/fmt/include/fmt/color.h
@@ -1,0 +1,585 @@
+// Formatting library for C++ - color support
+//
+// Copyright (c) 2018 - present, Victor Zverovich and fmt contributors
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_COLOR_H_
+#define FMT_COLOR_H_
+
+#include "format.h"
+
+FMT_BEGIN_NAMESPACE
+
+enum class color : uint32_t {
+  alice_blue = 0xF0F8FF,               // rgb(240,248,255)
+  antique_white = 0xFAEBD7,            // rgb(250,235,215)
+  aqua = 0x00FFFF,                     // rgb(0,255,255)
+  aquamarine = 0x7FFFD4,               // rgb(127,255,212)
+  azure = 0xF0FFFF,                    // rgb(240,255,255)
+  beige = 0xF5F5DC,                    // rgb(245,245,220)
+  bisque = 0xFFE4C4,                   // rgb(255,228,196)
+  black = 0x000000,                    // rgb(0,0,0)
+  blanched_almond = 0xFFEBCD,          // rgb(255,235,205)
+  blue = 0x0000FF,                     // rgb(0,0,255)
+  blue_violet = 0x8A2BE2,              // rgb(138,43,226)
+  brown = 0xA52A2A,                    // rgb(165,42,42)
+  burly_wood = 0xDEB887,               // rgb(222,184,135)
+  cadet_blue = 0x5F9EA0,               // rgb(95,158,160)
+  chartreuse = 0x7FFF00,               // rgb(127,255,0)
+  chocolate = 0xD2691E,                // rgb(210,105,30)
+  coral = 0xFF7F50,                    // rgb(255,127,80)
+  cornflower_blue = 0x6495ED,          // rgb(100,149,237)
+  cornsilk = 0xFFF8DC,                 // rgb(255,248,220)
+  crimson = 0xDC143C,                  // rgb(220,20,60)
+  cyan = 0x00FFFF,                     // rgb(0,255,255)
+  dark_blue = 0x00008B,                // rgb(0,0,139)
+  dark_cyan = 0x008B8B,                // rgb(0,139,139)
+  dark_golden_rod = 0xB8860B,          // rgb(184,134,11)
+  dark_gray = 0xA9A9A9,                // rgb(169,169,169)
+  dark_green = 0x006400,               // rgb(0,100,0)
+  dark_khaki = 0xBDB76B,               // rgb(189,183,107)
+  dark_magenta = 0x8B008B,             // rgb(139,0,139)
+  dark_olive_green = 0x556B2F,         // rgb(85,107,47)
+  dark_orange = 0xFF8C00,              // rgb(255,140,0)
+  dark_orchid = 0x9932CC,              // rgb(153,50,204)
+  dark_red = 0x8B0000,                 // rgb(139,0,0)
+  dark_salmon = 0xE9967A,              // rgb(233,150,122)
+  dark_sea_green = 0x8FBC8F,           // rgb(143,188,143)
+  dark_slate_blue = 0x483D8B,          // rgb(72,61,139)
+  dark_slate_gray = 0x2F4F4F,          // rgb(47,79,79)
+  dark_turquoise = 0x00CED1,           // rgb(0,206,209)
+  dark_violet = 0x9400D3,              // rgb(148,0,211)
+  deep_pink = 0xFF1493,                // rgb(255,20,147)
+  deep_sky_blue = 0x00BFFF,            // rgb(0,191,255)
+  dim_gray = 0x696969,                 // rgb(105,105,105)
+  dodger_blue = 0x1E90FF,              // rgb(30,144,255)
+  fire_brick = 0xB22222,               // rgb(178,34,34)
+  floral_white = 0xFFFAF0,             // rgb(255,250,240)
+  forest_green = 0x228B22,             // rgb(34,139,34)
+  fuchsia = 0xFF00FF,                  // rgb(255,0,255)
+  gainsboro = 0xDCDCDC,                // rgb(220,220,220)
+  ghost_white = 0xF8F8FF,              // rgb(248,248,255)
+  gold = 0xFFD700,                     // rgb(255,215,0)
+  golden_rod = 0xDAA520,               // rgb(218,165,32)
+  gray = 0x808080,                     // rgb(128,128,128)
+  green = 0x008000,                    // rgb(0,128,0)
+  green_yellow = 0xADFF2F,             // rgb(173,255,47)
+  honey_dew = 0xF0FFF0,                // rgb(240,255,240)
+  hot_pink = 0xFF69B4,                 // rgb(255,105,180)
+  indian_red = 0xCD5C5C,               // rgb(205,92,92)
+  indigo = 0x4B0082,                   // rgb(75,0,130)
+  ivory = 0xFFFFF0,                    // rgb(255,255,240)
+  khaki = 0xF0E68C,                    // rgb(240,230,140)
+  lavender = 0xE6E6FA,                 // rgb(230,230,250)
+  lavender_blush = 0xFFF0F5,           // rgb(255,240,245)
+  lawn_green = 0x7CFC00,               // rgb(124,252,0)
+  lemon_chiffon = 0xFFFACD,            // rgb(255,250,205)
+  light_blue = 0xADD8E6,               // rgb(173,216,230)
+  light_coral = 0xF08080,              // rgb(240,128,128)
+  light_cyan = 0xE0FFFF,               // rgb(224,255,255)
+  light_golden_rod_yellow = 0xFAFAD2,  // rgb(250,250,210)
+  light_gray = 0xD3D3D3,               // rgb(211,211,211)
+  light_green = 0x90EE90,              // rgb(144,238,144)
+  light_pink = 0xFFB6C1,               // rgb(255,182,193)
+  light_salmon = 0xFFA07A,             // rgb(255,160,122)
+  light_sea_green = 0x20B2AA,          // rgb(32,178,170)
+  light_sky_blue = 0x87CEFA,           // rgb(135,206,250)
+  light_slate_gray = 0x778899,         // rgb(119,136,153)
+  light_steel_blue = 0xB0C4DE,         // rgb(176,196,222)
+  light_yellow = 0xFFFFE0,             // rgb(255,255,224)
+  lime = 0x00FF00,                     // rgb(0,255,0)
+  lime_green = 0x32CD32,               // rgb(50,205,50)
+  linen = 0xFAF0E6,                    // rgb(250,240,230)
+  magenta = 0xFF00FF,                  // rgb(255,0,255)
+  maroon = 0x800000,                   // rgb(128,0,0)
+  medium_aquamarine = 0x66CDAA,        // rgb(102,205,170)
+  medium_blue = 0x0000CD,              // rgb(0,0,205)
+  medium_orchid = 0xBA55D3,            // rgb(186,85,211)
+  medium_purple = 0x9370DB,            // rgb(147,112,219)
+  medium_sea_green = 0x3CB371,         // rgb(60,179,113)
+  medium_slate_blue = 0x7B68EE,        // rgb(123,104,238)
+  medium_spring_green = 0x00FA9A,      // rgb(0,250,154)
+  medium_turquoise = 0x48D1CC,         // rgb(72,209,204)
+  medium_violet_red = 0xC71585,        // rgb(199,21,133)
+  midnight_blue = 0x191970,            // rgb(25,25,112)
+  mint_cream = 0xF5FFFA,               // rgb(245,255,250)
+  misty_rose = 0xFFE4E1,               // rgb(255,228,225)
+  moccasin = 0xFFE4B5,                 // rgb(255,228,181)
+  navajo_white = 0xFFDEAD,             // rgb(255,222,173)
+  navy = 0x000080,                     // rgb(0,0,128)
+  old_lace = 0xFDF5E6,                 // rgb(253,245,230)
+  olive = 0x808000,                    // rgb(128,128,0)
+  olive_drab = 0x6B8E23,               // rgb(107,142,35)
+  orange = 0xFFA500,                   // rgb(255,165,0)
+  orange_red = 0xFF4500,               // rgb(255,69,0)
+  orchid = 0xDA70D6,                   // rgb(218,112,214)
+  pale_golden_rod = 0xEEE8AA,          // rgb(238,232,170)
+  pale_green = 0x98FB98,               // rgb(152,251,152)
+  pale_turquoise = 0xAFEEEE,           // rgb(175,238,238)
+  pale_violet_red = 0xDB7093,          // rgb(219,112,147)
+  papaya_whip = 0xFFEFD5,              // rgb(255,239,213)
+  peach_puff = 0xFFDAB9,               // rgb(255,218,185)
+  peru = 0xCD853F,                     // rgb(205,133,63)
+  pink = 0xFFC0CB,                     // rgb(255,192,203)
+  plum = 0xDDA0DD,                     // rgb(221,160,221)
+  powder_blue = 0xB0E0E6,              // rgb(176,224,230)
+  purple = 0x800080,                   // rgb(128,0,128)
+  rebecca_purple = 0x663399,           // rgb(102,51,153)
+  red = 0xFF0000,                      // rgb(255,0,0)
+  rosy_brown = 0xBC8F8F,               // rgb(188,143,143)
+  royal_blue = 0x4169E1,               // rgb(65,105,225)
+  saddle_brown = 0x8B4513,             // rgb(139,69,19)
+  salmon = 0xFA8072,                   // rgb(250,128,114)
+  sandy_brown = 0xF4A460,              // rgb(244,164,96)
+  sea_green = 0x2E8B57,                // rgb(46,139,87)
+  sea_shell = 0xFFF5EE,                // rgb(255,245,238)
+  sienna = 0xA0522D,                   // rgb(160,82,45)
+  silver = 0xC0C0C0,                   // rgb(192,192,192)
+  sky_blue = 0x87CEEB,                 // rgb(135,206,235)
+  slate_blue = 0x6A5ACD,               // rgb(106,90,205)
+  slate_gray = 0x708090,               // rgb(112,128,144)
+  snow = 0xFFFAFA,                     // rgb(255,250,250)
+  spring_green = 0x00FF7F,             // rgb(0,255,127)
+  steel_blue = 0x4682B4,               // rgb(70,130,180)
+  tan = 0xD2B48C,                      // rgb(210,180,140)
+  teal = 0x008080,                     // rgb(0,128,128)
+  thistle = 0xD8BFD8,                  // rgb(216,191,216)
+  tomato = 0xFF6347,                   // rgb(255,99,71)
+  turquoise = 0x40E0D0,                // rgb(64,224,208)
+  violet = 0xEE82EE,                   // rgb(238,130,238)
+  wheat = 0xF5DEB3,                    // rgb(245,222,179)
+  white = 0xFFFFFF,                    // rgb(255,255,255)
+  white_smoke = 0xF5F5F5,              // rgb(245,245,245)
+  yellow = 0xFFFF00,                   // rgb(255,255,0)
+  yellow_green = 0x9ACD32              // rgb(154,205,50)
+};                                     // enum class color
+
+enum class terminal_color : uint8_t {
+  black = 30,
+  red,
+  green,
+  yellow,
+  blue,
+  magenta,
+  cyan,
+  white,
+  bright_black = 90,
+  bright_red,
+  bright_green,
+  bright_yellow,
+  bright_blue,
+  bright_magenta,
+  bright_cyan,
+  bright_white
+};
+
+enum class emphasis : uint8_t {
+  bold = 1,
+  italic = 1 << 1,
+  underline = 1 << 2,
+  strikethrough = 1 << 3
+};
+
+// rgb is a struct for red, green and blue colors.
+// Using the name "rgb" makes some editors show the color in a tooltip.
+struct rgb {
+  FMT_CONSTEXPR rgb() : r(0), g(0), b(0) {}
+  FMT_CONSTEXPR rgb(uint8_t r_, uint8_t g_, uint8_t b_) : r(r_), g(g_), b(b_) {}
+  FMT_CONSTEXPR rgb(uint32_t hex)
+      : r((hex >> 16) & 0xFF), g((hex >> 8) & 0xFF), b(hex & 0xFF) {}
+  FMT_CONSTEXPR rgb(color hex)
+      : r((uint32_t(hex) >> 16) & 0xFF),
+        g((uint32_t(hex) >> 8) & 0xFF),
+        b(uint32_t(hex) & 0xFF) {}
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+};
+
+namespace internal {
+
+// color is a struct of either a rgb color or a terminal color.
+struct color_type {
+  FMT_CONSTEXPR color_type() FMT_NOEXCEPT : is_rgb(), value{} {}
+  FMT_CONSTEXPR color_type(color rgb_color) FMT_NOEXCEPT : is_rgb(true),
+                                                           value{} {
+    value.rgb_color = static_cast<uint32_t>(rgb_color);
+  }
+  FMT_CONSTEXPR color_type(rgb rgb_color) FMT_NOEXCEPT : is_rgb(true), value{} {
+    value.rgb_color = (static_cast<uint32_t>(rgb_color.r) << 16) |
+                      (static_cast<uint32_t>(rgb_color.g) << 8) | rgb_color.b;
+  }
+  FMT_CONSTEXPR color_type(terminal_color term_color) FMT_NOEXCEPT : is_rgb(),
+                                                                     value{} {
+    value.term_color = static_cast<uint8_t>(term_color);
+  }
+  bool is_rgb;
+  union color_union {
+    uint8_t term_color;
+    uint32_t rgb_color;
+  } value;
+};
+}  // namespace internal
+
+// Experimental text formatting support.
+class text_style {
+ public:
+  FMT_CONSTEXPR text_style(emphasis em = emphasis()) FMT_NOEXCEPT
+      : set_foreground_color(),
+        set_background_color(),
+        ems(em) {}
+
+  FMT_CONSTEXPR text_style& operator|=(const text_style& rhs) {
+    if (!set_foreground_color) {
+      set_foreground_color = rhs.set_foreground_color;
+      foreground_color = rhs.foreground_color;
+    } else if (rhs.set_foreground_color) {
+      if (!foreground_color.is_rgb || !rhs.foreground_color.is_rgb)
+        FMT_THROW(format_error("can't OR a terminal color"));
+      foreground_color.value.rgb_color |= rhs.foreground_color.value.rgb_color;
+    }
+
+    if (!set_background_color) {
+      set_background_color = rhs.set_background_color;
+      background_color = rhs.background_color;
+    } else if (rhs.set_background_color) {
+      if (!background_color.is_rgb || !rhs.background_color.is_rgb)
+        FMT_THROW(format_error("can't OR a terminal color"));
+      background_color.value.rgb_color |= rhs.background_color.value.rgb_color;
+    }
+
+    ems = static_cast<emphasis>(static_cast<uint8_t>(ems) |
+                                static_cast<uint8_t>(rhs.ems));
+    return *this;
+  }
+
+  friend FMT_CONSTEXPR text_style operator|(text_style lhs,
+                                            const text_style& rhs) {
+    return lhs |= rhs;
+  }
+
+  FMT_CONSTEXPR text_style& operator&=(const text_style& rhs) {
+    if (!set_foreground_color) {
+      set_foreground_color = rhs.set_foreground_color;
+      foreground_color = rhs.foreground_color;
+    } else if (rhs.set_foreground_color) {
+      if (!foreground_color.is_rgb || !rhs.foreground_color.is_rgb)
+        FMT_THROW(format_error("can't AND a terminal color"));
+      foreground_color.value.rgb_color &= rhs.foreground_color.value.rgb_color;
+    }
+
+    if (!set_background_color) {
+      set_background_color = rhs.set_background_color;
+      background_color = rhs.background_color;
+    } else if (rhs.set_background_color) {
+      if (!background_color.is_rgb || !rhs.background_color.is_rgb)
+        FMT_THROW(format_error("can't AND a terminal color"));
+      background_color.value.rgb_color &= rhs.background_color.value.rgb_color;
+    }
+
+    ems = static_cast<emphasis>(static_cast<uint8_t>(ems) &
+                                static_cast<uint8_t>(rhs.ems));
+    return *this;
+  }
+
+  friend FMT_CONSTEXPR text_style operator&(text_style lhs,
+                                            const text_style& rhs) {
+    return lhs &= rhs;
+  }
+
+  FMT_CONSTEXPR bool has_foreground() const FMT_NOEXCEPT {
+    return set_foreground_color;
+  }
+  FMT_CONSTEXPR bool has_background() const FMT_NOEXCEPT {
+    return set_background_color;
+  }
+  FMT_CONSTEXPR bool has_emphasis() const FMT_NOEXCEPT {
+    return static_cast<uint8_t>(ems) != 0;
+  }
+  FMT_CONSTEXPR internal::color_type get_foreground() const FMT_NOEXCEPT {
+    assert(has_foreground() && "no foreground specified for this style");
+    return foreground_color;
+  }
+  FMT_CONSTEXPR internal::color_type get_background() const FMT_NOEXCEPT {
+    assert(has_background() && "no background specified for this style");
+    return background_color;
+  }
+  FMT_CONSTEXPR emphasis get_emphasis() const FMT_NOEXCEPT {
+    assert(has_emphasis() && "no emphasis specified for this style");
+    return ems;
+  }
+
+ private:
+  FMT_CONSTEXPR text_style(bool is_foreground,
+                           internal::color_type text_color) FMT_NOEXCEPT
+      : set_foreground_color(),
+        set_background_color(),
+        ems() {
+    if (is_foreground) {
+      foreground_color = text_color;
+      set_foreground_color = true;
+    } else {
+      background_color = text_color;
+      set_background_color = true;
+    }
+  }
+
+  friend FMT_CONSTEXPR_DECL text_style fg(internal::color_type foreground)
+      FMT_NOEXCEPT;
+  friend FMT_CONSTEXPR_DECL text_style bg(internal::color_type background)
+      FMT_NOEXCEPT;
+
+  internal::color_type foreground_color;
+  internal::color_type background_color;
+  bool set_foreground_color;
+  bool set_background_color;
+  emphasis ems;
+};
+
+FMT_CONSTEXPR text_style fg(internal::color_type foreground) FMT_NOEXCEPT {
+  return text_style(/*is_foreground=*/true, foreground);
+}
+
+FMT_CONSTEXPR text_style bg(internal::color_type background) FMT_NOEXCEPT {
+  return text_style(/*is_foreground=*/false, background);
+}
+
+FMT_CONSTEXPR text_style operator|(emphasis lhs, emphasis rhs) FMT_NOEXCEPT {
+  return text_style(lhs) | rhs;
+}
+
+namespace internal {
+
+template <typename Char> struct ansi_color_escape {
+  FMT_CONSTEXPR ansi_color_escape(internal::color_type text_color,
+                                  const char* esc) FMT_NOEXCEPT {
+    // If we have a terminal color, we need to output another escape code
+    // sequence.
+    if (!text_color.is_rgb) {
+      bool is_background = esc == internal::data::background_color;
+      uint32_t value = text_color.value.term_color;
+      // Background ASCII codes are the same as the foreground ones but with
+      // 10 more.
+      if (is_background) value += 10u;
+
+      std::size_t index = 0;
+      buffer[index++] = static_cast<Char>('\x1b');
+      buffer[index++] = static_cast<Char>('[');
+
+      if (value >= 100u) {
+        buffer[index++] = static_cast<Char>('1');
+        value %= 100u;
+      }
+      buffer[index++] = static_cast<Char>('0' + value / 10u);
+      buffer[index++] = static_cast<Char>('0' + value % 10u);
+
+      buffer[index++] = static_cast<Char>('m');
+      buffer[index++] = static_cast<Char>('\0');
+      return;
+    }
+
+    for (int i = 0; i < 7; i++) {
+      buffer[i] = static_cast<Char>(esc[i]);
+    }
+    rgb color(text_color.value.rgb_color);
+    to_esc(color.r, buffer + 7, ';');
+    to_esc(color.g, buffer + 11, ';');
+    to_esc(color.b, buffer + 15, 'm');
+    buffer[19] = static_cast<Char>(0);
+  }
+  FMT_CONSTEXPR ansi_color_escape(emphasis em) FMT_NOEXCEPT {
+    uint8_t em_codes[4] = {};
+    uint8_t em_bits = static_cast<uint8_t>(em);
+    if (em_bits & static_cast<uint8_t>(emphasis::bold)) em_codes[0] = 1;
+    if (em_bits & static_cast<uint8_t>(emphasis::italic)) em_codes[1] = 3;
+    if (em_bits & static_cast<uint8_t>(emphasis::underline)) em_codes[2] = 4;
+    if (em_bits & static_cast<uint8_t>(emphasis::strikethrough))
+      em_codes[3] = 9;
+
+    std::size_t index = 0;
+    for (int i = 0; i < 4; ++i) {
+      if (!em_codes[i]) continue;
+      buffer[index++] = static_cast<Char>('\x1b');
+      buffer[index++] = static_cast<Char>('[');
+      buffer[index++] = static_cast<Char>('0' + em_codes[i]);
+      buffer[index++] = static_cast<Char>('m');
+    }
+    buffer[index++] = static_cast<Char>(0);
+  }
+  FMT_CONSTEXPR operator const Char*() const FMT_NOEXCEPT { return buffer; }
+
+  FMT_CONSTEXPR const Char* begin() const FMT_NOEXCEPT { return buffer; }
+  FMT_CONSTEXPR const Char* end() const FMT_NOEXCEPT {
+    return buffer + std::strlen(buffer);
+  }
+
+ private:
+  Char buffer[7u + 3u * 4u + 1u];
+
+  static FMT_CONSTEXPR void to_esc(uint8_t c, Char* out,
+                                   char delimiter) FMT_NOEXCEPT {
+    out[0] = static_cast<Char>('0' + c / 100);
+    out[1] = static_cast<Char>('0' + c / 10 % 10);
+    out[2] = static_cast<Char>('0' + c % 10);
+    out[3] = static_cast<Char>(delimiter);
+  }
+};
+
+template <typename Char>
+FMT_CONSTEXPR ansi_color_escape<Char> make_foreground_color(
+    internal::color_type foreground) FMT_NOEXCEPT {
+  return ansi_color_escape<Char>(foreground, internal::data::foreground_color);
+}
+
+template <typename Char>
+FMT_CONSTEXPR ansi_color_escape<Char> make_background_color(
+    internal::color_type background) FMT_NOEXCEPT {
+  return ansi_color_escape<Char>(background, internal::data::background_color);
+}
+
+template <typename Char>
+FMT_CONSTEXPR ansi_color_escape<Char> make_emphasis(emphasis em) FMT_NOEXCEPT {
+  return ansi_color_escape<Char>(em);
+}
+
+template <typename Char>
+inline void fputs(const Char* chars, FILE* stream) FMT_NOEXCEPT {
+  std::fputs(chars, stream);
+}
+
+template <>
+inline void fputs<wchar_t>(const wchar_t* chars, FILE* stream) FMT_NOEXCEPT {
+  std::fputws(chars, stream);
+}
+
+template <typename Char> inline void reset_color(FILE* stream) FMT_NOEXCEPT {
+  fputs(internal::data::reset_color, stream);
+}
+
+template <> inline void reset_color<wchar_t>(FILE* stream) FMT_NOEXCEPT {
+  fputs(internal::data::wreset_color, stream);
+}
+
+template <typename Char>
+inline void reset_color(basic_memory_buffer<Char>& buffer) FMT_NOEXCEPT {
+  const char* begin = data::reset_color;
+  const char* end = begin + sizeof(data::reset_color) - 1;
+  buffer.append(begin, end);
+}
+
+template <typename Char>
+std::basic_string<Char> vformat(const text_style& ts,
+                                basic_string_view<Char> format_str,
+                                basic_format_args<buffer_context<Char> > args) {
+  basic_memory_buffer<Char> buffer;
+  bool has_style = false;
+  if (ts.has_emphasis()) {
+    has_style = true;
+    ansi_color_escape<Char> escape = make_emphasis<Char>(ts.get_emphasis());
+    buffer.append(escape.begin(), escape.end());
+  }
+  if (ts.has_foreground()) {
+    has_style = true;
+    ansi_color_escape<Char> escape =
+        make_foreground_color<Char>(ts.get_foreground());
+    buffer.append(escape.begin(), escape.end());
+  }
+  if (ts.has_background()) {
+    has_style = true;
+    ansi_color_escape<Char> escape =
+        make_background_color<Char>(ts.get_background());
+    buffer.append(escape.begin(), escape.end());
+  }
+  internal::vformat_to(buffer, format_str, args);
+  if (has_style) {
+    reset_color<Char>(buffer);
+  }
+  return fmt::to_string(buffer);
+}
+}  // namespace internal
+
+template <typename S, typename Char = char_t<S> >
+void vprint(std::FILE* f, const text_style& ts, const S& format,
+            basic_format_args<buffer_context<Char> > args) {
+  bool has_style = false;
+  if (ts.has_emphasis()) {
+    has_style = true;
+    internal::fputs<Char>(internal::make_emphasis<Char>(ts.get_emphasis()), f);
+  }
+  if (ts.has_foreground()) {
+    has_style = true;
+    internal::fputs<Char>(
+        internal::make_foreground_color<Char>(ts.get_foreground()), f);
+  }
+  if (ts.has_background()) {
+    has_style = true;
+    internal::fputs<Char>(
+        internal::make_background_color<Char>(ts.get_background()), f);
+  }
+  vprint(f, format, args);
+  if (has_style) {
+    internal::reset_color<Char>(f);
+  }
+}
+
+/**
+  Formats a string and prints it to the specified file stream using ANSI
+  escape sequences to specify text formatting.
+  Example:
+    fmt::print(fmt::emphasis::bold | fg(fmt::color::red),
+               "Elapsed time: {0:.2f} seconds", 1.23);
+ */
+template <typename S, typename... Args,
+          FMT_ENABLE_IF(internal::is_string<S>::value)>
+void print(std::FILE* f, const text_style& ts, const S& format_str,
+           const Args&... args) {
+  internal::check_format_string<Args...>(format_str);
+  using context = buffer_context<char_t<S> >;
+  format_arg_store<context, Args...> as{args...};
+  vprint(f, ts, format_str, basic_format_args<context>(as));
+}
+
+/**
+  Formats a string and prints it to stdout using ANSI escape sequences to
+  specify text formatting.
+  Example:
+    fmt::print(fmt::emphasis::bold | fg(fmt::color::red),
+               "Elapsed time: {0:.2f} seconds", 1.23);
+ */
+template <typename S, typename... Args,
+          FMT_ENABLE_IF(internal::is_string<S>::value)>
+void print(const text_style& ts, const S& format_str, const Args&... args) {
+  return print(stdout, ts, format_str, args...);
+}
+
+template <typename S, typename Char = char_t<S> >
+inline std::basic_string<Char> vformat(
+    const text_style& ts, const S& format_str,
+    basic_format_args<buffer_context<Char> > args) {
+  return internal::vformat(ts, to_string_view(format_str), args);
+}
+
+/**
+  \rst
+  Formats arguments and returns the result as a string using ANSI
+  escape sequences to specify text formatting.
+
+  **Example**::
+
+    #include <fmt/color.h>
+    std::string message = fmt::format(fmt::emphasis::bold | fg(fmt::color::red),
+                                      "The answer is {}", 42);
+  \endrst
+*/
+template <typename S, typename... Args, typename Char = char_t<S> >
+inline std::basic_string<Char> format(const text_style& ts, const S& format_str,
+                                      const Args&... args) {
+  return internal::vformat(ts, to_string_view(format_str),
+                           {internal::make_args_checked(format_str, args...)});
+}
+
+FMT_END_NAMESPACE
+
+#endif  // FMT_COLOR_H_

--- a/contrib/fmt/include/fmt/compile.h
+++ b/contrib/fmt/include/fmt/compile.h
@@ -1,0 +1,466 @@
+// Formatting library for C++ - experimental format string compilation
+//
+// Copyright (c) 2012 - present, Victor Zverovich and fmt contributors
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_COMPILE_H_
+#define FMT_COMPILE_H_
+
+#include <vector>
+#include "format.h"
+
+FMT_BEGIN_NAMESPACE
+namespace internal {
+
+template <typename Char> struct format_part {
+ public:
+  struct named_argument_id {
+    FMT_CONSTEXPR named_argument_id(internal::string_view_metadata id)
+        : id(id) {}
+    internal::string_view_metadata id;
+  };
+
+  struct argument_id {
+    FMT_CONSTEXPR argument_id() : argument_id(0u) {}
+
+    FMT_CONSTEXPR argument_id(unsigned id)
+        : which(which_arg_id::index), val(id) {}
+
+    FMT_CONSTEXPR argument_id(internal::string_view_metadata id)
+        : which(which_arg_id::named_index), val(id) {}
+
+    enum class which_arg_id { index, named_index };
+
+    which_arg_id which;
+
+    union value {
+      FMT_CONSTEXPR value() : index(0u) {}
+      FMT_CONSTEXPR value(unsigned id) : index(id) {}
+      FMT_CONSTEXPR value(internal::string_view_metadata id)
+          : named_index(id) {}
+
+      unsigned index;
+      internal::string_view_metadata named_index;
+    } val;
+  };
+
+  struct specification {
+    FMT_CONSTEXPR specification() : arg_id(0u) {}
+    FMT_CONSTEXPR specification(unsigned id) : arg_id(id) {}
+
+    FMT_CONSTEXPR specification(internal::string_view_metadata id)
+        : arg_id(id) {}
+
+    argument_id arg_id;
+    internal::dynamic_format_specs<Char> parsed_specs;
+  };
+
+  FMT_CONSTEXPR format_part()
+      : which(kind::argument_id), end_of_argument_id(0u), val(0u) {}
+
+  FMT_CONSTEXPR format_part(internal::string_view_metadata text)
+      : which(kind::text), end_of_argument_id(0u), val(text) {}
+
+  FMT_CONSTEXPR format_part(unsigned id)
+      : which(kind::argument_id), end_of_argument_id(0u), val(id) {}
+
+  FMT_CONSTEXPR format_part(named_argument_id arg_id)
+      : which(kind::named_argument_id), end_of_argument_id(0u), val(arg_id) {}
+
+  FMT_CONSTEXPR format_part(specification spec)
+      : which(kind::specification), end_of_argument_id(0u), val(spec) {}
+
+  enum class kind { argument_id, named_argument_id, text, specification };
+
+  kind which;
+  std::size_t end_of_argument_id;
+  union value {
+    FMT_CONSTEXPR value() : arg_id(0u) {}
+    FMT_CONSTEXPR value(unsigned id) : arg_id(id) {}
+    FMT_CONSTEXPR value(named_argument_id named_id)
+        : named_arg_id(named_id.id) {}
+    FMT_CONSTEXPR value(internal::string_view_metadata t) : text(t) {}
+    FMT_CONSTEXPR value(specification s) : spec(s) {}
+    unsigned arg_id;
+    internal::string_view_metadata named_arg_id;
+    internal::string_view_metadata text;
+    specification spec;
+  } val;
+};
+
+template <typename Char, typename PartsContainer>
+class format_preparation_handler : public internal::error_handler {
+ private:
+  using part = format_part<Char>;
+
+ public:
+  using iterator = typename basic_string_view<Char>::iterator;
+
+  FMT_CONSTEXPR format_preparation_handler(basic_string_view<Char> format,
+                                           PartsContainer& parts)
+      : parts_(parts), format_(format), parse_context_(format) {}
+
+  FMT_CONSTEXPR void on_text(const Char* begin, const Char* end) {
+    if (begin == end) return;
+    const auto offset = begin - format_.data();
+    const auto size = end - begin;
+    parts_.push_back(part(string_view_metadata(offset, size)));
+  }
+
+  FMT_CONSTEXPR void on_arg_id() {
+    parts_.push_back(part(parse_context_.next_arg_id()));
+  }
+
+  FMT_CONSTEXPR void on_arg_id(unsigned id) {
+    parse_context_.check_arg_id(id);
+    parts_.push_back(part(id));
+  }
+
+  FMT_CONSTEXPR void on_arg_id(basic_string_view<Char> id) {
+    const auto view = string_view_metadata(format_, id);
+    const auto arg_id = typename part::named_argument_id(view);
+    parts_.push_back(part(arg_id));
+  }
+
+  FMT_CONSTEXPR void on_replacement_field(const Char* ptr) {
+    parts_.back().end_of_argument_id = ptr - format_.begin();
+  }
+
+  FMT_CONSTEXPR const Char* on_format_specs(const Char* begin,
+                                            const Char* end) {
+    const auto specs_offset = to_unsigned(begin - format_.begin());
+
+    using parse_context = basic_parse_context<Char>;
+    internal::dynamic_format_specs<Char> parsed_specs;
+    dynamic_specs_handler<parse_context> handler(parsed_specs, parse_context_);
+    begin = parse_format_specs(begin, end, handler);
+
+    if (*begin != '}') on_error("missing '}' in format string");
+
+    auto& last_part = parts_.back();
+    auto specs = last_part.which == part::kind::argument_id
+                     ? typename part::specification(last_part.val.arg_id)
+                     : typename part::specification(last_part.val.named_arg_id);
+    specs.parsed_specs = parsed_specs;
+    last_part = part(specs);
+    last_part.end_of_argument_id = specs_offset;
+    return begin;
+  }
+
+ private:
+  PartsContainer& parts_;
+  basic_string_view<Char> format_;
+  basic_parse_context<Char> parse_context_;
+};
+
+template <typename Format, typename PreparedPartsProvider, typename... Args>
+class prepared_format {
+ public:
+  using char_type = char_t<Format>;
+  using format_part_t = format_part<char_type>;
+
+  constexpr prepared_format(Format f)
+      : format_(std::move(f)), parts_provider_(to_string_view(format_)) {}
+
+  prepared_format() = delete;
+
+  using context = buffer_context<char_type>;
+
+  template <typename Range, typename Context>
+  auto vformat_to(Range out, basic_format_args<Context> args) const ->
+      typename Context::iterator {
+    const auto format_view = internal::to_string_view(format_);
+    basic_parse_context<char_type> parse_ctx(format_view);
+    Context ctx(out.begin(), args);
+
+    const auto& parts = parts_provider_.parts();
+    for (auto part_it = parts.begin(); part_it != parts.end(); ++part_it) {
+      const auto& part = *part_it;
+      const auto& value = part.val;
+
+      switch (part.which) {
+      case format_part_t::kind::text: {
+        const auto text = value.text.to_view(format_view.data());
+        auto output = ctx.out();
+        auto&& it = internal::reserve(output, text.size());
+        it = std::copy_n(text.begin(), text.size(), it);
+        ctx.advance_to(output);
+      } break;
+
+      case format_part_t::kind::argument_id: {
+        advance_parse_context_to_specification(parse_ctx, part);
+        format_arg<Range>(parse_ctx, ctx, value.arg_id);
+      } break;
+
+      case format_part_t::kind::named_argument_id: {
+        advance_parse_context_to_specification(parse_ctx, part);
+        const auto named_arg_id =
+            value.named_arg_id.to_view(format_view.data());
+        format_arg<Range>(parse_ctx, ctx, named_arg_id);
+      } break;
+      case format_part_t::kind::specification: {
+        const auto& arg_id_value = value.spec.arg_id.val;
+        const auto arg = value.spec.arg_id.which ==
+                                 format_part_t::argument_id::which_arg_id::index
+                             ? ctx.arg(arg_id_value.index)
+                             : ctx.arg(arg_id_value.named_index.to_view(
+                                   to_string_view(format_).data()));
+
+        auto specs = value.spec.parsed_specs;
+
+        handle_dynamic_spec<internal::width_checker>(
+            specs.width, specs.width_ref, ctx, format_view.begin());
+        handle_dynamic_spec<internal::precision_checker>(
+            specs.precision, specs.precision_ref, ctx, format_view.begin());
+
+        check_prepared_specs(specs, arg.type());
+        advance_parse_context_to_specification(parse_ctx, part);
+        ctx.advance_to(
+            visit_format_arg(arg_formatter<Range>(ctx, nullptr, &specs), arg));
+      } break;
+      }
+    }
+
+    return ctx.out();
+  }
+
+ private:
+  void advance_parse_context_to_specification(
+      basic_parse_context<char_type>& parse_ctx,
+      const format_part_t& part) const {
+    const auto view = to_string_view(format_);
+    const auto specification_begin = view.data() + part.end_of_argument_id;
+    advance_to(parse_ctx, specification_begin);
+  }
+
+  template <typename Range, typename Context, typename Id>
+  void format_arg(basic_parse_context<char_type>& parse_ctx, Context& ctx,
+                  Id arg_id) const {
+    parse_ctx.check_arg_id(arg_id);
+    const auto stopped_at =
+        visit_format_arg(arg_formatter<Range>(ctx), ctx.arg(arg_id));
+    ctx.advance_to(stopped_at);
+  }
+
+  template <typename Char>
+  void check_prepared_specs(const basic_format_specs<Char>& specs,
+                            internal::type arg_type) const {
+    internal::error_handler h;
+    numeric_specs_checker<internal::error_handler> checker(h, arg_type);
+    if (specs.align == align::numeric) checker.require_numeric_argument();
+    if (specs.sign != sign::none) checker.check_sign();
+    if (specs.alt) checker.require_numeric_argument();
+    if (specs.precision >= 0) checker.check_precision();
+  }
+
+ private:
+  Format format_;
+  PreparedPartsProvider parts_provider_;
+};
+
+template <typename Char> struct part_counter {
+  unsigned num_parts = 0;
+
+  FMT_CONSTEXPR void on_text(const Char* begin, const Char* end) {
+    if (begin != end) ++num_parts;
+  }
+
+  FMT_CONSTEXPR void on_arg_id() { ++num_parts; }
+  FMT_CONSTEXPR void on_arg_id(unsigned) { ++num_parts; }
+  FMT_CONSTEXPR void on_arg_id(basic_string_view<Char>) { ++num_parts; }
+
+  FMT_CONSTEXPR void on_replacement_field(const Char*) {}
+
+  FMT_CONSTEXPR const Char* on_format_specs(const Char* begin,
+                                            const Char* end) {
+    // Find the matching brace.
+    unsigned braces_counter = 0;
+    for (; begin != end; ++begin) {
+      if (*begin == '{') {
+        ++braces_counter;
+      } else if (*begin == '}') {
+        if (braces_counter == 0u) break;
+        --braces_counter;
+      }
+    }
+    return begin;
+  }
+
+  FMT_CONSTEXPR void on_error(const char*) {}
+};
+
+template <typename Format> class compiletime_prepared_parts_type_provider {
+ private:
+  using char_type = char_t<Format>;
+
+  static FMT_CONSTEXPR unsigned count_parts() {
+    FMT_CONSTEXPR_DECL const auto text = to_string_view(Format{});
+    part_counter<char_type> counter;
+    internal::parse_format_string</*IS_CONSTEXPR=*/true>(text, counter);
+    return counter.num_parts;
+  }
+
+// Workaround for old compilers. Compiletime parts preparation will not be
+// performed with them anyway.
+#if FMT_USE_CONSTEXPR
+  static FMT_CONSTEXPR_DECL const unsigned number_of_format_parts =
+      compiletime_prepared_parts_type_provider::count_parts();
+#else
+  static const unsigned number_of_format_parts = 0u;
+#endif
+
+ public:
+  template <unsigned N> struct format_parts_array {
+    using value_type = format_part<char_type>;
+
+    FMT_CONSTEXPR format_parts_array() : arr{} {}
+
+    FMT_CONSTEXPR value_type& operator[](unsigned ind) { return arr[ind]; }
+
+    FMT_CONSTEXPR const value_type* begin() const { return arr; }
+    FMT_CONSTEXPR const value_type* end() const { return begin() + N; }
+
+   private:
+    value_type arr[N];
+  };
+
+  struct empty {
+    // Parts preparator will search for it
+    using value_type = format_part<char_type>;
+  };
+
+  using type = conditional_t<number_of_format_parts != 0,
+                             format_parts_array<number_of_format_parts>, empty>;
+};
+
+template <typename Parts> class compiletime_prepared_parts_collector {
+ private:
+  using format_part = typename Parts::value_type;
+
+ public:
+  FMT_CONSTEXPR explicit compiletime_prepared_parts_collector(Parts& parts)
+      : parts_{parts}, counter_{0u} {}
+
+  FMT_CONSTEXPR void push_back(format_part part) { parts_[counter_++] = part; }
+
+  FMT_CONSTEXPR format_part& back() { return parts_[counter_ - 1]; }
+
+ private:
+  Parts& parts_;
+  unsigned counter_;
+};
+
+template <typename PartsContainer, typename Char>
+FMT_CONSTEXPR PartsContainer prepare_parts(basic_string_view<Char> format) {
+  PartsContainer parts;
+  internal::parse_format_string</*IS_CONSTEXPR=*/false>(
+      format, format_preparation_handler<Char, PartsContainer>(format, parts));
+  return parts;
+}
+
+template <typename PartsContainer, typename Char>
+FMT_CONSTEXPR PartsContainer
+prepare_compiletime_parts(basic_string_view<Char> format) {
+  using collector = compiletime_prepared_parts_collector<PartsContainer>;
+
+  PartsContainer parts;
+  collector c(parts);
+  internal::parse_format_string</*IS_CONSTEXPR=*/true>(
+      format, format_preparation_handler<Char, collector>(format, c));
+  return parts;
+}
+
+template <typename PartsContainer> class runtime_parts_provider {
+ public:
+  runtime_parts_provider() = delete;
+  template <typename Char>
+  runtime_parts_provider(basic_string_view<Char> format)
+      : parts_(prepare_parts<PartsContainer>(format)) {}
+
+  const PartsContainer& parts() const { return parts_; }
+
+ private:
+  PartsContainer parts_;
+};
+
+template <typename Format, typename PartsContainer>
+struct compiletime_parts_provider {
+  compiletime_parts_provider() = delete;
+  template <typename Char>
+  FMT_CONSTEXPR compiletime_parts_provider(basic_string_view<Char>) {}
+
+  const PartsContainer& parts() const {
+    static FMT_CONSTEXPR_DECL const PartsContainer prepared_parts =
+        prepare_compiletime_parts<PartsContainer>(
+            internal::to_string_view(Format{}));
+
+    return prepared_parts;
+  }
+};
+}  // namespace internal
+
+#if FMT_USE_CONSTEXPR
+template <typename... Args, typename S,
+          FMT_ENABLE_IF(is_compile_string<S>::value)>
+FMT_CONSTEXPR auto compile(S format_str) -> internal::prepared_format<
+    S,
+    internal::compiletime_parts_provider<
+        S,
+        typename internal::compiletime_prepared_parts_type_provider<S>::type>,
+    Args...> {
+  return format_str;
+}
+#endif
+
+template <typename... Args, typename Char, size_t N>
+auto compile(const Char (&format_str)[N]) -> internal::prepared_format<
+    std::basic_string<Char>,
+    internal::runtime_parts_provider<std::vector<internal::format_part<Char>>>,
+    Args...> {
+  return std::basic_string<Char>(format_str, N - 1);
+}
+
+template <typename CompiledFormat, typename... Args,
+          typename Char = typename CompiledFormat::char_type>
+std::basic_string<Char> format(const CompiledFormat& cf, const Args&... args) {
+  basic_memory_buffer<Char> buffer;
+  using range = internal::buffer_range<Char>;
+  using context = buffer_context<Char>;
+  cf.template vformat_to<range, context>(range(buffer),
+                                         {make_format_args<context>(args...)});
+  return to_string(buffer);
+}
+
+template <typename OutputIt, typename CompiledFormat, typename... Args>
+OutputIt format_to(OutputIt out, const CompiledFormat& cf,
+                   const Args&... args) {
+  using char_type = typename CompiledFormat::char_type;
+  using range = internal::output_range<OutputIt, char_type>;
+  using context = format_context_t<OutputIt, char_type>;
+  return cf.template vformat_to<range, context>(
+      range(out), {make_format_args<context>(args...)});
+}
+
+template <typename OutputIt, typename CompiledFormat, typename... Args,
+          FMT_ENABLE_IF(internal::is_output_iterator<OutputIt>::value)>
+format_to_n_result<OutputIt> format_to_n(OutputIt out, size_t n,
+                                         const CompiledFormat& cf,
+                                         const Args&... args) {
+  auto it =
+      format_to(internal::truncating_iterator<OutputIt>(out, n), cf, args...);
+  return {it.base(), it.count()};
+}
+
+template <typename CompiledFormat, typename... Args>
+std::size_t formatted_size(const CompiledFormat& cf, const Args&... args) {
+  return fmt::format_to(
+             internal::counting_iterator<typename CompiledFormat::char_type>(),
+             cf, args...)
+      .count();
+}
+
+FMT_END_NAMESPACE
+
+#endif  // FMT_COMPILE_H_

--- a/contrib/fmt/include/fmt/core.h
+++ b/contrib/fmt/include/fmt/core.h
@@ -1,0 +1,1414 @@
+// Formatting library for C++ - the core API
+//
+// Copyright (c) 2012 - present, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_CORE_H_
+#define FMT_CORE_H_
+
+#include <cassert>
+#include <cstdio>  // std::FILE
+#include <cstring>
+#include <iterator>
+#include <string>
+#include <type_traits>
+
+// The fmt library version in the form major * 10000 + minor * 100 + patch.
+#define FMT_VERSION 60000
+
+#ifdef __has_feature
+#  define FMT_HAS_FEATURE(x) __has_feature(x)
+#else
+#  define FMT_HAS_FEATURE(x) 0
+#endif
+
+#if defined(__has_include) && !defined(__INTELLISENSE__) && \
+    !(defined(__INTEL_COMPILER) && __INTEL_COMPILER < 1600)
+#  define FMT_HAS_INCLUDE(x) __has_include(x)
+#else
+#  define FMT_HAS_INCLUDE(x) 0
+#endif
+
+#ifdef __has_cpp_attribute
+#  define FMT_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+#else
+#  define FMT_HAS_CPP_ATTRIBUTE(x) 0
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+#  define FMT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+#else
+#  define FMT_GCC_VERSION 0
+#endif
+
+#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+#  define FMT_HAS_GXX_CXX11 FMT_GCC_VERSION
+#else
+#  define FMT_HAS_GXX_CXX11 0
+#endif
+
+#ifdef _MSC_VER
+#  define FMT_MSC_VER _MSC_VER
+#else
+#  define FMT_MSC_VER 0
+#endif
+
+// Check if relaxed C++14 constexpr is supported.
+// GCC doesn't allow throw in constexpr until version 6 (bug 67371).
+#ifndef FMT_USE_CONSTEXPR
+#  define FMT_USE_CONSTEXPR                                           \
+    (FMT_HAS_FEATURE(cxx_relaxed_constexpr) || FMT_MSC_VER >= 1910 || \
+     (FMT_GCC_VERSION >= 600 && __cplusplus >= 201402L))
+#endif
+#if FMT_USE_CONSTEXPR
+#  define FMT_CONSTEXPR constexpr
+#  define FMT_CONSTEXPR_DECL constexpr
+#else
+#  define FMT_CONSTEXPR inline
+#  define FMT_CONSTEXPR_DECL
+#endif
+
+#ifndef FMT_OVERRIDE
+#  if FMT_HAS_FEATURE(cxx_override) || \
+      (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1900
+#    define FMT_OVERRIDE override
+#  else
+#    define FMT_OVERRIDE
+#  endif
+#endif
+
+// Check if exceptions are disabled.
+#ifndef FMT_EXCEPTIONS
+#  if (defined(__GNUC__) && !defined(__EXCEPTIONS)) || \
+      FMT_MSC_VER && !_HAS_EXCEPTIONS
+#    define FMT_EXCEPTIONS 0
+#  else
+#    define FMT_EXCEPTIONS 1
+#  endif
+#endif
+
+// Define FMT_USE_NOEXCEPT to make fmt use noexcept (C++11 feature).
+#ifndef FMT_USE_NOEXCEPT
+#  define FMT_USE_NOEXCEPT 0
+#endif
+
+#if FMT_USE_NOEXCEPT || FMT_HAS_FEATURE(cxx_noexcept) || \
+    (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1900
+#  define FMT_DETECTED_NOEXCEPT noexcept
+#  define FMT_HAS_CXX11_NOEXCEPT 1
+#else
+#  define FMT_DETECTED_NOEXCEPT throw()
+#  define FMT_HAS_CXX11_NOEXCEPT 0
+#endif
+
+#ifndef FMT_NOEXCEPT
+#  if FMT_EXCEPTIONS || FMT_HAS_CXX11_NOEXCEPT
+#    define FMT_NOEXCEPT FMT_DETECTED_NOEXCEPT
+#  else
+#    define FMT_NOEXCEPT
+#  endif
+#endif
+
+// [[noreturn]] is disabled on MSVC because of bogus unreachable code warnings.
+#if FMT_EXCEPTIONS && FMT_HAS_CPP_ATTRIBUTE(noreturn) && !FMT_MSC_VER
+#  define FMT_NORETURN [[noreturn]]
+#else
+#  define FMT_NORETURN
+#endif
+
+#ifndef FMT_DEPRECATED
+#  if (FMT_HAS_CPP_ATTRIBUTE(deprecated) && __cplusplus >= 201402L) || \
+      FMT_MSC_VER >= 1900
+#    define FMT_DEPRECATED [[deprecated]]
+#  else
+#    if defined(__GNUC__) || defined(__clang__)
+#      define FMT_DEPRECATED __attribute__((deprecated))
+#    elif FMT_MSC_VER
+#      define FMT_DEPRECATED __declspec(deprecated)
+#    else
+#      define FMT_DEPRECATED /* deprecated */
+#    endif
+#  endif
+#endif
+
+#ifndef FMT_BEGIN_NAMESPACE
+#  if FMT_HAS_FEATURE(cxx_inline_namespaces) || FMT_GCC_VERSION >= 404 || \
+      FMT_MSC_VER >= 1900
+#    define FMT_INLINE_NAMESPACE inline namespace
+#    define FMT_END_NAMESPACE \
+      }                       \
+      }
+#  else
+#    define FMT_INLINE_NAMESPACE namespace
+#    define FMT_END_NAMESPACE \
+      }                       \
+      using namespace v6;     \
+      }
+#  endif
+#  define FMT_BEGIN_NAMESPACE \
+    namespace fmt {           \
+    FMT_INLINE_NAMESPACE v6 {
+#endif
+
+#if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
+#  ifdef FMT_EXPORT
+#    define FMT_API __declspec(dllexport)
+#  elif defined(FMT_SHARED)
+#    define FMT_API __declspec(dllimport)
+#    define FMT_EXTERN_TEMPLATE_API FMT_API
+#  endif
+#endif
+#ifndef FMT_API
+#  define FMT_API
+#endif
+#ifndef FMT_EXTERN_TEMPLATE_API
+#  define FMT_EXTERN_TEMPLATE_API
+#endif
+
+#ifndef FMT_HEADER_ONLY
+#  define FMT_EXTERN extern
+#else
+#  define FMT_EXTERN
+#endif
+
+#ifndef FMT_ASSERT
+#  define FMT_ASSERT(condition, message) assert((condition) && message)
+#endif
+
+// libc++ supports string_view in pre-c++17.
+#if (FMT_HAS_INCLUDE(<string_view>) &&                       \
+     (__cplusplus > 201402L || defined(_LIBCPP_VERSION))) || \
+    (defined(_MSVC_LANG) && _MSVC_LANG > 201402L && _MSC_VER >= 1910)
+#  include <string_view>
+#  define FMT_USE_STRING_VIEW
+#elif FMT_HAS_INCLUDE("experimental/string_view") && __cplusplus >= 201402L
+#  include <experimental/string_view>
+#  define FMT_USE_EXPERIMENTAL_STRING_VIEW
+#endif
+
+FMT_BEGIN_NAMESPACE
+
+// Implementations of enable_if_t and other types for pre-C++14 systems.
+template <bool B, class T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+template <bool B, class T, class F>
+using conditional_t = typename std::conditional<B, T, F>::type;
+template <bool B> using bool_constant = std::integral_constant<bool, B>;
+template <typename T>
+using remove_reference_t = typename std::remove_reference<T>::type;
+template <typename T>
+using remove_const_t = typename std::remove_const<T>::type;
+
+struct monostate {};
+
+// An enable_if helper to be used in template parameters which results in much
+// shorter symbols: https://godbolt.org/z/sWw4vP. Extra parentheses are needed
+// to workaround a bug in MSVC 2019 (see #1140 and #1186).
+#define FMT_ENABLE_IF(...) enable_if_t<(__VA_ARGS__), int> = 0
+
+namespace internal {
+
+// A workaround for gcc 4.8 to make void_t work in a SFINAE context.
+template <typename... Ts> struct void_t_impl { using type = void; };
+
+#if defined(FMT_USE_STRING_VIEW)
+template <typename Char> using std_string_view = std::basic_string_view<Char>;
+#elif defined(FMT_USE_EXPERIMENTAL_STRING_VIEW)
+template <typename Char>
+using std_string_view = std::experimental::basic_string_view<Char>;
+#else
+template <typename T> struct std_string_view {};
+#endif
+
+// Casts nonnegative integer to unsigned.
+template <typename Int>
+FMT_CONSTEXPR typename std::make_unsigned<Int>::type to_unsigned(Int value) {
+  FMT_ASSERT(value >= 0, "negative value");
+  return static_cast<typename std::make_unsigned<Int>::type>(value);
+}
+}  // namespace internal
+
+template <typename... Ts>
+using void_t = typename internal::void_t_impl<Ts...>::type;
+
+/**
+  An implementation of ``std::basic_string_view`` for pre-C++17. It provides a
+  subset of the API. ``fmt::basic_string_view`` is used for format strings even
+  if ``std::string_view`` is available to prevent issues when a library is
+  compiled with a different ``-std`` option than the client code (which is not
+  recommended).
+ */
+template <typename Char> class basic_string_view {
+ private:
+  const Char* data_;
+  size_t size_;
+
+ public:
+  using char_type = Char;
+  using iterator = const Char*;
+
+  FMT_CONSTEXPR basic_string_view() FMT_NOEXCEPT : data_(nullptr), size_(0) {}
+
+  /** Constructs a string reference object from a C string and a size. */
+  FMT_CONSTEXPR basic_string_view(const Char* s, size_t count) FMT_NOEXCEPT
+      : data_(s),
+        size_(count) {}
+
+  /**
+    \rst
+    Constructs a string reference object from a C string computing
+    the size with ``std::char_traits<Char>::length``.
+    \endrst
+   */
+  basic_string_view(const Char* s)
+      : data_(s), size_(std::char_traits<Char>::length(s)) {}
+
+  /** Constructs a string reference from a ``std::basic_string`` object. */
+  template <typename Alloc>
+  FMT_CONSTEXPR basic_string_view(const std::basic_string<Char, Alloc>& s)
+      FMT_NOEXCEPT : data_(s.data()),
+                     size_(s.size()) {}
+
+  template <
+      typename S,
+      FMT_ENABLE_IF(std::is_same<S, internal::std_string_view<Char>>::value)>
+  FMT_CONSTEXPR basic_string_view(S s) FMT_NOEXCEPT : data_(s.data()),
+                                                      size_(s.size()) {}
+
+  /** Returns a pointer to the string data. */
+  FMT_CONSTEXPR const Char* data() const { return data_; }
+
+  /** Returns the string size. */
+  FMT_CONSTEXPR size_t size() const { return size_; }
+
+  FMT_CONSTEXPR iterator begin() const { return data_; }
+  FMT_CONSTEXPR iterator end() const { return data_ + size_; }
+
+  FMT_CONSTEXPR void remove_prefix(size_t n) {
+    data_ += n;
+    size_ -= n;
+  }
+
+  // Lexicographically compare this string reference to other.
+  int compare(basic_string_view other) const {
+    size_t str_size = size_ < other.size_ ? size_ : other.size_;
+    int result = std::char_traits<Char>::compare(data_, other.data_, str_size);
+    if (result == 0)
+      result = size_ == other.size_ ? 0 : (size_ < other.size_ ? -1 : 1);
+    return result;
+  }
+
+  friend bool operator==(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) == 0;
+  }
+  friend bool operator!=(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) != 0;
+  }
+  friend bool operator<(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) < 0;
+  }
+  friend bool operator<=(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) <= 0;
+  }
+  friend bool operator>(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) > 0;
+  }
+  friend bool operator>=(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) >= 0;
+  }
+};
+
+using string_view = basic_string_view<char>;
+using wstring_view = basic_string_view<wchar_t>;
+
+#ifndef __cpp_char8_t
+// A UTF-8 code unit type.
+enum char8_t : unsigned char {};
+#endif
+
+/** Specifies if ``T`` is a character type. Can be specialized by users. */
+template <typename T> struct is_char : std::false_type {};
+template <> struct is_char<char> : std::true_type {};
+template <> struct is_char<wchar_t> : std::true_type {};
+template <> struct is_char<char8_t> : std::true_type {};
+template <> struct is_char<char16_t> : std::true_type {};
+template <> struct is_char<char32_t> : std::true_type {};
+
+/**
+  \rst
+  Returns a string view of `s`. In order to add custom string type support to
+  {fmt} provide an overload of `to_string_view` for it in the same namespace as
+  the type for the argument-dependent lookup to work.
+
+  **Example**::
+
+    namespace my_ns {
+    inline string_view to_string_view(const my_string& s) {
+      return {s.data(), s.length()};
+    }
+    }
+    std::string message = fmt::format(my_string("The answer is {}"), 42);
+  \endrst
+ */
+template <typename Char, FMT_ENABLE_IF(is_char<Char>::value)>
+inline basic_string_view<Char> to_string_view(const Char* s) {
+  return s;
+}
+
+template <typename Char, typename Traits, typename Allocator>
+inline basic_string_view<Char> to_string_view(
+    const std::basic_string<Char, Traits, Allocator>& s) {
+  return {s.data(), s.size()};
+}
+
+template <typename Char>
+inline basic_string_view<Char> to_string_view(basic_string_view<Char> s) {
+  return s;
+}
+
+template <typename Char,
+          FMT_ENABLE_IF(!std::is_empty<internal::std_string_view<Char>>::value)>
+inline basic_string_view<Char> to_string_view(
+    internal::std_string_view<Char> s) {
+  return s;
+}
+
+// A base class for compile-time strings. It is defined in the fmt namespace to
+// make formatting functions visible via ADL, e.g. format(fmt("{}"), 42).
+struct compile_string {};
+
+template <typename S>
+struct is_compile_string : std::is_base_of<compile_string, S> {};
+
+template <typename S, FMT_ENABLE_IF(is_compile_string<S>::value)>
+constexpr basic_string_view<typename S::char_type> to_string_view(const S& s) {
+  return s;
+}
+
+namespace internal {
+void to_string_view(...);
+using fmt::v6::to_string_view;
+
+// Specifies whether S is a string type convertible to fmt::basic_string_view.
+// It should be a constexpr function but MSVC 2017 fails to compile it in
+// enable_if and MSVC 2015 fails to compile it as an alias template.
+template <typename S>
+struct is_string : std::is_class<decltype(to_string_view(std::declval<S>()))> {
+};
+
+template <typename S, typename = void> struct char_t_impl {};
+template <typename S> struct char_t_impl<S, enable_if_t<is_string<S>::value>> {
+  using result = decltype(to_string_view(std::declval<S>()));
+  using type = typename result::char_type;
+};
+
+struct error_handler {
+  FMT_CONSTEXPR error_handler() {}
+  FMT_CONSTEXPR error_handler(const error_handler&) {}
+
+  // This function is intentionally not constexpr to give a compile-time error.
+  FMT_NORETURN FMT_API void on_error(const char* message);
+};
+}  // namespace internal
+
+/** String's character type. */
+template <typename S> using char_t = typename internal::char_t_impl<S>::type;
+
+// Parsing context consisting of a format string range being parsed and an
+// argument counter for automatic indexing.
+template <typename Char, typename ErrorHandler = internal::error_handler>
+class basic_parse_context : private ErrorHandler {
+ private:
+  basic_string_view<Char> format_str_;
+  int next_arg_id_;
+
+ public:
+  using char_type = Char;
+  using iterator = typename basic_string_view<Char>::iterator;
+
+  explicit FMT_CONSTEXPR basic_parse_context(basic_string_view<Char> format_str,
+                                             ErrorHandler eh = ErrorHandler())
+      : ErrorHandler(eh), format_str_(format_str), next_arg_id_(0) {}
+
+  // Returns an iterator to the beginning of the format string range being
+  // parsed.
+  FMT_CONSTEXPR iterator begin() const FMT_NOEXCEPT {
+    return format_str_.begin();
+  }
+
+  // Returns an iterator past the end of the format string range being parsed.
+  FMT_CONSTEXPR iterator end() const FMT_NOEXCEPT { return format_str_.end(); }
+
+  // Advances the begin iterator to ``it``.
+  FMT_CONSTEXPR void advance_to(iterator it) {
+    format_str_.remove_prefix(internal::to_unsigned(it - begin()));
+  }
+
+  // Returns the next argument index.
+  FMT_CONSTEXPR int next_arg_id() {
+    if (next_arg_id_ >= 0) return next_arg_id_++;
+    on_error("cannot switch from manual to automatic argument indexing");
+    return 0;
+  }
+
+  FMT_CONSTEXPR bool check_arg_id(int) {
+    if (next_arg_id_ > 0) {
+      on_error("cannot switch from automatic to manual argument indexing");
+      return false;
+    }
+    next_arg_id_ = -1;
+    return true;
+  }
+
+  FMT_CONSTEXPR void check_arg_id(basic_string_view<Char>) {}
+
+  FMT_CONSTEXPR void on_error(const char* message) {
+    ErrorHandler::on_error(message);
+  }
+
+  FMT_CONSTEXPR ErrorHandler error_handler() const { return *this; }
+};
+
+using format_parse_context = basic_parse_context<char>;
+using wformat_parse_context = basic_parse_context<wchar_t>;
+
+using parse_context FMT_DEPRECATED = basic_parse_context<char>;
+using wparse_context FMT_DEPRECATED = basic_parse_context<wchar_t>;
+
+template <typename Context> class basic_format_arg;
+template <typename Context> class basic_format_args;
+
+// A formatter for objects of type T.
+template <typename T, typename Char = char, typename Enable = void>
+struct formatter {
+  // A deleted default constructor indicates a disabled formatter.
+  formatter() = delete;
+};
+
+template <typename T, typename Char, typename Enable = void>
+struct FMT_DEPRECATED convert_to_int
+    : bool_constant<!std::is_arithmetic<T>::value &&
+                    std::is_convertible<T, int>::value> {};
+
+namespace internal {
+
+// Specifies if T has an enabled formatter specialization. A type can be
+// formattable even if it doesn't have a formatter e.g. via a conversion.
+template <typename T, typename Context>
+using has_formatter =
+    std::is_constructible<typename Context::template formatter_type<T>>;
+
+/** A contiguous memory buffer with an optional growing ability. */
+template <typename T> class buffer {
+ private:
+  buffer(const buffer&) = delete;
+  void operator=(const buffer&) = delete;
+
+  T* ptr_;
+  std::size_t size_;
+  std::size_t capacity_;
+
+ protected:
+  // Don't initialize ptr_ since it is not accessed to save a few cycles.
+  buffer(std::size_t sz) FMT_NOEXCEPT : size_(sz), capacity_(sz) {}
+
+  buffer(T* p = nullptr, std::size_t sz = 0, std::size_t cap = 0) FMT_NOEXCEPT
+      : ptr_(p),
+        size_(sz),
+        capacity_(cap) {}
+
+  /** Sets the buffer data and capacity. */
+  void set(T* buf_data, std::size_t buf_capacity) FMT_NOEXCEPT {
+    ptr_ = buf_data;
+    capacity_ = buf_capacity;
+  }
+
+  /** Increases the buffer capacity to hold at least *capacity* elements. */
+  virtual void grow(std::size_t capacity) = 0;
+
+ public:
+  using value_type = T;
+  using const_reference = const T&;
+
+  virtual ~buffer() {}
+
+  T* begin() FMT_NOEXCEPT { return ptr_; }
+  T* end() FMT_NOEXCEPT { return ptr_ + size_; }
+
+  /** Returns the size of this buffer. */
+  std::size_t size() const FMT_NOEXCEPT { return size_; }
+
+  /** Returns the capacity of this buffer. */
+  std::size_t capacity() const FMT_NOEXCEPT { return capacity_; }
+
+  /** Returns a pointer to the buffer data. */
+  T* data() FMT_NOEXCEPT { return ptr_; }
+
+  /** Returns a pointer to the buffer data. */
+  const T* data() const FMT_NOEXCEPT { return ptr_; }
+
+  /**
+    Resizes the buffer. If T is a POD type new elements may not be initialized.
+   */
+  void resize(std::size_t new_size) {
+    reserve(new_size);
+    size_ = new_size;
+  }
+
+  /** Clears this buffer. */
+  void clear() { size_ = 0; }
+
+  /** Reserves space to store at least *capacity* elements. */
+  void reserve(std::size_t new_capacity) {
+    if (new_capacity > capacity_) grow(new_capacity);
+  }
+
+  void push_back(const T& value) {
+    reserve(size_ + 1);
+    ptr_[size_++] = value;
+  }
+
+  /** Appends data to the end of the buffer. */
+  template <typename U> void append(const U* begin, const U* end);
+
+  T& operator[](std::size_t index) { return ptr_[index]; }
+  const T& operator[](std::size_t index) const { return ptr_[index]; }
+};
+
+// A container-backed buffer.
+template <typename Container>
+class container_buffer : public buffer<typename Container::value_type> {
+ private:
+  Container& container_;
+
+ protected:
+  void grow(std::size_t capacity) FMT_OVERRIDE {
+    container_.resize(capacity);
+    this->set(&container_[0], capacity);
+  }
+
+ public:
+  explicit container_buffer(Container& c)
+      : buffer<typename Container::value_type>(c.size()), container_(c) {}
+};
+
+// Extracts a reference to the container from back_insert_iterator.
+template <typename Container>
+inline Container& get_container(std::back_insert_iterator<Container> it) {
+  using bi_iterator = std::back_insert_iterator<Container>;
+  struct accessor : bi_iterator {
+    accessor(bi_iterator iter) : bi_iterator(iter) {}
+    using bi_iterator::container;
+  };
+  return *accessor(it).container;
+}
+
+template <typename T, typename Char = char, typename Enable = void>
+struct fallback_formatter {
+  fallback_formatter() = delete;
+};
+
+// Specifies if T has an enabled fallback_formatter specialization.
+template <typename T, typename Context>
+using has_fallback_formatter =
+    std::is_constructible<fallback_formatter<T, typename Context::char_type>>;
+
+template <typename Char> struct named_arg_base;
+template <typename T, typename Char> struct named_arg;
+
+enum type {
+  none_type,
+  named_arg_type,
+  // Integer types should go first,
+  int_type,
+  uint_type,
+  long_long_type,
+  ulong_long_type,
+  bool_type,
+  char_type,
+  last_integer_type = char_type,
+  // followed by floating-point types.
+  double_type,
+  long_double_type,
+  last_numeric_type = long_double_type,
+  cstring_type,
+  string_type,
+  pointer_type,
+  custom_type
+};
+
+// Maps core type T to the corresponding type enum constant.
+template <typename T, typename Char>
+struct type_constant : std::integral_constant<type, custom_type> {};
+
+#define FMT_TYPE_CONSTANT(Type, constant) \
+  template <typename Char>                \
+  struct type_constant<Type, Char> : std::integral_constant<type, constant> {}
+
+FMT_TYPE_CONSTANT(const named_arg_base<Char>&, named_arg_type);
+FMT_TYPE_CONSTANT(int, int_type);
+FMT_TYPE_CONSTANT(unsigned, uint_type);
+FMT_TYPE_CONSTANT(long long, long_long_type);
+FMT_TYPE_CONSTANT(unsigned long long, ulong_long_type);
+FMT_TYPE_CONSTANT(bool, bool_type);
+FMT_TYPE_CONSTANT(Char, char_type);
+FMT_TYPE_CONSTANT(double, double_type);
+FMT_TYPE_CONSTANT(long double, long_double_type);
+FMT_TYPE_CONSTANT(const Char*, cstring_type);
+FMT_TYPE_CONSTANT(basic_string_view<Char>, string_type);
+FMT_TYPE_CONSTANT(const void*, pointer_type);
+
+FMT_CONSTEXPR bool is_integral(type t) {
+  FMT_ASSERT(t != named_arg_type, "invalid argument type");
+  return t > none_type && t <= last_integer_type;
+}
+
+FMT_CONSTEXPR bool is_arithmetic(type t) {
+  FMT_ASSERT(t != named_arg_type, "invalid argument type");
+  return t > none_type && t <= last_numeric_type;
+}
+
+template <typename Char> struct string_value {
+  const Char* data;
+  std::size_t size;
+};
+
+template <typename Context> struct custom_value {
+  using parse_context = basic_parse_context<typename Context::char_type>;
+  const void* value;
+  void (*format)(const void* arg, parse_context& parse_ctx, Context& ctx);
+};
+
+// A formatting argument value.
+template <typename Context> class value {
+ public:
+  using char_type = typename Context::char_type;
+
+  union {
+    int int_value;
+    unsigned uint_value;
+    long long long_long_value;
+    unsigned long long ulong_long_value;
+    bool bool_value;
+    char_type char_value;
+    double double_value;
+    long double long_double_value;
+    const void* pointer;
+    string_value<char_type> string;
+    custom_value<Context> custom;
+    const named_arg_base<char_type>* named_arg;
+  };
+
+  FMT_CONSTEXPR value(int val = 0) : int_value(val) {}
+  FMT_CONSTEXPR value(unsigned val) : uint_value(val) {}
+  value(long long val) : long_long_value(val) {}
+  value(unsigned long long val) : ulong_long_value(val) {}
+  value(double val) : double_value(val) {}
+  value(long double val) : long_double_value(val) {}
+  value(bool val) : bool_value(val) {}
+  value(char_type val) : char_value(val) {}
+  value(const char_type* val) { string.data = val; }
+  value(basic_string_view<char_type> val) {
+    string.data = val.data();
+    string.size = val.size();
+  }
+  value(const void* val) : pointer(val) {}
+
+  template <typename T> value(const T& val) {
+    custom.value = &val;
+    // Get the formatter type through the context to allow different contexts
+    // have different extension points, e.g. `formatter<T>` for `format` and
+    // `printf_formatter<T>` for `printf`.
+    custom.format = format_custom_arg<
+        T, conditional_t<has_formatter<T, Context>::value,
+                         typename Context::template formatter_type<T>,
+                         fallback_formatter<T, char_type>>>;
+  }
+
+  value(const named_arg_base<char_type>& val) { named_arg = &val; }
+
+ private:
+  // Formats an argument of a custom type, such as a user-defined class.
+  template <typename T, typename Formatter>
+  static void format_custom_arg(const void* arg,
+                                basic_parse_context<char_type>& parse_ctx,
+                                Context& ctx) {
+    Formatter f;
+    parse_ctx.advance_to(f.parse(parse_ctx));
+    ctx.advance_to(f.format(*static_cast<const T*>(arg), ctx));
+  }
+};
+
+template <typename Context, typename T>
+FMT_CONSTEXPR basic_format_arg<Context> make_arg(const T& value);
+
+// To minimize the number of types we need to deal with, long is translated
+// either to int or to long long depending on its size.
+enum { long_short = sizeof(long) == sizeof(int) };
+using long_type = conditional_t<long_short, int, long long>;
+using ulong_type = conditional_t<long_short, unsigned, unsigned long long>;
+
+// Maps formatting arguments to core types.
+template <typename Context> struct arg_mapper {
+  using char_type = typename Context::char_type;
+
+  FMT_CONSTEXPR int map(signed char val) { return val; }
+  FMT_CONSTEXPR unsigned map(unsigned char val) { return val; }
+  FMT_CONSTEXPR int map(short val) { return val; }
+  FMT_CONSTEXPR unsigned map(unsigned short val) { return val; }
+  FMT_CONSTEXPR int map(int val) { return val; }
+  FMT_CONSTEXPR unsigned map(unsigned val) { return val; }
+  FMT_CONSTEXPR long_type map(long val) { return val; }
+  FMT_CONSTEXPR ulong_type map(unsigned long val) { return val; }
+  FMT_CONSTEXPR long long map(long long val) { return val; }
+  FMT_CONSTEXPR unsigned long long map(unsigned long long val) { return val; }
+  FMT_CONSTEXPR bool map(bool val) { return val; }
+
+  template <typename T, FMT_ENABLE_IF(is_char<T>::value)>
+  FMT_CONSTEXPR char_type map(T val) {
+    static_assert(
+        std::is_same<T, char>::value || std::is_same<T, char_type>::value,
+        "mixing character types is disallowed");
+    return val;
+  }
+
+  FMT_CONSTEXPR double map(float val) { return static_cast<double>(val); }
+  FMT_CONSTEXPR double map(double val) { return val; }
+  FMT_CONSTEXPR long double map(long double val) { return val; }
+
+  FMT_CONSTEXPR const char_type* map(char_type* val) { return val; }
+  FMT_CONSTEXPR const char_type* map(const char_type* val) { return val; }
+  template <typename T, FMT_ENABLE_IF(is_string<T>::value)>
+  FMT_CONSTEXPR basic_string_view<char_type> map(const T& val) {
+    static_assert(std::is_same<char_type, char_t<T>>::value,
+                  "mixing character types is disallowed");
+    return to_string_view(val);
+  }
+  template <typename T,
+            FMT_ENABLE_IF(
+                std::is_constructible<basic_string_view<char_type>, T>::value &&
+                !is_string<T>::value)>
+  FMT_CONSTEXPR basic_string_view<char_type> map(const T& val) {
+    return basic_string_view<char_type>(val);
+  }
+  FMT_CONSTEXPR const char* map(const signed char* val) {
+    static_assert(std::is_same<char_type, char>::value, "invalid string type");
+    return reinterpret_cast<const char*>(val);
+  }
+  FMT_CONSTEXPR const char* map(const unsigned char* val) {
+    static_assert(std::is_same<char_type, char>::value, "invalid string type");
+    return reinterpret_cast<const char*>(val);
+  }
+
+  FMT_CONSTEXPR const void* map(void* val) { return val; }
+  FMT_CONSTEXPR const void* map(const void* val) { return val; }
+  FMT_CONSTEXPR const void* map(std::nullptr_t val) { return val; }
+  template <typename T> FMT_CONSTEXPR int map(const T*) {
+    // Formatting of arbitrary pointers is disallowed. If you want to output
+    // a pointer cast it to "void *" or "const void *". In particular, this
+    // forbids formatting of "[const] volatile char *" which is printed as bool
+    // by iostreams.
+    static_assert(!sizeof(T), "formatting of non-void pointers is disallowed");
+    return 0;
+  }
+
+  template <typename T,
+            FMT_ENABLE_IF(std::is_enum<T>::value &&
+                          !has_formatter<T, Context>::value &&
+                          !has_fallback_formatter<T, Context>::value)>
+  FMT_CONSTEXPR int map(const T& val) {
+    return static_cast<int>(val);
+  }
+  template <typename T,
+            FMT_ENABLE_IF(!is_string<T>::value && !is_char<T>::value &&
+                          (has_formatter<T, Context>::value ||
+                           has_fallback_formatter<T, Context>::value))>
+  FMT_CONSTEXPR const T& map(const T& val) {
+    return val;
+  }
+
+  template <typename T>
+  FMT_CONSTEXPR const named_arg_base<char_type>& map(
+      const named_arg<T, char_type>& val) {
+    auto arg = make_arg<Context>(val.value);
+    std::memcpy(val.data, &arg, sizeof(arg));
+    return val;
+  }
+};
+
+// A type constant after applying arg_mapper<Context>.
+template <typename T, typename Context>
+using mapped_type_constant =
+    type_constant<decltype(arg_mapper<Context>().map(std::declval<T>())),
+                  typename Context::char_type>;
+
+// Maximum number of arguments with packed types.
+enum { max_packed_args = 15 };
+enum : unsigned long long { is_unpacked_bit = 1ull << 63 };
+
+template <typename Context> class arg_map;
+}  // namespace internal
+
+// A formatting argument. It is a trivially copyable/constructible type to
+// allow storage in basic_memory_buffer.
+template <typename Context> class basic_format_arg {
+ private:
+  internal::value<Context> value_;
+  internal::type type_;
+
+  template <typename ContextType, typename T>
+  friend FMT_CONSTEXPR basic_format_arg<ContextType> internal::make_arg(
+      const T& value);
+
+  template <typename Visitor, typename Ctx>
+  friend FMT_CONSTEXPR auto visit_format_arg(Visitor&& vis,
+                                             const basic_format_arg<Ctx>& arg)
+      -> decltype(vis(0));
+
+  friend class basic_format_args<Context>;
+  friend class internal::arg_map<Context>;
+
+  using char_type = typename Context::char_type;
+
+ public:
+  class handle {
+   public:
+    explicit handle(internal::custom_value<Context> custom) : custom_(custom) {}
+
+    void format(basic_parse_context<char_type>& parse_ctx, Context& ctx) const {
+      custom_.format(custom_.value, parse_ctx, ctx);
+    }
+
+   private:
+    internal::custom_value<Context> custom_;
+  };
+
+  FMT_CONSTEXPR basic_format_arg() : type_(internal::none_type) {}
+
+  FMT_CONSTEXPR explicit operator bool() const FMT_NOEXCEPT {
+    return type_ != internal::none_type;
+  }
+
+  internal::type type() const { return type_; }
+
+  bool is_integral() const { return internal::is_integral(type_); }
+  bool is_arithmetic() const { return internal::is_arithmetic(type_); }
+};
+
+/**
+  \rst
+  Visits an argument dispatching to the appropriate visit method based on
+  the argument type. For example, if the argument type is ``double`` then
+  ``vis(value)`` will be called with the value of type ``double``.
+  \endrst
+ */
+template <typename Visitor, typename Context>
+FMT_CONSTEXPR auto visit_format_arg(Visitor&& vis,
+                                    const basic_format_arg<Context>& arg)
+    -> decltype(vis(0)) {
+  using char_type = typename Context::char_type;
+  switch (arg.type_) {
+  case internal::none_type:
+    break;
+  case internal::named_arg_type:
+    FMT_ASSERT(false, "invalid argument type");
+    break;
+  case internal::int_type:
+    return vis(arg.value_.int_value);
+  case internal::uint_type:
+    return vis(arg.value_.uint_value);
+  case internal::long_long_type:
+    return vis(arg.value_.long_long_value);
+  case internal::ulong_long_type:
+    return vis(arg.value_.ulong_long_value);
+  case internal::bool_type:
+    return vis(arg.value_.bool_value);
+  case internal::char_type:
+    return vis(arg.value_.char_value);
+  case internal::double_type:
+    return vis(arg.value_.double_value);
+  case internal::long_double_type:
+    return vis(arg.value_.long_double_value);
+  case internal::cstring_type:
+    return vis(arg.value_.string.data);
+  case internal::string_type:
+    return vis(basic_string_view<char_type>(arg.value_.string.data,
+                                            arg.value_.string.size));
+  case internal::pointer_type:
+    return vis(arg.value_.pointer);
+  case internal::custom_type:
+    return vis(typename basic_format_arg<Context>::handle(arg.value_.custom));
+  }
+  return vis(monostate());
+}
+
+namespace internal {
+// A map from argument names to their values for named arguments.
+template <typename Context> class arg_map {
+ private:
+  arg_map(const arg_map&) = delete;
+  void operator=(const arg_map&) = delete;
+
+  using char_type = typename Context::char_type;
+
+  struct entry {
+    basic_string_view<char_type> name;
+    basic_format_arg<Context> arg;
+  };
+
+  entry* map_;
+  unsigned size_;
+
+  void push_back(value<Context> val) {
+    const auto& named = *val.named_arg;
+    map_[size_] = {named.name, named.template deserialize<Context>()};
+    ++size_;
+  }
+
+ public:
+  arg_map() : map_(nullptr), size_(0) {}
+  void init(const basic_format_args<Context>& args);
+  ~arg_map() { delete[] map_; }
+
+  basic_format_arg<Context> find(basic_string_view<char_type> name) const {
+    // The list is unsorted, so just return the first matching name.
+    for (entry *it = map_, *end = map_ + size_; it != end; ++it) {
+      if (it->name == name) return it->arg;
+    }
+    return {};
+  }
+};
+
+// A type-erased reference to an std::locale to avoid heavy <locale> include.
+class locale_ref {
+ private:
+  const void* locale_;  // A type-erased pointer to std::locale.
+
+ public:
+  locale_ref() : locale_(nullptr) {}
+  template <typename Locale> explicit locale_ref(const Locale& loc);
+
+  template <typename Locale> Locale get() const;
+};
+
+template <typename> constexpr unsigned long long encode_types() { return 0; }
+
+template <typename Context, typename Arg, typename... Args>
+constexpr unsigned long long encode_types() {
+  return mapped_type_constant<Arg, Context>::value |
+         (encode_types<Context, Args...>() << 4);
+}
+
+template <typename Context, typename T>
+FMT_CONSTEXPR basic_format_arg<Context> make_arg(const T& value) {
+  basic_format_arg<Context> arg;
+  arg.type_ = mapped_type_constant<T, Context>::value;
+  arg.value_ = arg_mapper<Context>().map(value);
+  return arg;
+}
+
+template <bool IS_PACKED, typename Context, typename T,
+          FMT_ENABLE_IF(IS_PACKED)>
+inline value<Context> make_arg(const T& val) {
+  return arg_mapper<Context>().map(val);
+}
+
+template <bool IS_PACKED, typename Context, typename T,
+          FMT_ENABLE_IF(!IS_PACKED)>
+inline basic_format_arg<Context> make_arg(const T& value) {
+  return make_arg<Context>(value);
+}
+}  // namespace internal
+
+// Formatting context.
+template <typename OutputIt, typename Char> class basic_format_context {
+ public:
+  /** The character type for the output. */
+  using char_type = Char;
+
+ private:
+  OutputIt out_;
+  basic_format_args<basic_format_context> args_;
+  internal::arg_map<basic_format_context> map_;
+  internal::locale_ref loc_;
+
+  basic_format_context(const basic_format_context&) = delete;
+  void operator=(const basic_format_context&) = delete;
+
+ public:
+  using iterator = OutputIt;
+  using format_arg = basic_format_arg<basic_format_context>;
+  template <typename T> using formatter_type = formatter<T, char_type>;
+
+  /**
+   Constructs a ``basic_format_context`` object. References to the arguments are
+   stored in the object so make sure they have appropriate lifetimes.
+   */
+  basic_format_context(OutputIt out,
+                       basic_format_args<basic_format_context> ctx_args,
+                       internal::locale_ref loc = internal::locale_ref())
+      : out_(out), args_(ctx_args), loc_(loc) {}
+
+  format_arg arg(int id) const { return args_.get(id); }
+
+  // Checks if manual indexing is used and returns the argument with the
+  // specified name.
+  format_arg arg(basic_string_view<char_type> name);
+
+  internal::error_handler error_handler() { return {}; }
+  void on_error(const char* message) { error_handler().on_error(message); }
+
+  // Returns an iterator to the beginning of the output range.
+  iterator out() { return out_; }
+
+  // Advances the begin iterator to ``it``.
+  void advance_to(iterator it) { out_ = it; }
+
+  internal::locale_ref locale() { return loc_; }
+};
+
+template <typename Char>
+using buffer_context =
+    basic_format_context<std::back_insert_iterator<internal::buffer<Char>>,
+                         Char>;
+using format_context = buffer_context<char>;
+using wformat_context = buffer_context<wchar_t>;
+
+/**
+  \rst
+  An array of references to arguments. It can be implicitly converted into
+  `~fmt::basic_format_args` for passing into type-erased formatting functions
+  such as `~fmt::vformat`.
+  \endrst
+ */
+template <typename Context, typename... Args> class format_arg_store {
+ private:
+  static const size_t num_args = sizeof...(Args);
+  static const bool is_packed = num_args < internal::max_packed_args;
+
+  using value_type = conditional_t<is_packed, internal::value<Context>,
+                                   basic_format_arg<Context>>;
+
+  // If the arguments are not packed, add one more element to mark the end.
+  value_type data_[num_args + (num_args == 0 ? 1 : 0)];
+
+  friend class basic_format_args<Context>;
+
+ public:
+  static constexpr unsigned long long types =
+      is_packed ? internal::encode_types<Context, Args...>()
+                : internal::is_unpacked_bit | num_args;
+  FMT_DEPRECATED static constexpr unsigned long long TYPES = types;
+
+  format_arg_store(const Args&... args)
+      : data_{internal::make_arg<is_packed, Context>(args)...} {}
+};
+
+/**
+  \rst
+  Constructs an `~fmt::format_arg_store` object that contains references to
+  arguments and can be implicitly converted to `~fmt::format_args`. `Context`
+  can be omitted in which case it defaults to `~fmt::context`.
+  See `~fmt::arg` for lifetime considerations.
+  \endrst
+ */
+template <typename Context = format_context, typename... Args>
+inline format_arg_store<Context, Args...> make_format_args(
+    const Args&... args) {
+  return {args...};
+}
+
+/** Formatting arguments. */
+template <typename Context> class basic_format_args {
+ public:
+  using size_type = int;
+  using format_arg = basic_format_arg<Context>;
+
+ private:
+  // To reduce compiled code size per formatting function call, types of first
+  // max_packed_args arguments are passed in the types_ field.
+  unsigned long long types_;
+  union {
+    // If the number of arguments is less than max_packed_args, the argument
+    // values are stored in values_, otherwise they are stored in args_.
+    // This is done to reduce compiled code size as storing larger objects
+    // may require more code (at least on x86-64) even if the same amount of
+    // data is actually copied to stack. It saves ~10% on the bloat test.
+    const internal::value<Context>* values_;
+    const format_arg* args_;
+  };
+
+  bool is_packed() const { return (types_ & internal::is_unpacked_bit) == 0; }
+
+  internal::type type(int index) const {
+    int shift = index * 4;
+    return static_cast<internal::type>((types_ & (0xfull << shift)) >> shift);
+  }
+
+  friend class internal::arg_map<Context>;
+
+  void set_data(const internal::value<Context>* values) { values_ = values; }
+  void set_data(const format_arg* args) { args_ = args; }
+
+  format_arg do_get(int index) const {
+    format_arg arg;
+    if (!is_packed()) {
+      auto num_args = max_size();
+      if (index < num_args) arg = args_[index];
+      return arg;
+    }
+    if (index > internal::max_packed_args) return arg;
+    arg.type_ = type(index);
+    if (arg.type_ == internal::none_type) return arg;
+    internal::value<Context>& val = arg.value_;
+    val = values_[index];
+    return arg;
+  }
+
+ public:
+  basic_format_args() : types_(0) {}
+
+  /**
+   \rst
+   Constructs a `basic_format_args` object from `~fmt::format_arg_store`.
+   \endrst
+   */
+  template <typename... Args>
+  basic_format_args(const format_arg_store<Context, Args...>& store)
+      : types_(static_cast<unsigned long long>(store.types)) {
+    set_data(store.data_);
+  }
+
+  /**
+   \rst
+   Constructs a `basic_format_args` object from a dynamic set of arguments.
+   \endrst
+   */
+  basic_format_args(const format_arg* args, int count)
+      : types_(internal::is_unpacked_bit | internal::to_unsigned(count)) {
+    set_data(args);
+  }
+
+  /** Returns the argument at specified index. */
+  format_arg get(int index) const {
+    format_arg arg = do_get(index);
+    if (arg.type_ == internal::named_arg_type)
+      arg = arg.value_.named_arg->template deserialize<Context>();
+    return arg;
+  }
+
+  int max_size() const {
+    unsigned long long max_packed = internal::max_packed_args;
+    return static_cast<int>(is_packed() ? max_packed
+                                        : types_ & ~internal::is_unpacked_bit);
+  }
+};
+
+/** An alias to ``basic_format_args<context>``. */
+// It is a separate type rather than an alias to make symbols readable.
+struct format_args : basic_format_args<format_context> {
+  template <typename... Args>
+  format_args(Args&&... args)
+      : basic_format_args<format_context>(std::forward<Args>(args)...) {}
+};
+struct wformat_args : basic_format_args<wformat_context> {
+  template <typename... Args>
+  wformat_args(Args&&... args)
+      : basic_format_args<wformat_context>(std::forward<Args>(args)...) {}
+};
+
+template <typename Container> struct is_contiguous : std::false_type {};
+
+template <typename Char>
+struct is_contiguous<std::basic_string<Char>> : std::true_type {};
+
+template <typename Char>
+struct is_contiguous<internal::buffer<Char>> : std::true_type {};
+
+namespace internal {
+
+template <typename OutputIt>
+struct is_contiguous_back_insert_iterator : std::false_type {};
+template <typename Container>
+struct is_contiguous_back_insert_iterator<std::back_insert_iterator<Container>>
+    : is_contiguous<Container> {};
+
+template <typename Char> struct named_arg_base {
+  basic_string_view<Char> name;
+
+  // Serialized value<context>.
+  mutable char data[sizeof(basic_format_arg<buffer_context<Char>>)];
+
+  named_arg_base(basic_string_view<Char> nm) : name(nm) {}
+
+  template <typename Context> basic_format_arg<Context> deserialize() const {
+    basic_format_arg<Context> arg;
+    std::memcpy(&arg, data, sizeof(basic_format_arg<Context>));
+    return arg;
+  }
+};
+
+template <typename T, typename Char> struct named_arg : named_arg_base<Char> {
+  const T& value;
+
+  named_arg(basic_string_view<Char> name, const T& val)
+      : named_arg_base<Char>(name), value(val) {}
+};
+
+template <typename..., typename S, FMT_ENABLE_IF(!is_compile_string<S>::value)>
+inline void check_format_string(const S&) {
+#if defined(FMT_ENFORCE_COMPILE_STRING)
+  static_assert(is_compile_string<S>::value,
+                "FMT_ENFORCE_COMPILE_STRING requires all format strings to "
+                "utilize FMT_STRING() or fmt().");
+#endif
+}
+template <typename..., typename S, FMT_ENABLE_IF(is_compile_string<S>::value)>
+void check_format_string(S);
+
+struct view {};
+template <bool...> struct bool_pack;
+template <bool... Args>
+using all_true =
+    std::is_same<bool_pack<Args..., true>, bool_pack<true, Args...>>;
+
+template <typename... Args, typename S, typename Char = char_t<S>>
+inline format_arg_store<buffer_context<Char>, remove_reference_t<Args>...>
+make_args_checked(const S& format_str,
+                  const remove_reference_t<Args>&... args) {
+  static_assert(all_true<(!std::is_base_of<view, remove_reference_t<Args>>() ||
+                          !std::is_reference<Args>())...>::value,
+                "passing views as lvalues is disallowed");
+  check_format_string<remove_const_t<remove_reference_t<Args>>...>(format_str);
+  return {args...};
+}
+
+template <typename Char>
+std::basic_string<Char> vformat(basic_string_view<Char> format_str,
+                                basic_format_args<buffer_context<Char>> args);
+
+template <typename Char>
+typename buffer_context<Char>::iterator vformat_to(
+    buffer<Char>& buf, basic_string_view<Char> format_str,
+    basic_format_args<buffer_context<Char>> args);
+}  // namespace internal
+
+/**
+  \rst
+  Returns a named argument to be used in a formatting function.
+
+  The named argument holds a reference and does not extend the lifetime
+  of its arguments.
+  Consequently, a dangling reference can accidentally be created.
+  The user should take care to only pass this function temporaries when
+  the named argument is itself a temporary, as per the following example.
+
+  **Example**::
+
+    fmt::print("Elapsed time: {s:.2f} seconds", fmt::arg("s", 1.23));
+  \endrst
+ */
+template <typename S, typename T, typename Char = char_t<S>>
+inline internal::named_arg<T, Char> arg(const S& name, const T& arg) {
+  static_assert(internal::is_string<S>::value, "");
+  return {name, arg};
+}
+
+// Disable nested named arguments, e.g. ``arg("a", arg("b", 42))``.
+template <typename S, typename T, typename Char>
+void arg(S, internal::named_arg<T, Char>) = delete;
+
+/** Formats a string and writes the output to ``out``. */
+// GCC 8 and earlier cannot handle std::back_insert_iterator<Container> with
+// vformat_to<ArgFormatter>(...) overload, so SFINAE on iterator type instead.
+template <typename OutputIt, typename S, typename Char = char_t<S>,
+          FMT_ENABLE_IF(
+              internal::is_contiguous_back_insert_iterator<OutputIt>::value)>
+OutputIt vformat_to(OutputIt out, const S& format_str,
+                    basic_format_args<buffer_context<Char>> args) {
+  using container = remove_reference_t<decltype(internal::get_container(out))>;
+  internal::container_buffer<container> buf((internal::get_container(out)));
+  internal::vformat_to(buf, to_string_view(format_str), args);
+  return out;
+}
+
+template <typename Container, typename S, typename... Args,
+          FMT_ENABLE_IF(
+              is_contiguous<Container>::value&& internal::is_string<S>::value)>
+inline std::back_insert_iterator<Container> format_to(
+    std::back_insert_iterator<Container> out, const S& format_str,
+    Args&&... args) {
+  return vformat_to(
+      out, to_string_view(format_str),
+      {internal::make_args_checked<Args...>(format_str, args...)});
+}
+
+template <typename S, typename Char = char_t<S>>
+inline std::basic_string<Char> vformat(
+    const S& format_str, basic_format_args<buffer_context<Char>> args) {
+  return internal::vformat(to_string_view(format_str), args);
+}
+
+/**
+  \rst
+  Formats arguments and returns the result as a string.
+
+  **Example**::
+
+    #include <fmt/core.h>
+    std::string message = fmt::format("The answer is {}", 42);
+  \endrst
+*/
+// Pass char_t as a default template parameter instead of using
+// std::basic_string<char_t<S>> to reduce the symbol size.
+template <typename S, typename... Args, typename Char = char_t<S>>
+inline std::basic_string<Char> format(const S& format_str, Args&&... args) {
+  return internal::vformat(
+      to_string_view(format_str),
+      {internal::make_args_checked<Args...>(format_str, args...)});
+}
+
+FMT_API void vprint(std::FILE* f, string_view format_str, format_args args);
+FMT_API void vprint(std::FILE* f, wstring_view format_str, wformat_args args);
+
+/**
+  \rst
+  Prints formatted data to the file *f*. For wide format strings,
+  *f* should be in wide-oriented mode set via ``fwide(f, 1)`` or
+  ``_setmode(_fileno(f), _O_U8TEXT)`` on Windows.
+
+  **Example**::
+
+    fmt::print(stderr, "Don't {}!", "panic");
+  \endrst
+ */
+template <typename S, typename... Args,
+          FMT_ENABLE_IF(internal::is_string<S>::value)>
+inline void print(std::FILE* f, const S& format_str, Args&&... args) {
+  vprint(f, to_string_view(format_str),
+         internal::make_args_checked<Args...>(format_str, args...));
+}
+
+FMT_API void vprint(string_view format_str, format_args args);
+FMT_API void vprint(wstring_view format_str, wformat_args args);
+
+/**
+  \rst
+  Prints formatted data to ``stdout``.
+
+  **Example**::
+
+    fmt::print("Elapsed time: {0:.2f} seconds", 1.23);
+  \endrst
+ */
+template <typename S, typename... Args,
+          FMT_ENABLE_IF(internal::is_string<S>::value)>
+inline void print(const S& format_str, Args&&... args) {
+  vprint(to_string_view(format_str),
+         internal::make_args_checked<Args...>(format_str, args...));
+}
+FMT_END_NAMESPACE
+
+#endif  // FMT_CORE_H_

--- a/contrib/fmt/include/fmt/format-inl.h
+++ b/contrib/fmt/include/fmt/format-inl.h
@@ -1,0 +1,1000 @@
+// Formatting library for C++
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_FORMAT_INL_H_
+#define FMT_FORMAT_INL_H_
+
+#include "format.h"
+
+#include <string.h>
+
+#include <cctype>
+#include <cerrno>
+#include <climits>
+#include <cmath>
+#include <cstdarg>
+#include <cstddef>  // for std::ptrdiff_t
+#include <cstring>  // for std::memmove
+#include <cwchar>
+#if !defined(FMT_STATIC_THOUSANDS_SEPARATOR)
+#  include <locale>
+#endif
+
+#if FMT_USE_WINDOWS_H
+#  if !defined(FMT_HEADER_ONLY) && !defined(WIN32_LEAN_AND_MEAN)
+#    define WIN32_LEAN_AND_MEAN
+#  endif
+#  if defined(NOMINMAX) || defined(FMT_WIN_MINMAX)
+#    include <windows.h>
+#  else
+#    define NOMINMAX
+#    include <windows.h>
+#    undef NOMINMAX
+#  endif
+#endif
+
+#if FMT_EXCEPTIONS
+#  define FMT_TRY try
+#  define FMT_CATCH(x) catch (x)
+#else
+#  define FMT_TRY if (true)
+#  define FMT_CATCH(x) if (false)
+#endif
+
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable : 4127)  // conditional expression is constant
+#  pragma warning(disable : 4702)  // unreachable code
+// Disable deprecation warning for strerror. The latter is not called but
+// MSVC fails to detect it.
+#  pragma warning(disable : 4996)
+#endif
+
+// Dummy implementations of strerror_r and strerror_s called if corresponding
+// system functions are not available.
+inline fmt::internal::null<> strerror_r(int, char*, ...) {
+  return fmt::internal::null<>();
+}
+inline fmt::internal::null<> strerror_s(char*, std::size_t, ...) {
+  return fmt::internal::null<>();
+}
+
+FMT_BEGIN_NAMESPACE
+namespace internal {
+
+#ifndef _MSC_VER
+#  define FMT_SNPRINTF snprintf
+#else  // _MSC_VER
+inline int fmt_snprintf(char* buffer, size_t size, const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  int result = vsnprintf_s(buffer, size, _TRUNCATE, format, args);
+  va_end(args);
+  return result;
+}
+#  define FMT_SNPRINTF fmt_snprintf
+#endif  // _MSC_VER
+
+using format_func = void (*)(internal::buffer<char>&, int, string_view);
+
+// Portable thread-safe version of strerror.
+// Sets buffer to point to a string describing the error code.
+// This can be either a pointer to a string stored in buffer,
+// or a pointer to some static immutable string.
+// Returns one of the following values:
+//   0      - success
+//   ERANGE - buffer is not large enough to store the error message
+//   other  - failure
+// Buffer should be at least of size 1.
+FMT_FUNC int safe_strerror(int error_code, char*& buffer,
+                           std::size_t buffer_size) FMT_NOEXCEPT {
+  FMT_ASSERT(buffer != nullptr && buffer_size != 0, "invalid buffer");
+
+  class dispatcher {
+   private:
+    int error_code_;
+    char*& buffer_;
+    std::size_t buffer_size_;
+
+    // A noop assignment operator to avoid bogus warnings.
+    void operator=(const dispatcher&) {}
+
+    // Handle the result of XSI-compliant version of strerror_r.
+    int handle(int result) {
+      // glibc versions before 2.13 return result in errno.
+      return result == -1 ? errno : result;
+    }
+
+    // Handle the result of GNU-specific version of strerror_r.
+    int handle(char* message) {
+      // If the buffer is full then the message is probably truncated.
+      if (message == buffer_ && strlen(buffer_) == buffer_size_ - 1)
+        return ERANGE;
+      buffer_ = message;
+      return 0;
+    }
+
+    // Handle the case when strerror_r is not available.
+    int handle(internal::null<>) {
+      return fallback(strerror_s(buffer_, buffer_size_, error_code_));
+    }
+
+    // Fallback to strerror_s when strerror_r is not available.
+    int fallback(int result) {
+      // If the buffer is full then the message is probably truncated.
+      return result == 0 && strlen(buffer_) == buffer_size_ - 1 ? ERANGE
+                                                                : result;
+    }
+
+#if !FMT_MSC_VER
+    // Fallback to strerror if strerror_r and strerror_s are not available.
+    int fallback(internal::null<>) {
+      errno = 0;
+      buffer_ = strerror(error_code_);
+      return errno;
+    }
+#endif
+
+   public:
+    dispatcher(int err_code, char*& buf, std::size_t buf_size)
+        : error_code_(err_code), buffer_(buf), buffer_size_(buf_size) {}
+
+    int run() { return handle(strerror_r(error_code_, buffer_, buffer_size_)); }
+  };
+  return dispatcher(error_code, buffer, buffer_size).run();
+}
+
+FMT_FUNC void format_error_code(internal::buffer<char>& out, int error_code,
+                                string_view message) FMT_NOEXCEPT {
+  // Report error code making sure that the output fits into
+  // inline_buffer_size to avoid dynamic memory allocation and potential
+  // bad_alloc.
+  out.resize(0);
+  static const char SEP[] = ": ";
+  static const char ERROR_STR[] = "error ";
+  // Subtract 2 to account for terminating null characters in SEP and ERROR_STR.
+  std::size_t error_code_size = sizeof(SEP) + sizeof(ERROR_STR) - 2;
+  auto abs_value = static_cast<uint32_or_64_t<int>>(error_code);
+  if (internal::is_negative(error_code)) {
+    abs_value = 0 - abs_value;
+    ++error_code_size;
+  }
+  error_code_size += internal::to_unsigned(internal::count_digits(abs_value));
+  internal::writer w(out);
+  if (message.size() <= inline_buffer_size - error_code_size) {
+    w.write(message);
+    w.write(SEP);
+  }
+  w.write(ERROR_STR);
+  w.write(error_code);
+  assert(out.size() <= inline_buffer_size);
+}
+
+// A wrapper around fwrite that throws on error.
+FMT_FUNC void fwrite_fully(const void* ptr, size_t size, size_t count,
+                           FILE* stream) {
+  size_t written = std::fwrite(ptr, size, count, stream);
+  if (written < count) {
+    FMT_THROW(system_error(errno, "cannot write to file"));
+  }
+}
+
+FMT_FUNC void report_error(format_func func, int error_code,
+                           string_view message) FMT_NOEXCEPT {
+  memory_buffer full_message;
+  func(full_message, error_code, message);
+  // Don't use fwrite_fully because the latter may throw.
+  (void)std::fwrite(full_message.data(), full_message.size(), 1, stderr);
+  std::fputc('\n', stderr);
+}
+}  // namespace internal
+
+#if !defined(FMT_STATIC_THOUSANDS_SEPARATOR)
+namespace internal {
+
+template <typename Locale>
+locale_ref::locale_ref(const Locale& loc) : locale_(&loc) {
+  static_assert(std::is_same<Locale, std::locale>::value, "");
+}
+
+template <typename Locale> Locale locale_ref::get() const {
+  static_assert(std::is_same<Locale, std::locale>::value, "");
+  return locale_ ? *static_cast<const std::locale*>(locale_) : std::locale();
+}
+
+template <typename Char> FMT_FUNC Char thousands_sep_impl(locale_ref loc) {
+  return std::use_facet<std::numpunct<Char>>(loc.get<std::locale>())
+      .thousands_sep();
+}
+template <typename Char> FMT_FUNC Char decimal_point_impl(locale_ref loc) {
+  return std::use_facet<std::numpunct<Char>>(loc.get<std::locale>())
+      .decimal_point();
+}
+}  // namespace internal
+#else
+template <typename Char>
+FMT_FUNC Char internal::thousands_sep_impl(locale_ref) {
+  return FMT_STATIC_THOUSANDS_SEPARATOR;
+}
+template <typename Char>
+FMT_FUNC Char internal::decimal_point_impl(locale_ref) {
+  return '.';
+}
+#endif
+
+FMT_API FMT_FUNC format_error::~format_error() FMT_NOEXCEPT {}
+FMT_API FMT_FUNC system_error::~system_error() FMT_NOEXCEPT {}
+
+FMT_FUNC void system_error::init(int err_code, string_view format_str,
+                                 format_args args) {
+  error_code_ = err_code;
+  memory_buffer buffer;
+  format_system_error(buffer, err_code, vformat(format_str, args));
+  std::runtime_error& base = *this;
+  base = std::runtime_error(to_string(buffer));
+}
+
+namespace internal {
+
+template <> FMT_FUNC int count_digits<4>(internal::fallback_uintptr n) {
+  // Assume little endian; pointer formatting is implementation-defined anyway.
+  int i = static_cast<int>(sizeof(void*)) - 1;
+  while (i > 0 && n.value[i] == 0) --i;
+  auto char_digits = std::numeric_limits<unsigned char>::digits / 4;
+  return i >= 0 ? i * char_digits + count_digits<4, unsigned>(n.value[i]) : 1;
+}
+
+template <typename T>
+int format_float(char* buf, std::size_t size, const char* format, int precision,
+                 T value) {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+  if (precision > 100000)
+    throw std::runtime_error(
+        "fuzz mode - avoid large allocation inside snprintf");
+#endif
+  // Suppress the warning about nonliteral format string.
+  auto snprintf_ptr = FMT_SNPRINTF;
+  return precision < 0 ? snprintf_ptr(buf, size, format, value)
+                       : snprintf_ptr(buf, size, format, precision, value);
+}
+
+template <typename T>
+const char basic_data<T>::digits[] =
+    "0001020304050607080910111213141516171819"
+    "2021222324252627282930313233343536373839"
+    "4041424344454647484950515253545556575859"
+    "6061626364656667686970717273747576777879"
+    "8081828384858687888990919293949596979899";
+
+template <typename T>
+const char basic_data<T>::hex_digits[] = "0123456789abcdef";
+
+#define FMT_POWERS_OF_10(factor)                                             \
+  factor * 10, factor * 100, factor * 1000, factor * 10000, factor * 100000, \
+      factor * 1000000, factor * 10000000, factor * 100000000,               \
+      factor * 1000000000
+
+template <typename T>
+const uint64_t basic_data<T>::powers_of_10_64[] = {
+    1, FMT_POWERS_OF_10(1), FMT_POWERS_OF_10(1000000000ull),
+    10000000000000000000ull};
+
+template <typename T>
+const uint32_t basic_data<T>::zero_or_powers_of_10_32[] = {0,
+                                                           FMT_POWERS_OF_10(1)};
+
+template <typename T>
+const uint64_t basic_data<T>::zero_or_powers_of_10_64[] = {
+    0, FMT_POWERS_OF_10(1), FMT_POWERS_OF_10(1000000000ull),
+    10000000000000000000ull};
+
+// Normalized 64-bit significands of pow(10, k), for k = -348, -340, ..., 340.
+// These are generated by support/compute-powers.py.
+template <typename T>
+const uint64_t basic_data<T>::pow10_significands[] = {
+    0xfa8fd5a0081c0288, 0xbaaee17fa23ebf76, 0x8b16fb203055ac76,
+    0xcf42894a5dce35ea, 0x9a6bb0aa55653b2d, 0xe61acf033d1a45df,
+    0xab70fe17c79ac6ca, 0xff77b1fcbebcdc4f, 0xbe5691ef416bd60c,
+    0x8dd01fad907ffc3c, 0xd3515c2831559a83, 0x9d71ac8fada6c9b5,
+    0xea9c227723ee8bcb, 0xaecc49914078536d, 0x823c12795db6ce57,
+    0xc21094364dfb5637, 0x9096ea6f3848984f, 0xd77485cb25823ac7,
+    0xa086cfcd97bf97f4, 0xef340a98172aace5, 0xb23867fb2a35b28e,
+    0x84c8d4dfd2c63f3b, 0xc5dd44271ad3cdba, 0x936b9fcebb25c996,
+    0xdbac6c247d62a584, 0xa3ab66580d5fdaf6, 0xf3e2f893dec3f126,
+    0xb5b5ada8aaff80b8, 0x87625f056c7c4a8b, 0xc9bcff6034c13053,
+    0x964e858c91ba2655, 0xdff9772470297ebd, 0xa6dfbd9fb8e5b88f,
+    0xf8a95fcf88747d94, 0xb94470938fa89bcf, 0x8a08f0f8bf0f156b,
+    0xcdb02555653131b6, 0x993fe2c6d07b7fac, 0xe45c10c42a2b3b06,
+    0xaa242499697392d3, 0xfd87b5f28300ca0e, 0xbce5086492111aeb,
+    0x8cbccc096f5088cc, 0xd1b71758e219652c, 0x9c40000000000000,
+    0xe8d4a51000000000, 0xad78ebc5ac620000, 0x813f3978f8940984,
+    0xc097ce7bc90715b3, 0x8f7e32ce7bea5c70, 0xd5d238a4abe98068,
+    0x9f4f2726179a2245, 0xed63a231d4c4fb27, 0xb0de65388cc8ada8,
+    0x83c7088e1aab65db, 0xc45d1df942711d9a, 0x924d692ca61be758,
+    0xda01ee641a708dea, 0xa26da3999aef774a, 0xf209787bb47d6b85,
+    0xb454e4a179dd1877, 0x865b86925b9bc5c2, 0xc83553c5c8965d3d,
+    0x952ab45cfa97a0b3, 0xde469fbd99a05fe3, 0xa59bc234db398c25,
+    0xf6c69a72a3989f5c, 0xb7dcbf5354e9bece, 0x88fcf317f22241e2,
+    0xcc20ce9bd35c78a5, 0x98165af37b2153df, 0xe2a0b5dc971f303a,
+    0xa8d9d1535ce3b396, 0xfb9b7cd9a4a7443c, 0xbb764c4ca7a44410,
+    0x8bab8eefb6409c1a, 0xd01fef10a657842c, 0x9b10a4e5e9913129,
+    0xe7109bfba19c0c9d, 0xac2820d9623bf429, 0x80444b5e7aa7cf85,
+    0xbf21e44003acdd2d, 0x8e679c2f5e44ff8f, 0xd433179d9c8cb841,
+    0x9e19db92b4e31ba9, 0xeb96bf6ebadf77d9, 0xaf87023b9bf0ee6b,
+};
+
+// Binary exponents of pow(10, k), for k = -348, -340, ..., 340, corresponding
+// to significands above.
+template <typename T>
+const int16_t basic_data<T>::pow10_exponents[] = {
+    -1220, -1193, -1166, -1140, -1113, -1087, -1060, -1034, -1007, -980, -954,
+    -927,  -901,  -874,  -847,  -821,  -794,  -768,  -741,  -715,  -688, -661,
+    -635,  -608,  -582,  -555,  -529,  -502,  -475,  -449,  -422,  -396, -369,
+    -343,  -316,  -289,  -263,  -236,  -210,  -183,  -157,  -130,  -103, -77,
+    -50,   -24,   3,     30,    56,    83,    109,   136,   162,   189,  216,
+    242,   269,   295,   322,   348,   375,   402,   428,   455,   481,  508,
+    534,   561,   588,   614,   641,   667,   694,   720,   747,   774,  800,
+    827,   853,   880,   907,   933,   960,   986,   1013,  1039,  1066};
+
+template <typename T>
+const char basic_data<T>::foreground_color[] = "\x1b[38;2;";
+template <typename T>
+const char basic_data<T>::background_color[] = "\x1b[48;2;";
+template <typename T> const char basic_data<T>::reset_color[] = "\x1b[0m";
+template <typename T> const wchar_t basic_data<T>::wreset_color[] = L"\x1b[0m";
+
+template <typename T> struct bits {
+  static FMT_CONSTEXPR_DECL const int value =
+      static_cast<int>(sizeof(T) * std::numeric_limits<unsigned char>::digits);
+};
+
+// A handmade floating-point number f * pow(2, e).
+class fp {
+ private:
+  using significand_type = uint64_t;
+
+  // All sizes are in bits.
+  // Subtract 1 to account for an implicit most significant bit in the
+  // normalized form.
+  static FMT_CONSTEXPR_DECL const int double_significand_size =
+      std::numeric_limits<double>::digits - 1;
+  static FMT_CONSTEXPR_DECL const uint64_t implicit_bit =
+      1ull << double_significand_size;
+
+ public:
+  significand_type f;
+  int e;
+
+  static FMT_CONSTEXPR_DECL const int significand_size =
+      bits<significand_type>::value;
+
+  fp() : f(0), e(0) {}
+  fp(uint64_t f_val, int e_val) : f(f_val), e(e_val) {}
+
+  // Constructs fp from an IEEE754 double. It is a template to prevent compile
+  // errors on platforms where double is not IEEE754.
+  template <typename Double> explicit fp(Double d) {
+    // Assume double is in the format [sign][exponent][significand].
+    using limits = std::numeric_limits<Double>;
+    const int exponent_size =
+        bits<Double>::value - double_significand_size - 1;  // -1 for sign
+    const uint64_t significand_mask = implicit_bit - 1;
+    const uint64_t exponent_mask = (~0ull >> 1) & ~significand_mask;
+    const int exponent_bias = (1 << exponent_size) - limits::max_exponent - 1;
+    auto u = bit_cast<uint64_t>(d);
+    auto biased_e = (u & exponent_mask) >> double_significand_size;
+    f = u & significand_mask;
+    if (biased_e != 0)
+      f += implicit_bit;
+    else
+      biased_e = 1;  // Subnormals use biased exponent 1 (min exponent).
+    e = static_cast<int>(biased_e - exponent_bias - double_significand_size);
+  }
+
+  // Normalizes the value converted from double and multiplied by (1 << SHIFT).
+  template <int SHIFT = 0> void normalize() {
+    // Handle subnormals.
+    auto shifted_implicit_bit = implicit_bit << SHIFT;
+    while ((f & shifted_implicit_bit) == 0) {
+      f <<= 1;
+      --e;
+    }
+    // Subtract 1 to account for hidden bit.
+    auto offset = significand_size - double_significand_size - SHIFT - 1;
+    f <<= offset;
+    e -= offset;
+  }
+
+  // Compute lower and upper boundaries (m^- and m^+ in the Grisu paper), where
+  // a boundary is a value half way between the number and its predecessor
+  // (lower) or successor (upper). The upper boundary is normalized and lower
+  // has the same exponent but may be not normalized.
+  void compute_boundaries(fp& lower, fp& upper) const {
+    lower =
+        f == implicit_bit ? fp((f << 2) - 1, e - 2) : fp((f << 1) - 1, e - 1);
+    upper = fp((f << 1) + 1, e - 1);
+    upper.normalize<1>();  // 1 is to account for the exponent shift above.
+    lower.f <<= lower.e - upper.e;
+    lower.e = upper.e;
+  }
+};
+
+// Returns an fp number representing x - y. Result may not be normalized.
+inline fp operator-(fp x, fp y) {
+  FMT_ASSERT(x.f >= y.f && x.e == y.e, "invalid operands");
+  return fp(x.f - y.f, x.e);
+}
+
+// Computes an fp number r with r.f = x.f * y.f / pow(2, 64) rounded to nearest
+// with half-up tie breaking, r.e = x.e + y.e + 64. Result may not be
+// normalized.
+FMT_FUNC fp operator*(fp x, fp y) {
+  int exp = x.e + y.e + 64;
+#if FMT_USE_INT128
+  auto product = static_cast<__uint128_t>(x.f) * y.f;
+  auto f = static_cast<uint64_t>(product >> 64);
+  if ((static_cast<uint64_t>(product) & (1ULL << 63)) != 0) ++f;
+  return fp(f, exp);
+#else
+  // Multiply 32-bit parts of significands.
+  uint64_t mask = (1ULL << 32) - 1;
+  uint64_t a = x.f >> 32, b = x.f & mask;
+  uint64_t c = y.f >> 32, d = y.f & mask;
+  uint64_t ac = a * c, bc = b * c, ad = a * d, bd = b * d;
+  // Compute mid 64-bit of result and round.
+  uint64_t mid = (bd >> 32) + (ad & mask) + (bc & mask) + (1U << 31);
+  return fp(ac + (ad >> 32) + (bc >> 32) + (mid >> 32), exp);
+#endif
+}
+
+// Returns cached power (of 10) c_k = c_k.f * pow(2, c_k.e) such that its
+// (binary) exponent satisfies min_exponent <= c_k.e <= min_exponent + 28.
+FMT_FUNC fp get_cached_power(int min_exponent, int& pow10_exponent) {
+  const double one_over_log2_10 = 0.30102999566398114;  // 1 / log2(10)
+  int index = static_cast<int>(
+      std::ceil((min_exponent + fp::significand_size - 1) * one_over_log2_10));
+  // Decimal exponent of the first (smallest) cached power of 10.
+  const int first_dec_exp = -348;
+  // Difference between 2 consecutive decimal exponents in cached powers of 10.
+  const int dec_exp_step = 8;
+  index = (index - first_dec_exp - 1) / dec_exp_step + 1;
+  pow10_exponent = first_dec_exp + index * dec_exp_step;
+  return fp(data::pow10_significands[index], data::pow10_exponents[index]);
+}
+
+enum round_direction { unknown, up, down };
+
+// Given the divisor (normally a power of 10), the remainder = v % divisor for
+// some number v and the error, returns whether v should be rounded up, down, or
+// whether the rounding direction can't be determined due to error.
+// error should be less than divisor / 2.
+inline round_direction get_round_direction(uint64_t divisor, uint64_t remainder,
+                                           uint64_t error) {
+  FMT_ASSERT(remainder < divisor, "");  // divisor - remainder won't overflow.
+  FMT_ASSERT(error < divisor, "");      // divisor - error won't overflow.
+  FMT_ASSERT(error < divisor - error, "");  // error * 2 won't overflow.
+  // Round down if (remainder + error) * 2 <= divisor.
+  if (remainder <= divisor - remainder && error * 2 <= divisor - remainder * 2)
+    return down;
+  // Round up if (remainder - error) * 2 >= divisor.
+  if (remainder >= error &&
+      remainder - error >= divisor - (remainder - error)) {
+    return up;
+  }
+  return unknown;
+}
+
+namespace digits {
+enum result {
+  more,  // Generate more digits.
+  done,  // Done generating digits.
+  error  // Digit generation cancelled due to an error.
+};
+}
+
+// Generates output using the Grisu digit-gen algorithm.
+// error: the size of the region (lower, upper) outside of which numbers
+// definitely do not round to value (Delta in Grisu3).
+template <typename Handler>
+digits::result grisu_gen_digits(fp value, uint64_t error, int& exp,
+                                Handler& handler) {
+  fp one(1ull << -value.e, value.e);
+  // The integral part of scaled value (p1 in Grisu) = value / one. It cannot be
+  // zero because it contains a product of two 64-bit numbers with MSB set (due
+  // to normalization) - 1, shifted right by at most 60 bits.
+  uint32_t integral = static_cast<uint32_t>(value.f >> -one.e);
+  FMT_ASSERT(integral != 0, "");
+  FMT_ASSERT(integral == value.f >> -one.e, "");
+  // The fractional part of scaled value (p2 in Grisu) c = value % one.
+  uint64_t fractional = value.f & (one.f - 1);
+  exp = count_digits(integral);  // kappa in Grisu.
+  // Divide by 10 to prevent overflow.
+  auto result = handler.on_start(data::powers_of_10_64[exp - 1] << -one.e,
+                                 value.f / 10, error * 10, exp);
+  if (result != digits::more) return result;
+  // Generate digits for the integral part. This can produce up to 10 digits.
+  do {
+    uint32_t digit = 0;
+    // This optimization by miloyip reduces the number of integer divisions by
+    // one per iteration.
+    switch (exp) {
+    case 10:
+      digit = integral / 1000000000;
+      integral %= 1000000000;
+      break;
+    case 9:
+      digit = integral / 100000000;
+      integral %= 100000000;
+      break;
+    case 8:
+      digit = integral / 10000000;
+      integral %= 10000000;
+      break;
+    case 7:
+      digit = integral / 1000000;
+      integral %= 1000000;
+      break;
+    case 6:
+      digit = integral / 100000;
+      integral %= 100000;
+      break;
+    case 5:
+      digit = integral / 10000;
+      integral %= 10000;
+      break;
+    case 4:
+      digit = integral / 1000;
+      integral %= 1000;
+      break;
+    case 3:
+      digit = integral / 100;
+      integral %= 100;
+      break;
+    case 2:
+      digit = integral / 10;
+      integral %= 10;
+      break;
+    case 1:
+      digit = integral;
+      integral = 0;
+      break;
+    default:
+      FMT_ASSERT(false, "invalid number of digits");
+    }
+    --exp;
+    uint64_t remainder =
+        (static_cast<uint64_t>(integral) << -one.e) + fractional;
+    result = handler.on_digit(static_cast<char>('0' + digit),
+                              data::powers_of_10_64[exp] << -one.e, remainder,
+                              error, exp, true);
+    if (result != digits::more) return result;
+  } while (exp > 0);
+  // Generate digits for the fractional part.
+  for (;;) {
+    fractional *= 10;
+    error *= 10;
+    char digit =
+        static_cast<char>('0' + static_cast<char>(fractional >> -one.e));
+    fractional &= one.f - 1;
+    --exp;
+    result = handler.on_digit(digit, one.f, fractional, error, exp, false);
+    if (result != digits::more) return result;
+  }
+}
+
+// The fixed precision digit handler.
+struct fixed_handler {
+  char* buf;
+  int size;
+  int precision;
+  int exp10;
+  bool fixed;
+
+  digits::result on_start(uint64_t divisor, uint64_t remainder, uint64_t error,
+                          int& exp) {
+    // Non-fixed formats require at least one digit and no precision adjustment.
+    if (!fixed) return digits::more;
+    // Adjust fixed precision by exponent because it is relative to decimal
+    // point.
+    precision += exp + exp10;
+    // Check if precision is satisfied just by leading zeros, e.g.
+    // format("{:.2f}", 0.001) gives "0.00" without generating any digits.
+    if (precision > 0) return digits::more;
+    if (precision < 0) return digits::done;
+    auto dir = get_round_direction(divisor, remainder, error);
+    if (dir == unknown) return digits::error;
+    buf[size++] = dir == up ? '1' : '0';
+    return digits::done;
+  }
+
+  digits::result on_digit(char digit, uint64_t divisor, uint64_t remainder,
+                          uint64_t error, int, bool integral) {
+    FMT_ASSERT(remainder < divisor, "");
+    buf[size++] = digit;
+    if (size < precision) return digits::more;
+    if (!integral) {
+      // Check if error * 2 < divisor with overflow prevention.
+      // The check is not needed for the integral part because error = 1
+      // and divisor > (1 << 32) there.
+      if (error >= divisor || error >= divisor - error) return digits::error;
+    } else {
+      FMT_ASSERT(error == 1 && divisor > 2, "");
+    }
+    auto dir = get_round_direction(divisor, remainder, error);
+    if (dir != up) return dir == down ? digits::done : digits::error;
+    ++buf[size - 1];
+    for (int i = size - 1; i > 0 && buf[i] > '9'; --i) {
+      buf[i] = '0';
+      ++buf[i - 1];
+    }
+    if (buf[0] > '9') {
+      buf[0] = '1';
+      buf[size++] = '0';
+    }
+    return digits::done;
+  }
+};
+
+// The shortest representation digit handler.
+template <int GRISU_VERSION> struct grisu_shortest_handler {
+  char* buf;
+  int size;
+  // Distance between scaled value and upper bound (wp_W in Grisu3).
+  uint64_t diff;
+
+  digits::result on_start(uint64_t, uint64_t, uint64_t, int&) {
+    return digits::more;
+  }
+
+  // Decrement the generated number approaching value from above.
+  void round(uint64_t d, uint64_t divisor, uint64_t& remainder,
+             uint64_t error) {
+    while (
+        remainder < d && error - remainder >= divisor &&
+        (remainder + divisor < d || d - remainder >= remainder + divisor - d)) {
+      --buf[size - 1];
+      remainder += divisor;
+    }
+  }
+
+  // Implements Grisu's round_weed.
+  digits::result on_digit(char digit, uint64_t divisor, uint64_t remainder,
+                          uint64_t error, int exp, bool integral) {
+    buf[size++] = digit;
+    if (remainder >= error) return digits::more;
+    if (GRISU_VERSION != 3) {
+      uint64_t d = integral ? diff : diff * data::powers_of_10_64[-exp];
+      round(d, divisor, remainder, error);
+      return digits::done;
+    }
+    uint64_t unit = integral ? 1 : data::powers_of_10_64[-exp];
+    uint64_t up = (diff - 1) * unit;  // wp_Wup
+    round(up, divisor, remainder, error);
+    uint64_t down = (diff + 1) * unit;  // wp_Wdown
+    if (remainder < down && error - remainder >= divisor &&
+        (remainder + divisor < down ||
+         down - remainder > remainder + divisor - down)) {
+      return digits::error;
+    }
+    return 2 * unit <= remainder && remainder <= error - 4 * unit
+               ? digits::done
+               : digits::error;
+  }
+};
+
+template <typename Double,
+          enable_if_t<(sizeof(Double) == sizeof(uint64_t)), int>>
+FMT_API bool grisu_format(Double value, buffer<char>& buf, int precision,
+                          unsigned options, int& exp) {
+  FMT_ASSERT(value >= 0, "value is negative");
+  bool fixed = (options & grisu_options::fixed) != 0;
+  if (value <= 0) {  // <= instead of == to silence a warning.
+    if (precision <= 0 || !fixed) {
+      exp = 0;
+      buf.push_back('0');
+    } else {
+      exp = -precision;
+      buf.resize(precision);
+      std::uninitialized_fill_n(buf.data(), precision, '0');
+    }
+    return true;
+  }
+
+  fp fp_value(value);
+  const int min_exp = -60;  // alpha in Grisu.
+  int cached_exp10 = 0;     // K in Grisu.
+  if (precision != -1) {
+    if (precision > 17) return false;
+    fp_value.normalize();
+    auto cached_pow = get_cached_power(
+        min_exp - (fp_value.e + fp::significand_size), cached_exp10);
+    fp_value = fp_value * cached_pow;
+    fixed_handler handler{buf.data(), 0, precision, -cached_exp10, fixed};
+    if (grisu_gen_digits(fp_value, 1, exp, handler) == digits::error)
+      return false;
+    buf.resize(to_unsigned(handler.size));
+  } else {
+    fp lower, upper;  // w^- and w^+ in the Grisu paper.
+    fp_value.compute_boundaries(lower, upper);
+    // Find a cached power of 10 such that multiplying upper by it will bring
+    // the exponent in the range [min_exp, -32].
+    auto cached_pow = get_cached_power(  // \tilde{c}_{-k} in Grisu.
+        min_exp - (upper.e + fp::significand_size), cached_exp10);
+    fp_value.normalize();
+    fp_value = fp_value * cached_pow;
+    lower = lower * cached_pow;  // \tilde{M}^- in Grisu.
+    upper = upper * cached_pow;  // \tilde{M}^+ in Grisu.
+    assert(min_exp <= upper.e && upper.e <= -32);
+    auto result = digits::result();
+    int size = 0;
+    if ((options & grisu_options::grisu3) != 0) {
+      --lower.f;  // \tilde{M}^- - 1 ulp -> M^-_{\downarrow}.
+      ++upper.f;  // \tilde{M}^+ + 1 ulp -> M^+_{\uparrow}.
+      // Numbers outside of (lower, upper) definitely do not round to value.
+      grisu_shortest_handler<3> handler{buf.data(), 0, (upper - fp_value).f};
+      result = grisu_gen_digits(upper, upper.f - lower.f, exp, handler);
+      size = handler.size;
+    } else {
+      ++lower.f;  // \tilde{M}^- + 1 ulp -> M^-_{\uparrow}.
+      --upper.f;  // \tilde{M}^+ - 1 ulp -> M^+_{\downarrow}.
+      grisu_shortest_handler<2> handler{buf.data(), 0, (upper - fp_value).f};
+      result = grisu_gen_digits(upper, upper.f - lower.f, exp, handler);
+      size = handler.size;
+    }
+    if (result == digits::error) return false;
+    buf.resize(to_unsigned(size));
+  }
+  exp -= cached_exp10;
+  return true;
+}
+
+template <typename Double>
+char* sprintf_format(Double value, internal::buffer<char>& buf,
+                     sprintf_specs specs) {
+  // Buffer capacity must be non-zero, otherwise MSVC's vsnprintf_s will fail.
+  FMT_ASSERT(buf.capacity() != 0, "empty buffer");
+
+  // Build format string.
+  enum { max_format_size = 10 };  // longest format: %#-*.*Lg
+  char format[max_format_size];
+  char* format_ptr = format;
+  *format_ptr++ = '%';
+  if (specs.alt || !specs.type) *format_ptr++ = '#';
+  if (specs.precision >= 0) {
+    *format_ptr++ = '.';
+    *format_ptr++ = '*';
+  }
+  if (std::is_same<Double, long double>::value) *format_ptr++ = 'L';
+
+  char type = specs.type;
+
+  if (type == '%')
+    type = 'f';
+  else if (type == 0 || type == 'n')
+    type = 'g';
+#if FMT_MSC_VER
+  if (type == 'F') {
+    // MSVC's printf doesn't support 'F'.
+    type = 'f';
+  }
+#endif
+  *format_ptr++ = type;
+  *format_ptr = '\0';
+
+  // Format using snprintf.
+  char* start = nullptr;
+  char* decimal_point_pos = nullptr;
+  for (;;) {
+    std::size_t buffer_size = buf.capacity();
+    start = &buf[0];
+    int result =
+        format_float(start, buffer_size, format, specs.precision, value);
+    if (result >= 0) {
+      unsigned n = internal::to_unsigned(result);
+      if (n < buf.capacity()) {
+        // Find the decimal point.
+        auto p = buf.data(), end = p + n;
+        if (*p == '+' || *p == '-') ++p;
+        if (specs.type != 'a' && specs.type != 'A') {
+          while (p < end && *p >= '0' && *p <= '9') ++p;
+          if (p < end && *p != 'e' && *p != 'E') {
+            decimal_point_pos = p;
+            if (!specs.type) {
+              // Keep only one trailing zero after the decimal point.
+              ++p;
+              if (*p == '0') ++p;
+              while (p != end && *p >= '1' && *p <= '9') ++p;
+              char* where = p;
+              while (p != end && *p == '0') ++p;
+              if (p == end || *p < '0' || *p > '9') {
+                if (p != end) std::memmove(where, p, to_unsigned(end - p));
+                n -= static_cast<unsigned>(p - where);
+              }
+            }
+          }
+        }
+        buf.resize(n);
+        break;  // The buffer is large enough - continue with formatting.
+      }
+      buf.reserve(n + 1);
+    } else {
+      // If result is negative we ask to increase the capacity by at least 1,
+      // but as std::vector, the buffer grows exponentially.
+      buf.reserve(buf.capacity() + 1);
+    }
+  }
+  return decimal_point_pos;
+}
+}  // namespace internal
+
+#if FMT_USE_WINDOWS_H
+
+FMT_FUNC internal::utf8_to_utf16::utf8_to_utf16(string_view s) {
+  static const char ERROR_MSG[] = "cannot convert string from UTF-8 to UTF-16";
+  if (s.size() > INT_MAX)
+    FMT_THROW(windows_error(ERROR_INVALID_PARAMETER, ERROR_MSG));
+  int s_size = static_cast<int>(s.size());
+  if (s_size == 0) {
+    // MultiByteToWideChar does not support zero length, handle separately.
+    buffer_.resize(1);
+    buffer_[0] = 0;
+    return;
+  }
+
+  int length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s.data(),
+                                   s_size, nullptr, 0);
+  if (length == 0) FMT_THROW(windows_error(GetLastError(), ERROR_MSG));
+  buffer_.resize(length + 1);
+  length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size,
+                               &buffer_[0], length);
+  if (length == 0) FMT_THROW(windows_error(GetLastError(), ERROR_MSG));
+  buffer_[length] = 0;
+}
+
+FMT_FUNC internal::utf16_to_utf8::utf16_to_utf8(wstring_view s) {
+  if (int error_code = convert(s)) {
+    FMT_THROW(windows_error(error_code,
+                            "cannot convert string from UTF-16 to UTF-8"));
+  }
+}
+
+FMT_FUNC int internal::utf16_to_utf8::convert(wstring_view s) {
+  if (s.size() > INT_MAX) return ERROR_INVALID_PARAMETER;
+  int s_size = static_cast<int>(s.size());
+  if (s_size == 0) {
+    // WideCharToMultiByte does not support zero length, handle separately.
+    buffer_.resize(1);
+    buffer_[0] = 0;
+    return 0;
+  }
+
+  int length = WideCharToMultiByte(CP_UTF8, 0, s.data(), s_size, nullptr, 0,
+                                   nullptr, nullptr);
+  if (length == 0) return GetLastError();
+  buffer_.resize(length + 1);
+  length = WideCharToMultiByte(CP_UTF8, 0, s.data(), s_size, &buffer_[0],
+                               length, nullptr, nullptr);
+  if (length == 0) return GetLastError();
+  buffer_[length] = 0;
+  return 0;
+}
+
+FMT_FUNC void windows_error::init(int err_code, string_view format_str,
+                                  format_args args) {
+  error_code_ = err_code;
+  memory_buffer buffer;
+  internal::format_windows_error(buffer, err_code, vformat(format_str, args));
+  std::runtime_error& base = *this;
+  base = std::runtime_error(to_string(buffer));
+}
+
+FMT_FUNC void internal::format_windows_error(internal::buffer<char>& out,
+                                             int error_code,
+                                             string_view message) FMT_NOEXCEPT {
+  FMT_TRY {
+    wmemory_buffer buf;
+    buf.resize(inline_buffer_size);
+    for (;;) {
+      wchar_t* system_message = &buf[0];
+      int result = FormatMessageW(
+          FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,
+          error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), system_message,
+          static_cast<uint32_t>(buf.size()), nullptr);
+      if (result != 0) {
+        utf16_to_utf8 utf8_message;
+        if (utf8_message.convert(system_message) == ERROR_SUCCESS) {
+          internal::writer w(out);
+          w.write(message);
+          w.write(": ");
+          w.write(utf8_message);
+          return;
+        }
+        break;
+      }
+      if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+        break;  // Can't get error message, report error code instead.
+      buf.resize(buf.size() * 2);
+    }
+  }
+  FMT_CATCH(...) {}
+  format_error_code(out, error_code, message);
+}
+
+#endif  // FMT_USE_WINDOWS_H
+
+FMT_FUNC void format_system_error(internal::buffer<char>& out, int error_code,
+                                  string_view message) FMT_NOEXCEPT {
+  FMT_TRY {
+    memory_buffer buf;
+    buf.resize(inline_buffer_size);
+    for (;;) {
+      char* system_message = &buf[0];
+      int result =
+          internal::safe_strerror(error_code, system_message, buf.size());
+      if (result == 0) {
+        internal::writer w(out);
+        w.write(message);
+        w.write(": ");
+        w.write(system_message);
+        return;
+      }
+      if (result != ERANGE)
+        break;  // Can't get error message, report error code instead.
+      buf.resize(buf.size() * 2);
+    }
+  }
+  FMT_CATCH(...) {}
+  format_error_code(out, error_code, message);
+}
+
+FMT_FUNC void internal::error_handler::on_error(const char* message) {
+  FMT_THROW(format_error(message));
+}
+
+FMT_FUNC void report_system_error(int error_code,
+                                  fmt::string_view message) FMT_NOEXCEPT {
+  report_error(format_system_error, error_code, message);
+}
+
+#if FMT_USE_WINDOWS_H
+FMT_FUNC void report_windows_error(int error_code,
+                                   fmt::string_view message) FMT_NOEXCEPT {
+  report_error(internal::format_windows_error, error_code, message);
+}
+#endif
+
+FMT_FUNC void vprint(std::FILE* f, string_view format_str, format_args args) {
+  memory_buffer buffer;
+  internal::vformat_to(buffer, format_str,
+                       basic_format_args<buffer_context<char>>(args));
+  internal::fwrite_fully(buffer.data(), 1, buffer.size(), f);
+}
+
+FMT_FUNC void vprint(std::FILE* f, wstring_view format_str, wformat_args args) {
+  wmemory_buffer buffer;
+  internal::vformat_to(buffer, format_str, args);
+  buffer.push_back(L'\0');
+  if (std::fputws(buffer.data(), f) == -1) {
+    FMT_THROW(system_error(errno, "cannot write to file"));
+  }
+}
+
+FMT_FUNC void vprint(string_view format_str, format_args args) {
+  vprint(stdout, format_str, args);
+}
+
+FMT_FUNC void vprint(wstring_view format_str, wformat_args args) {
+  vprint(stdout, format_str, args);
+}
+
+FMT_END_NAMESPACE
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
+
+#endif  // FMT_FORMAT_INL_H_

--- a/contrib/fmt/include/fmt/format.h
+++ b/contrib/fmt/include/fmt/format.h
@@ -1,0 +1,3600 @@
+/*
+ Formatting library for C++
+
+ Copyright (c) 2012 - present, Victor Zverovich
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ --- Optional exception to the license ---
+
+ As an exception, if, as a result of your compiling your source code, portions
+ of this Software are embedded into a machine-executable object form of such
+ source code, you may redistribute such embedded portions in such object form
+ without including the above copyright and permission notices.
+ */
+
+#ifndef FMT_FORMAT_H_
+#define FMT_FORMAT_H_
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+
+#include "core.h"
+
+#ifdef __clang__
+#  define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
+#else
+#  define FMT_CLANG_VERSION 0
+#endif
+
+#ifdef __INTEL_COMPILER
+#  define FMT_ICC_VERSION __INTEL_COMPILER
+#elif defined(__ICL)
+#  define FMT_ICC_VERSION __ICL
+#else
+#  define FMT_ICC_VERSION 0
+#endif
+
+#ifdef __NVCC__
+#  define FMT_CUDA_VERSION (__CUDACC_VER_MAJOR__ * 100 + __CUDACC_VER_MINOR__)
+#else
+#  define FMT_CUDA_VERSION 0
+#endif
+
+#ifdef __has_builtin
+#  define FMT_HAS_BUILTIN(x) __has_builtin(x)
+#else
+#  define FMT_HAS_BUILTIN(x) 0
+#endif
+
+#ifndef FMT_THROW
+#  if FMT_EXCEPTIONS
+#    if FMT_MSC_VER
+FMT_BEGIN_NAMESPACE
+namespace internal {
+template <typename Exception> inline void do_throw(const Exception& x) {
+  // Silence unreachable code warnings in MSVC because these are nearly
+  // impossible to fix in a generic code.
+  volatile bool b = true;
+  if (b) throw x;
+}
+}  // namespace internal
+FMT_END_NAMESPACE
+#      define FMT_THROW(x) fmt::internal::do_throw(x)
+#    else
+#      define FMT_THROW(x) throw x
+#    endif
+#  else
+#    define FMT_THROW(x)              \
+      do {                            \
+        static_cast<void>(sizeof(x)); \
+        assert(false);                \
+      } while (false)
+#  endif
+#endif
+
+#ifndef FMT_USE_USER_DEFINED_LITERALS
+// For Intel and NVIDIA compilers both they and the system gcc/msc support UDLs.
+#  if (FMT_HAS_FEATURE(cxx_user_literals) || FMT_GCC_VERSION >= 407 ||      \
+       FMT_MSC_VER >= 1900) &&                                              \
+      (!(FMT_ICC_VERSION || FMT_CUDA_VERSION) || FMT_ICC_VERSION >= 1500 || \
+       FMT_CUDA_VERSION >= 700)
+#    define FMT_USE_USER_DEFINED_LITERALS 1
+#  else
+#    define FMT_USE_USER_DEFINED_LITERALS 0
+#  endif
+#endif
+
+#ifndef FMT_USE_UDL_TEMPLATE
+// EDG front end based compilers (icc, nvcc) do not support UDL templates yet
+// and GCC 9 warns about them.
+#  if FMT_USE_USER_DEFINED_LITERALS && FMT_ICC_VERSION == 0 && \
+      FMT_CUDA_VERSION == 0 &&                                 \
+      ((FMT_GCC_VERSION >= 600 && FMT_GCC_VERSION <= 900 &&    \
+        __cplusplus >= 201402L) ||                             \
+       FMT_CLANG_VERSION >= 304)
+#    define FMT_USE_UDL_TEMPLATE 1
+#  else
+#    define FMT_USE_UDL_TEMPLATE 0
+#  endif
+#endif
+
+#ifdef FMT_USE_INT128
+// Do nothing.
+#elif defined(__SIZEOF_INT128__)
+#  define FMT_USE_INT128 1
+#else
+#  define FMT_USE_INT128 0
+#endif
+
+// __builtin_clz is broken in clang with Microsoft CodeGen:
+// https://github.com/fmtlib/fmt/issues/519
+#if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_clz)) && !FMT_MSC_VER
+#  define FMT_BUILTIN_CLZ(n) __builtin_clz(n)
+#endif
+#if (FMT_GCC_VERSION || FMT_HAS_BUILTIN(__builtin_clzll)) && !FMT_MSC_VER
+#  define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
+#endif
+
+// Some compilers masquerade as both MSVC and GCC-likes or otherwise support
+// __builtin_clz and __builtin_clzll, so only define FMT_BUILTIN_CLZ using the
+// MSVC intrinsics if the clz and clzll builtins are not available.
+#if FMT_MSC_VER && !defined(FMT_BUILTIN_CLZLL) && !defined(_MANAGED)
+#  include <intrin.h>  // _BitScanReverse, _BitScanReverse64
+
+FMT_BEGIN_NAMESPACE
+namespace internal {
+// Avoid Clang with Microsoft CodeGen's -Wunknown-pragmas warning.
+#  ifndef __clang__
+#    pragma intrinsic(_BitScanReverse)
+#  endif
+inline uint32_t clz(uint32_t x) {
+  unsigned long r = 0;
+  _BitScanReverse(&r, x);
+
+  assert(x != 0);
+  // Static analysis complains about using uninitialized data
+  // "r", but the only way that can happen is if "x" is 0,
+  // which the callers guarantee to not happen.
+#  pragma warning(suppress : 6102)
+  return 31 - r;
+}
+#  define FMT_BUILTIN_CLZ(n) fmt::internal::clz(n)
+
+#  if defined(_WIN64) && !defined(__clang__)
+#    pragma intrinsic(_BitScanReverse64)
+#  endif
+
+inline uint32_t clzll(uint64_t x) {
+  unsigned long r = 0;
+#  ifdef _WIN64
+  _BitScanReverse64(&r, x);
+#  else
+  // Scan the high 32 bits.
+  if (_BitScanReverse(&r, static_cast<uint32_t>(x >> 32))) return 63 - (r + 32);
+
+  // Scan the low 32 bits.
+  _BitScanReverse(&r, static_cast<uint32_t>(x));
+#  endif
+
+  assert(x != 0);
+  // Static analysis complains about using uninitialized data
+  // "r", but the only way that can happen is if "x" is 0,
+  // which the callers guarantee to not happen.
+#  pragma warning(suppress : 6102)
+  return 63 - r;
+}
+#  define FMT_BUILTIN_CLZLL(n) fmt::internal::clzll(n)
+}  // namespace internal
+FMT_END_NAMESPACE
+#endif
+
+FMT_BEGIN_NAMESPACE
+namespace internal {
+
+// A fallback implementation of uintptr_t for systems that lack it.
+struct fallback_uintptr {
+  unsigned char value[sizeof(void*)];
+};
+#ifdef UINTPTR_MAX
+using uintptr_t = ::uintptr_t;
+#else
+using uintptr_t = fallback_uintptr;
+#endif
+
+// An equivalent of `*reinterpret_cast<Dest*>(&source)` that doesn't produce
+// undefined behavior (e.g. due to type aliasing).
+// Example: uint64_t d = bit_cast<uint64_t>(2.718);
+template <typename Dest, typename Source>
+inline Dest bit_cast(const Source& source) {
+  static_assert(sizeof(Dest) == sizeof(Source), "size mismatch");
+  Dest dest;
+  std::memcpy(&dest, &source, sizeof(dest));
+  return dest;
+}
+
+// An approximation of iterator_t for pre-C++20 systems.
+template <typename T>
+using iterator_t = decltype(std::begin(std::declval<T&>()));
+
+// Detect the iterator category of *any* given type in a SFINAE-friendly way.
+// Unfortunately, older implementations of std::iterator_traits are not safe
+// for use in a SFINAE-context.
+template <typename It, typename Enable = void>
+struct iterator_category : std::false_type {};
+
+template <typename T> struct iterator_category<T*> {
+  using type = std::random_access_iterator_tag;
+};
+
+template <typename It>
+struct iterator_category<It, void_t<typename It::iterator_category>> {
+  using type = typename It::iterator_category;
+};
+
+// Detect if *any* given type models the OutputIterator concept.
+template <typename It> class is_output_iterator {
+  // Check for mutability because all iterator categories derived from
+  // std::input_iterator_tag *may* also meet the requirements of an
+  // OutputIterator, thereby falling into the category of 'mutable iterators'
+  // [iterator.requirements.general] clause 4. The compiler reveals this
+  // property only at the point of *actually dereferencing* the iterator!
+  template <typename U>
+  static decltype(*(std::declval<U>())) test(std::input_iterator_tag);
+  template <typename U> static char& test(std::output_iterator_tag);
+  template <typename U> static const char& test(...);
+
+  using type = decltype(test<It>(typename iterator_category<It>::type{}));
+
+ public:
+  static const bool value = !std::is_const<remove_reference_t<type>>::value;
+};
+
+// A workaround for std::string not having mutable data() until C++17.
+template <typename Char> inline Char* get_data(std::basic_string<Char>& s) {
+  return &s[0];
+}
+template <typename Container>
+inline typename Container::value_type* get_data(Container& c) {
+  return c.data();
+}
+
+#ifdef _SECURE_SCL
+// Make a checked iterator to avoid MSVC warnings.
+template <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;
+template <typename T> checked_ptr<T> make_checked(T* p, std::size_t size) {
+  return {p, size};
+}
+#else
+template <typename T> using checked_ptr = T*;
+template <typename T> inline T* make_checked(T* p, std::size_t) { return p; }
+#endif
+
+template <typename Container, FMT_ENABLE_IF(is_contiguous<Container>::value)>
+inline checked_ptr<typename Container::value_type> reserve(
+    std::back_insert_iterator<Container>& it, std::size_t n) {
+  Container& c = get_container(it);
+  std::size_t size = c.size();
+  c.resize(size + n);
+  return make_checked(get_data(c) + size, n);
+}
+
+template <typename Iterator>
+inline Iterator& reserve(Iterator& it, std::size_t) {
+  return it;
+}
+
+// An output iterator that counts the number of objects written to it and
+// discards them.
+template <typename T> class counting_iterator {
+ private:
+  std::size_t count_;
+  mutable T blackhole_;
+
+ public:
+  using iterator_category = std::output_iterator_tag;
+  using value_type = T;
+  using difference_type = std::ptrdiff_t;
+  using pointer = T*;
+  using reference = T&;
+  using _Unchecked_type = counting_iterator;  // Mark iterator as checked.
+
+  counting_iterator() : count_(0) {}
+
+  std::size_t count() const { return count_; }
+
+  counting_iterator& operator++() {
+    ++count_;
+    return *this;
+  }
+
+  counting_iterator operator++(int) {
+    auto it = *this;
+    ++*this;
+    return it;
+  }
+
+  T& operator*() const { return blackhole_; }
+};
+
+template <typename OutputIt> class truncating_iterator_base {
+ protected:
+  OutputIt out_;
+  std::size_t limit_;
+  std::size_t count_;
+
+  truncating_iterator_base(OutputIt out, std::size_t limit)
+      : out_(out), limit_(limit), count_(0) {}
+
+ public:
+  using iterator_category = std::output_iterator_tag;
+  using difference_type = void;
+  using pointer = void;
+  using reference = void;
+  using _Unchecked_type =
+      truncating_iterator_base;  // Mark iterator as checked.
+
+  OutputIt base() const { return out_; }
+  std::size_t count() const { return count_; }
+};
+
+// An output iterator that truncates the output and counts the number of objects
+// written to it.
+template <typename OutputIt,
+          typename Enable = typename std::is_void<
+              typename std::iterator_traits<OutputIt>::value_type>::type>
+class truncating_iterator;
+
+template <typename OutputIt>
+class truncating_iterator<OutputIt, std::false_type>
+    : public truncating_iterator_base<OutputIt> {
+  using traits = std::iterator_traits<OutputIt>;
+
+  mutable typename traits::value_type blackhole_;
+
+ public:
+  using value_type = typename traits::value_type;
+
+  truncating_iterator(OutputIt out, std::size_t limit)
+      : truncating_iterator_base<OutputIt>(out, limit) {}
+
+  truncating_iterator& operator++() {
+    if (this->count_++ < this->limit_) ++this->out_;
+    return *this;
+  }
+
+  truncating_iterator operator++(int) {
+    auto it = *this;
+    ++*this;
+    return it;
+  }
+
+  value_type& operator*() const {
+    return this->count_ < this->limit_ ? *this->out_ : blackhole_;
+  }
+};
+
+template <typename OutputIt>
+class truncating_iterator<OutputIt, std::true_type>
+    : public truncating_iterator_base<OutputIt> {
+ public:
+  using value_type = typename OutputIt::container_type::value_type;
+
+  truncating_iterator(OutputIt out, std::size_t limit)
+      : truncating_iterator_base<OutputIt>(out, limit) {}
+
+  truncating_iterator& operator=(value_type val) {
+    if (this->count_++ < this->limit_) this->out_ = val;
+    return *this;
+  }
+
+  truncating_iterator& operator++() { return *this; }
+  truncating_iterator& operator++(int) { return *this; }
+  truncating_iterator& operator*() { return *this; }
+};
+
+// A range with the specified output iterator and value type.
+template <typename OutputIt, typename T = typename OutputIt::value_type>
+class output_range {
+ private:
+  OutputIt it_;
+
+ public:
+  using value_type = T;
+  using iterator = OutputIt;
+  struct sentinel {};
+
+  explicit output_range(OutputIt it) : it_(it) {}
+  OutputIt begin() const { return it_; }
+  sentinel end() const { return {}; }  // Sentinel is not used yet.
+};
+
+// A range with an iterator appending to a buffer.
+template <typename T>
+class buffer_range
+    : public output_range<std::back_insert_iterator<buffer<T>>, T> {
+ public:
+  using iterator = std::back_insert_iterator<buffer<T>>;
+  using output_range<iterator, T>::output_range;
+  buffer_range(buffer<T>& buf)
+      : output_range<iterator, T>(std::back_inserter(buf)) {}
+};
+
+template <typename Char>
+inline size_t count_code_points(basic_string_view<Char> s) {
+  return s.size();
+}
+
+// Counts the number of code points in a UTF-8 string.
+inline size_t count_code_points(basic_string_view<char8_t> s) {
+  const char8_t* data = s.data();
+  size_t num_code_points = 0;
+  for (size_t i = 0, size = s.size(); i != size; ++i) {
+    if ((data[i] & 0xc0) != 0x80) ++num_code_points;
+  }
+  return num_code_points;
+}
+
+inline char8_t to_char8_t(char c) { return static_cast<char8_t>(c); }
+
+template <typename InputIt, typename OutChar>
+using needs_conversion = bool_constant<
+    std::is_same<typename std::iterator_traits<InputIt>::value_type,
+                 char>::value &&
+    std::is_same<OutChar, char8_t>::value>;
+
+template <typename OutChar, typename InputIt, typename OutputIt,
+          FMT_ENABLE_IF(!needs_conversion<InputIt, OutChar>::value)>
+OutputIt copy_str(InputIt begin, InputIt end, OutputIt it) {
+  return std::copy(begin, end, it);
+}
+
+template <typename OutChar, typename InputIt, typename OutputIt,
+          FMT_ENABLE_IF(needs_conversion<InputIt, OutChar>::value)>
+OutputIt copy_str(InputIt begin, InputIt end, OutputIt it) {
+  return std::transform(begin, end, it, to_char8_t);
+}
+
+#ifndef FMT_USE_GRISU
+#  define FMT_USE_GRISU 0
+#endif
+
+template <typename T> constexpr bool use_grisu() {
+  return FMT_USE_GRISU && std::numeric_limits<double>::is_iec559 &&
+         sizeof(T) <= sizeof(double);
+}
+
+template <typename T>
+template <typename U>
+void buffer<T>::append(const U* begin, const U* end) {
+  std::size_t new_size = size_ + to_unsigned(end - begin);
+  reserve(new_size);
+  std::uninitialized_copy(begin, end, make_checked(ptr_, capacity_) + size_);
+  size_ = new_size;
+}
+}  // namespace internal
+
+// A UTF-8 string view.
+class u8string_view : public basic_string_view<char8_t> {
+ public:
+  u8string_view(const char* s)
+      : basic_string_view<char8_t>(reinterpret_cast<const char8_t*>(s)) {}
+  u8string_view(const char* s, size_t count) FMT_NOEXCEPT
+      : basic_string_view<char8_t>(reinterpret_cast<const char8_t*>(s), count) {
+  }
+};
+
+#if FMT_USE_USER_DEFINED_LITERALS
+inline namespace literals {
+inline u8string_view operator"" _u(const char* s, std::size_t n) {
+  return {s, n};
+}
+}  // namespace literals
+#endif
+
+// The number of characters to store in the basic_memory_buffer object itself
+// to avoid dynamic memory allocation.
+enum { inline_buffer_size = 500 };
+
+/**
+  \rst
+  A dynamically growing memory buffer for trivially copyable/constructible types
+  with the first ``SIZE`` elements stored in the object itself.
+
+  You can use one of the following type aliases for common character types:
+
+  +----------------+------------------------------+
+  | Type           | Definition                   |
+  +================+==============================+
+  | memory_buffer  | basic_memory_buffer<char>    |
+  +----------------+------------------------------+
+  | wmemory_buffer | basic_memory_buffer<wchar_t> |
+  +----------------+------------------------------+
+
+  **Example**::
+
+     fmt::memory_buffer out;
+     format_to(out, "The answer is {}.", 42);
+
+  This will append the following output to the ``out`` object:
+
+  .. code-block:: none
+
+     The answer is 42.
+
+  The output can be converted to an ``std::string`` with ``to_string(out)``.
+  \endrst
+ */
+template <typename T, std::size_t SIZE = inline_buffer_size,
+          typename Allocator = std::allocator<T>>
+class basic_memory_buffer : private Allocator, public internal::buffer<T> {
+ private:
+  T store_[SIZE];
+
+  // Deallocate memory allocated by the buffer.
+  void deallocate() {
+    T* data = this->data();
+    if (data != store_) Allocator::deallocate(data, this->capacity());
+  }
+
+ protected:
+  void grow(std::size_t size) FMT_OVERRIDE;
+
+ public:
+  using value_type = T;
+  using const_reference = const T&;
+
+  explicit basic_memory_buffer(const Allocator& alloc = Allocator())
+      : Allocator(alloc) {
+    this->set(store_, SIZE);
+  }
+  ~basic_memory_buffer() { deallocate(); }
+
+ private:
+  // Move data from other to this buffer.
+  void move(basic_memory_buffer& other) {
+    Allocator &this_alloc = *this, &other_alloc = other;
+    this_alloc = std::move(other_alloc);
+    T* data = other.data();
+    std::size_t size = other.size(), capacity = other.capacity();
+    if (data == other.store_) {
+      this->set(store_, capacity);
+      std::uninitialized_copy(other.store_, other.store_ + size,
+                              internal::make_checked(store_, capacity));
+    } else {
+      this->set(data, capacity);
+      // Set pointer to the inline array so that delete is not called
+      // when deallocating.
+      other.set(other.store_, 0);
+    }
+    this->resize(size);
+  }
+
+ public:
+  /**
+    \rst
+    Constructs a :class:`fmt::basic_memory_buffer` object moving the content
+    of the other object to it.
+    \endrst
+   */
+  basic_memory_buffer(basic_memory_buffer&& other) { move(other); }
+
+  /**
+    \rst
+    Moves the content of the other ``basic_memory_buffer`` object to this one.
+    \endrst
+   */
+  basic_memory_buffer& operator=(basic_memory_buffer&& other) {
+    assert(this != &other);
+    deallocate();
+    move(other);
+    return *this;
+  }
+
+  // Returns a copy of the allocator associated with this buffer.
+  Allocator get_allocator() const { return *this; }
+};
+
+template <typename T, std::size_t SIZE, typename Allocator>
+void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+  if (size > 1000) throw std::runtime_error("fuzz mode - won't grow that much");
+#endif
+  std::size_t old_capacity = this->capacity();
+  std::size_t new_capacity = old_capacity + old_capacity / 2;
+  if (size > new_capacity) new_capacity = size;
+  T* old_data = this->data();
+  T* new_data = std::allocator_traits<Allocator>::allocate(*this, new_capacity);
+  // The following code doesn't throw, so the raw pointer above doesn't leak.
+  std::uninitialized_copy(old_data, old_data + this->size(),
+                          internal::make_checked(new_data, new_capacity));
+  this->set(new_data, new_capacity);
+  // deallocate must not throw according to the standard, but even if it does,
+  // the buffer already uses the new storage and will deallocate it in
+  // destructor.
+  if (old_data != store_) Allocator::deallocate(old_data, old_capacity);
+}
+
+using memory_buffer = basic_memory_buffer<char>;
+using wmemory_buffer = basic_memory_buffer<wchar_t>;
+
+/** A formatting error such as invalid format string. */
+class FMT_API format_error : public std::runtime_error {
+ public:
+  explicit format_error(const char* message) : std::runtime_error(message) {}
+  explicit format_error(const std::string& message)
+      : std::runtime_error(message) {}
+  ~format_error() FMT_NOEXCEPT;
+};
+
+namespace internal {
+
+// Returns true if value is negative, false otherwise.
+// Same as `value < 0` but doesn't produce warnings if T is an unsigned type.
+template <typename T, FMT_ENABLE_IF(std::numeric_limits<T>::is_signed)>
+FMT_CONSTEXPR bool is_negative(T value) {
+  return value < 0;
+}
+template <typename T, FMT_ENABLE_IF(!std::numeric_limits<T>::is_signed)>
+FMT_CONSTEXPR bool is_negative(T) {
+  return false;
+}
+
+// Smallest of uint32_t and uint64_t that is large enough to represent all
+// values of T.
+template <typename T>
+using uint32_or_64_t =
+    conditional_t<std::numeric_limits<T>::digits <= 32, uint32_t, uint64_t>;
+
+// Static data is placed in this class template for the header-only config.
+template <typename T = void> struct FMT_EXTERN_TEMPLATE_API basic_data {
+  static const uint64_t powers_of_10_64[];
+  static const uint32_t zero_or_powers_of_10_32[];
+  static const uint64_t zero_or_powers_of_10_64[];
+  static const uint64_t pow10_significands[];
+  static const int16_t pow10_exponents[];
+  static const char digits[];
+  static const char hex_digits[];
+  static const char foreground_color[];
+  static const char background_color[];
+  static const char reset_color[5];
+  static const wchar_t wreset_color[5];
+};
+
+FMT_EXTERN template struct basic_data<void>;
+
+// This is a struct rather than an alias to avoid shadowing warnings in gcc.
+struct data : basic_data<> {};
+
+#ifdef FMT_BUILTIN_CLZLL
+// Returns the number of decimal digits in n. Leading zeros are not counted
+// except for n == 0 in which case count_digits returns 1.
+inline int count_digits(uint64_t n) {
+  // Based on http://graphics.stanford.edu/~seander/bithacks.html#IntegerLog10
+  // and the benchmark https://github.com/localvoid/cxx-benchmark-count-digits.
+  int t = (64 - FMT_BUILTIN_CLZLL(n | 1)) * 1233 >> 12;
+  return t - (n < data::zero_or_powers_of_10_64[t]) + 1;
+}
+#else
+// Fallback version of count_digits used when __builtin_clz is not available.
+inline int count_digits(uint64_t n) {
+  int count = 1;
+  for (;;) {
+    // Integer division is slow so do it for a group of four digits instead
+    // of for every digit. The idea comes from the talk by Alexandrescu
+    // "Three Optimization Tips for C++". See speed-test for a comparison.
+    if (n < 10) return count;
+    if (n < 100) return count + 1;
+    if (n < 1000) return count + 2;
+    if (n < 10000) return count + 3;
+    n /= 10000u;
+    count += 4;
+  }
+}
+#endif
+
+// Counts the number of digits in n. BITS = log2(radix).
+template <unsigned BITS, typename UInt> inline int count_digits(UInt n) {
+  int num_digits = 0;
+  do {
+    ++num_digits;
+  } while ((n >>= BITS) != 0);
+  return num_digits;
+}
+
+template <> int count_digits<4>(internal::fallback_uintptr n);
+
+#if FMT_HAS_CPP_ATTRIBUTE(always_inline)
+#  define FMT_ALWAYS_INLINE __attribute__((always_inline))
+#else
+#  define FMT_ALWAYS_INLINE
+#endif
+
+template <typename Handler>
+inline char* lg(uint32_t n, Handler h) FMT_ALWAYS_INLINE;
+
+// Computes g = floor(log10(n)) and calls h.on<g>(n);
+template <typename Handler> inline char* lg(uint32_t n, Handler h) {
+  return n < 100 ? n < 10 ? h.template on<0>(n) : h.template on<1>(n)
+                 : n < 1000000
+                       ? n < 10000 ? n < 1000 ? h.template on<2>(n)
+                                              : h.template on<3>(n)
+                                   : n < 100000 ? h.template on<4>(n)
+                                                : h.template on<5>(n)
+                       : n < 100000000 ? n < 10000000 ? h.template on<6>(n)
+                                                      : h.template on<7>(n)
+                                       : n < 1000000000 ? h.template on<8>(n)
+                                                        : h.template on<9>(n);
+}
+
+// An lg handler that formats a decimal number.
+// Usage: lg(n, decimal_formatter(buffer));
+class decimal_formatter {
+ private:
+  char* buffer_;
+
+  void write_pair(unsigned N, uint32_t index) {
+    std::memcpy(buffer_ + N, data::digits + index * 2, 2);
+  }
+
+ public:
+  explicit decimal_formatter(char* buf) : buffer_(buf) {}
+
+  template <unsigned N> char* on(uint32_t u) {
+    if (N == 0) {
+      *buffer_ = static_cast<char>(u) + '0';
+    } else if (N == 1) {
+      write_pair(0, u);
+    } else {
+      // The idea of using 4.32 fixed-point numbers is based on
+      // https://github.com/jeaiii/itoa
+      unsigned n = N - 1;
+      unsigned a = n / 5 * n * 53 / 16;
+      uint64_t t =
+          ((1ULL << (32 + a)) / data::zero_or_powers_of_10_32[n] + 1 - n / 9);
+      t = ((t * u) >> a) + n / 5 * 4;
+      write_pair(0, t >> 32);
+      for (unsigned i = 2; i < N; i += 2) {
+        t = 100ULL * static_cast<uint32_t>(t);
+        write_pair(i, t >> 32);
+      }
+      if (N % 2 == 0) {
+        buffer_[N] =
+            static_cast<char>((10ULL * static_cast<uint32_t>(t)) >> 32) + '0';
+      }
+    }
+    return buffer_ += N + 1;
+  }
+};
+
+#ifdef FMT_BUILTIN_CLZ
+// Optional version of count_digits for better performance on 32-bit platforms.
+inline int count_digits(uint32_t n) {
+  int t = (32 - FMT_BUILTIN_CLZ(n | 1)) * 1233 >> 12;
+  return t - (n < data::zero_or_powers_of_10_32[t]) + 1;
+}
+#endif
+
+template <typename Char> FMT_API Char thousands_sep_impl(locale_ref loc);
+template <typename Char> inline Char thousands_sep(locale_ref loc) {
+  return Char(thousands_sep_impl<char>(loc));
+}
+template <> inline wchar_t thousands_sep(locale_ref loc) {
+  return thousands_sep_impl<wchar_t>(loc);
+}
+
+template <typename Char> FMT_API Char decimal_point_impl(locale_ref loc);
+template <typename Char> inline Char decimal_point(locale_ref loc) {
+  return Char(decimal_point_impl<char>(loc));
+}
+template <> inline wchar_t decimal_point(locale_ref loc) {
+  return decimal_point_impl<wchar_t>(loc);
+}
+
+// Formats a decimal unsigned integer value writing into buffer.
+// add_thousands_sep is called after writing each char to add a thousands
+// separator if necessary.
+template <typename UInt, typename Char, typename F>
+inline Char* format_decimal(Char* buffer, UInt value, int num_digits,
+                            F add_thousands_sep) {
+  FMT_ASSERT(num_digits >= 0, "invalid digit count");
+  buffer += num_digits;
+  Char* end = buffer;
+  while (value >= 100) {
+    // Integer division is slow so do it for a group of two digits instead
+    // of for every digit. The idea comes from the talk by Alexandrescu
+    // "Three Optimization Tips for C++". See speed-test for a comparison.
+    unsigned index = static_cast<unsigned>((value % 100) * 2);
+    value /= 100;
+    *--buffer = static_cast<Char>(data::digits[index + 1]);
+    add_thousands_sep(buffer);
+    *--buffer = static_cast<Char>(data::digits[index]);
+    add_thousands_sep(buffer);
+  }
+  if (value < 10) {
+    *--buffer = static_cast<Char>('0' + value);
+    return end;
+  }
+  unsigned index = static_cast<unsigned>(value * 2);
+  *--buffer = static_cast<Char>(data::digits[index + 1]);
+  add_thousands_sep(buffer);
+  *--buffer = static_cast<Char>(data::digits[index]);
+  return end;
+}
+
+template <typename Char, typename UInt, typename Iterator, typename F>
+inline Iterator format_decimal(Iterator out, UInt value, int num_digits,
+                               F add_thousands_sep) {
+  FMT_ASSERT(num_digits >= 0, "invalid digit count");
+  // Buffer should be large enough to hold all digits (<= digits10 + 1).
+  enum { max_size = std::numeric_limits<UInt>::digits10 + 1 };
+  Char buffer[max_size + max_size / 3];
+  auto end = format_decimal(buffer, value, num_digits, add_thousands_sep);
+  return internal::copy_str<Char>(buffer, end, out);
+}
+
+template <typename Char, typename It, typename UInt>
+inline It format_decimal(It out, UInt value, int num_digits) {
+  return format_decimal<Char>(out, value, num_digits, [](Char*) {});
+}
+
+template <unsigned BASE_BITS, typename Char, typename UInt>
+inline Char* format_uint(Char* buffer, UInt value, int num_digits,
+                         bool upper = false) {
+  buffer += num_digits;
+  Char* end = buffer;
+  do {
+    const char* digits = upper ? "0123456789ABCDEF" : data::hex_digits;
+    unsigned digit = (value & ((1 << BASE_BITS) - 1));
+    *--buffer = static_cast<Char>(BASE_BITS < 4 ? static_cast<char>('0' + digit)
+                                                : digits[digit]);
+  } while ((value >>= BASE_BITS) != 0);
+  return end;
+}
+
+template <unsigned BASE_BITS, typename Char>
+Char* format_uint(Char* buffer, internal::fallback_uintptr n, int num_digits,
+                  bool = false) {
+  auto char_digits = std::numeric_limits<unsigned char>::digits / 4;
+  int start = (num_digits + char_digits - 1) / char_digits - 1;
+  if (int start_digits = num_digits % char_digits) {
+    unsigned value = n.value[start--];
+    buffer = format_uint<BASE_BITS>(buffer, value, start_digits);
+  }
+  for (; start >= 0; --start) {
+    unsigned value = n.value[start];
+    buffer += char_digits;
+    auto p = buffer;
+    for (int i = 0; i < char_digits; ++i) {
+      unsigned digit = (value & ((1 << BASE_BITS) - 1));
+      *--p = static_cast<Char>(data::hex_digits[digit]);
+      value >>= BASE_BITS;
+    }
+  }
+  return buffer;
+}
+
+template <unsigned BASE_BITS, typename Char, typename It, typename UInt>
+inline It format_uint(It out, UInt value, int num_digits, bool upper = false) {
+  // Buffer should be large enough to hold all digits (digits / BASE_BITS + 1).
+  char buffer[std::numeric_limits<UInt>::digits / BASE_BITS + 1];
+  format_uint<BASE_BITS>(buffer, value, num_digits, upper);
+  return internal::copy_str<Char>(buffer, buffer + num_digits, out);
+}
+
+#ifndef _WIN32
+#  define FMT_USE_WINDOWS_H 0
+#elif !defined(FMT_USE_WINDOWS_H)
+#  define FMT_USE_WINDOWS_H 1
+#endif
+
+// Define FMT_USE_WINDOWS_H to 0 to disable use of windows.h.
+// All the functionality that relies on it will be disabled too.
+#if FMT_USE_WINDOWS_H
+// A converter from UTF-8 to UTF-16.
+// It is only provided for Windows since other systems support UTF-8 natively.
+class utf8_to_utf16 {
+ private:
+  wmemory_buffer buffer_;
+
+ public:
+  FMT_API explicit utf8_to_utf16(string_view s);
+  operator wstring_view() const { return wstring_view(&buffer_[0], size()); }
+  size_t size() const { return buffer_.size() - 1; }
+  const wchar_t* c_str() const { return &buffer_[0]; }
+  std::wstring str() const { return std::wstring(&buffer_[0], size()); }
+};
+
+// A converter from UTF-16 to UTF-8.
+// It is only provided for Windows since other systems support UTF-8 natively.
+class utf16_to_utf8 {
+ private:
+  memory_buffer buffer_;
+
+ public:
+  utf16_to_utf8() {}
+  FMT_API explicit utf16_to_utf8(wstring_view s);
+  operator string_view() const { return string_view(&buffer_[0], size()); }
+  size_t size() const { return buffer_.size() - 1; }
+  const char* c_str() const { return &buffer_[0]; }
+  std::string str() const { return std::string(&buffer_[0], size()); }
+
+  // Performs conversion returning a system error code instead of
+  // throwing exception on conversion error. This method may still throw
+  // in case of memory allocation error.
+  FMT_API int convert(wstring_view s);
+};
+
+FMT_API void format_windows_error(fmt::internal::buffer<char>& out,
+                                  int error_code,
+                                  fmt::string_view message) FMT_NOEXCEPT;
+#endif
+
+template <typename T = void> struct null {};
+
+// Workaround an array initialization issue in gcc 4.8.
+template <typename Char> struct fill_t {
+ private:
+  Char data_[6];
+
+ public:
+  FMT_CONSTEXPR Char& operator[](size_t index) { return data_[index]; }
+  FMT_CONSTEXPR const Char& operator[](size_t index) const {
+    return data_[index];
+  }
+
+  static FMT_CONSTEXPR fill_t<Char> make() {
+    auto fill = fill_t<Char>();
+    fill[0] = Char(' ');
+    return fill;
+  }
+};
+}  // namespace internal
+
+// We cannot use enum classes as bit fields because of a gcc bug
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61414.
+namespace align {
+enum type { none, left, right, center, numeric };
+}
+using align_t = align::type;
+
+namespace sign {
+enum type { none, minus, plus, space };
+}
+using sign_t = sign::type;
+
+// Format specifiers for built-in and string types.
+template <typename Char> struct basic_format_specs {
+  int width;
+  int precision;
+  char type;
+  align_t align : 4;
+  sign_t sign : 3;
+  bool alt : 1;  // Alternate form ('#').
+  internal::fill_t<Char> fill;
+
+  constexpr basic_format_specs()
+      : width(0),
+        precision(-1),
+        type(0),
+        align(align::none),
+        sign(sign::none),
+        alt(false),
+        fill(internal::fill_t<Char>::make()) {}
+};
+
+using format_specs = basic_format_specs<char>;
+
+namespace internal {
+
+// Writes the exponent exp in the form "[+-]d{2,3}" to buffer.
+template <typename Char, typename It> It write_exponent(int exp, It it) {
+  FMT_ASSERT(-1000 < exp && exp < 1000, "exponent out of range");
+  if (exp < 0) {
+    *it++ = static_cast<Char>('-');
+    exp = -exp;
+  } else {
+    *it++ = static_cast<Char>('+');
+  }
+  if (exp >= 100) {
+    *it++ = static_cast<Char>(static_cast<char>('0' + exp / 100));
+    exp %= 100;
+  }
+  const char* d = data::digits + exp * 2;
+  *it++ = static_cast<Char>(d[0]);
+  *it++ = static_cast<Char>(d[1]);
+  return it;
+}
+
+struct gen_digits_params {
+  int num_digits;
+  bool fixed;
+  bool upper;
+  bool trailing_zeros;
+};
+
+// The number is given as v = digits * pow(10, exp).
+template <typename Char, typename It>
+It grisu_prettify(const char* digits, int size, int exp, It it,
+                  gen_digits_params params, Char decimal_point) {
+  // pow(10, full_exp - 1) <= v <= pow(10, full_exp).
+  int full_exp = size + exp;
+  if (!params.fixed) {
+    // Insert a decimal point after the first digit and add an exponent.
+    *it++ = static_cast<Char>(*digits);
+    if (size > 1) *it++ = decimal_point;
+    exp += size - 1;
+    it = copy_str<Char>(digits + 1, digits + size, it);
+    if (size < params.num_digits)
+      it = std::fill_n(it, params.num_digits - size, static_cast<Char>('0'));
+    *it++ = static_cast<Char>(params.upper ? 'E' : 'e');
+    return write_exponent<Char>(exp, it);
+  }
+  if (size <= full_exp) {
+    // 1234e7 -> 12340000000[.0+]
+    it = copy_str<Char>(digits, digits + size, it);
+    it = std::fill_n(it, full_exp - size, static_cast<Char>('0'));
+    int num_zeros = (std::max)(params.num_digits - full_exp, 1);
+    if (params.trailing_zeros) {
+      *it++ = decimal_point;
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+      if (num_zeros > 1000)
+        throw std::runtime_error("fuzz mode - avoiding excessive cpu use");
+#endif
+      it = std::fill_n(it, num_zeros, static_cast<Char>('0'));
+    }
+  } else if (full_exp > 0) {
+    // 1234e-2 -> 12.34[0+]
+    it = copy_str<Char>(digits, digits + full_exp, it);
+    if (!params.trailing_zeros) {
+      // Remove trailing zeros.
+      while (size > full_exp && digits[size - 1] == '0') --size;
+      if (size != full_exp) *it++ = decimal_point;
+      return copy_str<Char>(digits + full_exp, digits + size, it);
+    }
+    *it++ = decimal_point;
+    it = copy_str<Char>(digits + full_exp, digits + size, it);
+    if (params.num_digits > size) {
+      // Add trailing zeros.
+      int num_zeros = params.num_digits - size;
+      it = std::fill_n(it, num_zeros, static_cast<Char>('0'));
+    }
+  } else {
+    // 1234e-6 -> 0.001234
+    *it++ = static_cast<Char>('0');
+    int num_zeros = -full_exp;
+    if (params.num_digits >= 0 && params.num_digits < num_zeros)
+      num_zeros = params.num_digits;
+    if (!params.trailing_zeros)
+      while (size > 0 && digits[size - 1] == '0') --size;
+    if (num_zeros != 0 || size != 0) {
+      *it++ = decimal_point;
+      it = std::fill_n(it, num_zeros, static_cast<Char>('0'));
+      it = copy_str<Char>(digits, digits + size, it);
+    }
+  }
+  return it;
+}
+
+namespace grisu_options {
+enum { fixed = 1, grisu3 = 2 };
+}
+
+// Formats value using the Grisu algorithm:
+// https://www.cs.tufts.edu/~nr/cs257/archive/florian-loitsch/printf.pdf
+template <typename Double, FMT_ENABLE_IF(sizeof(Double) == sizeof(uint64_t))>
+FMT_API bool grisu_format(Double, buffer<char>&, int, unsigned, int&);
+template <typename Double, FMT_ENABLE_IF(sizeof(Double) != sizeof(uint64_t))>
+inline bool grisu_format(Double, buffer<char>&, int, unsigned, int&) {
+  return false;
+}
+
+struct sprintf_specs {
+  int precision;
+  char type;
+  bool alt : 1;
+
+  template <typename Char>
+  constexpr sprintf_specs(basic_format_specs<Char> specs)
+      : precision(specs.precision), type(specs.type), alt(specs.alt) {}
+
+  constexpr bool has_precision() const { return precision >= 0; }
+};
+
+template <typename Double>
+char* sprintf_format(Double, internal::buffer<char>&, sprintf_specs);
+
+template <typename Handler>
+FMT_CONSTEXPR void handle_int_type_spec(char spec, Handler&& handler) {
+  switch (spec) {
+  case 0:
+  case 'd':
+    handler.on_dec();
+    break;
+  case 'x':
+  case 'X':
+    handler.on_hex();
+    break;
+  case 'b':
+  case 'B':
+    handler.on_bin();
+    break;
+  case 'o':
+    handler.on_oct();
+    break;
+  case 'n':
+    handler.on_num();
+    break;
+  default:
+    handler.on_error();
+  }
+}
+
+template <typename Handler>
+FMT_CONSTEXPR void handle_float_type_spec(char spec, Handler&& handler) {
+  switch (spec) {
+  case 0:
+  case 'g':
+  case 'G':
+    handler.on_general();
+    break;
+  case 'e':
+  case 'E':
+    handler.on_exp();
+    break;
+  case 'f':
+  case 'F':
+    handler.on_fixed();
+    break;
+  case '%':
+    handler.on_percent();
+    break;
+  case 'a':
+  case 'A':
+    handler.on_hex();
+    break;
+  case 'n':
+    handler.on_num();
+    break;
+  default:
+    handler.on_error();
+    break;
+  }
+}
+
+template <typename Char, typename Handler>
+FMT_CONSTEXPR void handle_char_specs(const basic_format_specs<Char>* specs,
+                                     Handler&& handler) {
+  if (!specs) return handler.on_char();
+  if (specs->type && specs->type != 'c') return handler.on_int();
+  if (specs->align == align::numeric || specs->sign != sign::none || specs->alt)
+    handler.on_error("invalid format specifier for char");
+  handler.on_char();
+}
+
+template <typename Char, typename Handler>
+FMT_CONSTEXPR void handle_cstring_type_spec(Char spec, Handler&& handler) {
+  if (spec == 0 || spec == 's')
+    handler.on_string();
+  else if (spec == 'p')
+    handler.on_pointer();
+  else
+    handler.on_error("invalid type specifier");
+}
+
+template <typename Char, typename ErrorHandler>
+FMT_CONSTEXPR void check_string_type_spec(Char spec, ErrorHandler&& eh) {
+  if (spec != 0 && spec != 's') eh.on_error("invalid type specifier");
+}
+
+template <typename Char, typename ErrorHandler>
+FMT_CONSTEXPR void check_pointer_type_spec(Char spec, ErrorHandler&& eh) {
+  if (spec != 0 && spec != 'p') eh.on_error("invalid type specifier");
+}
+
+template <typename ErrorHandler> class int_type_checker : private ErrorHandler {
+ public:
+  FMT_CONSTEXPR explicit int_type_checker(ErrorHandler eh) : ErrorHandler(eh) {}
+
+  FMT_CONSTEXPR void on_dec() {}
+  FMT_CONSTEXPR void on_hex() {}
+  FMT_CONSTEXPR void on_bin() {}
+  FMT_CONSTEXPR void on_oct() {}
+  FMT_CONSTEXPR void on_num() {}
+
+  FMT_CONSTEXPR void on_error() {
+    ErrorHandler::on_error("invalid type specifier");
+  }
+};
+
+template <typename ErrorHandler>
+class float_type_checker : private ErrorHandler {
+ public:
+  FMT_CONSTEXPR explicit float_type_checker(ErrorHandler eh)
+      : ErrorHandler(eh) {}
+
+  FMT_CONSTEXPR void on_general() {}
+  FMT_CONSTEXPR void on_exp() {}
+  FMT_CONSTEXPR void on_fixed() {}
+  FMT_CONSTEXPR void on_percent() {}
+  FMT_CONSTEXPR void on_hex() {}
+  FMT_CONSTEXPR void on_num() {}
+
+  FMT_CONSTEXPR void on_error() {
+    ErrorHandler::on_error("invalid type specifier");
+  }
+};
+
+template <typename ErrorHandler>
+class char_specs_checker : public ErrorHandler {
+ private:
+  char type_;
+
+ public:
+  FMT_CONSTEXPR char_specs_checker(char type, ErrorHandler eh)
+      : ErrorHandler(eh), type_(type) {}
+
+  FMT_CONSTEXPR void on_int() {
+    handle_int_type_spec(type_, int_type_checker<ErrorHandler>(*this));
+  }
+  FMT_CONSTEXPR void on_char() {}
+};
+
+template <typename ErrorHandler>
+class cstring_type_checker : public ErrorHandler {
+ public:
+  FMT_CONSTEXPR explicit cstring_type_checker(ErrorHandler eh)
+      : ErrorHandler(eh) {}
+
+  FMT_CONSTEXPR void on_string() {}
+  FMT_CONSTEXPR void on_pointer() {}
+};
+
+template <typename Context>
+void arg_map<Context>::init(const basic_format_args<Context>& args) {
+  if (map_) return;
+  map_ = new entry[internal::to_unsigned(args.max_size())];
+  if (args.is_packed()) {
+    for (int i = 0;; ++i) {
+      internal::type arg_type = args.type(i);
+      if (arg_type == internal::none_type) return;
+      if (arg_type == internal::named_arg_type) push_back(args.values_[i]);
+    }
+  }
+  for (int i = 0, n = args.max_size(); i < n; ++i) {
+    auto type = args.args_[i].type_;
+    if (type == internal::named_arg_type) push_back(args.args_[i].value_);
+  }
+}
+
+// This template provides operations for formatting and writing data into a
+// character range.
+template <typename Range> class basic_writer {
+ public:
+  using char_type = typename Range::value_type;
+  using iterator = typename Range::iterator;
+  using format_specs = basic_format_specs<char_type>;
+
+ private:
+  iterator out_;  // Output iterator.
+  internal::locale_ref locale_;
+
+  // Attempts to reserve space for n extra characters in the output range.
+  // Returns a pointer to the reserved range or a reference to out_.
+  auto reserve(std::size_t n) -> decltype(internal::reserve(out_, n)) {
+    return internal::reserve(out_, n);
+  }
+
+  template <typename F> struct padded_int_writer {
+    size_t size_;
+    string_view prefix;
+    char_type fill;
+    std::size_t padding;
+    F f;
+
+    size_t size() const { return size_; }
+    size_t width() const { return size_; }
+
+    template <typename It> void operator()(It&& it) const {
+      if (prefix.size() != 0)
+        it = internal::copy_str<char_type>(prefix.begin(), prefix.end(), it);
+      it = std::fill_n(it, padding, fill);
+      f(it);
+    }
+  };
+
+  // Writes an integer in the format
+  //   <left-padding><prefix><numeric-padding><digits><right-padding>
+  // where <digits> are written by f(it).
+  template <typename F>
+  void write_int(int num_digits, string_view prefix, format_specs specs, F f) {
+    std::size_t size = prefix.size() + internal::to_unsigned(num_digits);
+    char_type fill = specs.fill[0];
+    std::size_t padding = 0;
+    if (specs.align == align::numeric) {
+      auto unsiged_width = internal::to_unsigned(specs.width);
+      if (unsiged_width > size) {
+        padding = unsiged_width - size;
+        size = unsiged_width;
+      }
+    } else if (specs.precision > num_digits) {
+      size = prefix.size() + internal::to_unsigned(specs.precision);
+      padding = internal::to_unsigned(specs.precision - num_digits);
+      fill = static_cast<char_type>('0');
+    }
+    if (specs.align == align::none) specs.align = align::right;
+    write_padded(specs, padded_int_writer<F>{size, prefix, fill, padding, f});
+  }
+
+  // Writes a decimal integer.
+  template <typename Int> void write_decimal(Int value) {
+    auto abs_value = static_cast<uint32_or_64_t<Int>>(value);
+    bool is_negative = internal::is_negative(value);
+    if (is_negative) abs_value = 0 - abs_value;
+    int num_digits = internal::count_digits(abs_value);
+    auto&& it =
+        reserve((is_negative ? 1 : 0) + static_cast<size_t>(num_digits));
+    if (is_negative) *it++ = static_cast<char_type>('-');
+    it = internal::format_decimal<char_type>(it, abs_value, num_digits);
+  }
+
+  // The handle_int_type_spec handler that writes an integer.
+  template <typename Int, typename Specs> struct int_writer {
+    using unsigned_type = uint32_or_64_t<Int>;
+
+    basic_writer<Range>& writer;
+    const Specs& specs;
+    unsigned_type abs_value;
+    char prefix[4];
+    unsigned prefix_size;
+
+    string_view get_prefix() const { return string_view(prefix, prefix_size); }
+
+    int_writer(basic_writer<Range>& w, Int value, const Specs& s)
+        : writer(w),
+          specs(s),
+          abs_value(static_cast<unsigned_type>(value)),
+          prefix_size(0) {
+      if (internal::is_negative(value)) {
+        prefix[0] = '-';
+        ++prefix_size;
+        abs_value = 0 - abs_value;
+      } else if (specs.sign != sign::none && specs.sign != sign::minus) {
+        prefix[0] = specs.sign == sign::plus ? '+' : ' ';
+        ++prefix_size;
+      }
+    }
+
+    struct dec_writer {
+      unsigned_type abs_value;
+      int num_digits;
+
+      template <typename It> void operator()(It&& it) const {
+        it = internal::format_decimal<char_type>(it, abs_value, num_digits);
+      }
+    };
+
+    void on_dec() {
+      int num_digits = internal::count_digits(abs_value);
+      writer.write_int(num_digits, get_prefix(), specs,
+                       dec_writer{abs_value, num_digits});
+    }
+
+    struct hex_writer {
+      int_writer& self;
+      int num_digits;
+
+      template <typename It> void operator()(It&& it) const {
+        it = internal::format_uint<4, char_type>(it, self.abs_value, num_digits,
+                                                 self.specs.type != 'x');
+      }
+    };
+
+    void on_hex() {
+      if (specs.alt) {
+        prefix[prefix_size++] = '0';
+        prefix[prefix_size++] = specs.type;
+      }
+      int num_digits = internal::count_digits<4>(abs_value);
+      writer.write_int(num_digits, get_prefix(), specs,
+                       hex_writer{*this, num_digits});
+    }
+
+    template <int BITS> struct bin_writer {
+      unsigned_type abs_value;
+      int num_digits;
+
+      template <typename It> void operator()(It&& it) const {
+        it = internal::format_uint<BITS, char_type>(it, abs_value, num_digits);
+      }
+    };
+
+    void on_bin() {
+      if (specs.alt) {
+        prefix[prefix_size++] = '0';
+        prefix[prefix_size++] = static_cast<char>(specs.type);
+      }
+      int num_digits = internal::count_digits<1>(abs_value);
+      writer.write_int(num_digits, get_prefix(), specs,
+                       bin_writer<1>{abs_value, num_digits});
+    }
+
+    void on_oct() {
+      int num_digits = internal::count_digits<3>(abs_value);
+      if (specs.alt && specs.precision <= num_digits) {
+        // Octal prefix '0' is counted as a digit, so only add it if precision
+        // is not greater than the number of digits.
+        prefix[prefix_size++] = '0';
+      }
+      writer.write_int(num_digits, get_prefix(), specs,
+                       bin_writer<3>{abs_value, num_digits});
+    }
+
+    enum { sep_size = 1 };
+
+    struct num_writer {
+      unsigned_type abs_value;
+      int size;
+      char_type sep;
+
+      template <typename It> void operator()(It&& it) const {
+        basic_string_view<char_type> s(&sep, sep_size);
+        // Index of a decimal digit with the least significant digit having
+        // index 0.
+        unsigned digit_index = 0;
+        it = internal::format_decimal<char_type>(
+            it, abs_value, size, [s, &digit_index](char_type*& buffer) {
+              if (++digit_index % 3 != 0) return;
+              buffer -= s.size();
+              std::uninitialized_copy(s.data(), s.data() + s.size(),
+                                      internal::make_checked(buffer, s.size()));
+            });
+      }
+    };
+
+    void on_num() {
+      char_type sep = internal::thousands_sep<char_type>(writer.locale_);
+      if (!sep) return on_dec();
+      int num_digits = internal::count_digits(abs_value);
+      int size = num_digits + sep_size * ((num_digits - 1) / 3);
+      writer.write_int(size, get_prefix(), specs,
+                       num_writer{abs_value, size, sep});
+    }
+
+    FMT_NORETURN void on_error() {
+      FMT_THROW(format_error("invalid type specifier"));
+    }
+  };
+
+  enum { inf_size = 3 };  // This is an enum to workaround a bug in MSVC.
+
+  struct inf_or_nan_writer {
+    char sign;
+    bool as_percentage;
+    const char* str;
+
+    size_t size() const {
+      return static_cast<std::size_t>(inf_size + (sign ? 1 : 0) +
+                                      (as_percentage ? 1 : 0));
+    }
+    size_t width() const { return size(); }
+
+    template <typename It> void operator()(It&& it) const {
+      if (sign) *it++ = static_cast<char_type>(sign);
+      it = internal::copy_str<char_type>(
+          str, str + static_cast<std::size_t>(inf_size), it);
+      if (as_percentage) *it++ = static_cast<char_type>('%');
+    }
+  };
+
+  struct double_writer {
+    char sign;
+    internal::buffer<char>& buffer;
+    char* decimal_point_pos;
+    char_type decimal_point;
+
+    size_t size() const { return buffer.size() + (sign ? 1 : 0); }
+    size_t width() const { return size(); }
+
+    template <typename It> void operator()(It&& it) {
+      if (sign) *it++ = static_cast<char_type>(sign);
+      auto begin = buffer.begin();
+      if (decimal_point_pos) {
+        it = internal::copy_str<char_type>(begin, decimal_point_pos, it);
+        *it++ = decimal_point;
+        begin = decimal_point_pos + 1;
+      }
+      it = internal::copy_str<char_type>(begin, buffer.end(), it);
+    }
+  };
+
+  class grisu_writer {
+   private:
+    internal::buffer<char>& digits_;
+    size_t size_;
+    char sign_;
+    int exp_;
+    internal::gen_digits_params params_;
+    char_type decimal_point_;
+
+   public:
+    grisu_writer(char sign, internal::buffer<char>& digits, int exp,
+                 const internal::gen_digits_params& params,
+                 char_type decimal_point)
+        : digits_(digits),
+          sign_(sign),
+          exp_(exp),
+          params_(params),
+          decimal_point_(decimal_point) {
+      int num_digits = static_cast<int>(digits.size());
+      int full_exp = num_digits + exp - 1;
+      int precision = params.num_digits > 0 ? params.num_digits : 11;
+      params_.fixed |= full_exp >= -4 && full_exp < precision;
+      auto it = internal::grisu_prettify<char>(
+          digits.data(), num_digits, exp, internal::counting_iterator<char>(),
+          params_, '.');
+      size_ = it.count();
+    }
+
+    size_t size() const { return size_ + (sign_ ? 1 : 0); }
+    size_t width() const { return size(); }
+
+    template <typename It> void operator()(It&& it) {
+      if (sign_) *it++ = static_cast<char_type>(sign_);
+      int num_digits = static_cast<int>(digits_.size());
+      it = internal::grisu_prettify<char_type>(digits_.data(), num_digits, exp_,
+                                               it, params_, decimal_point_);
+    }
+  };
+
+  template <typename Char> struct str_writer {
+    const Char* s;
+    size_t size_;
+
+    size_t size() const { return size_; }
+    size_t width() const {
+      return internal::count_code_points(basic_string_view<Char>(s, size_));
+    }
+
+    template <typename It> void operator()(It&& it) const {
+      it = internal::copy_str<char_type>(s, s + size_, it);
+    }
+  };
+
+  template <typename UIntPtr> struct pointer_writer {
+    UIntPtr value;
+    int num_digits;
+
+    size_t size() const { return to_unsigned(num_digits) + 2; }
+    size_t width() const { return size(); }
+
+    template <typename It> void operator()(It&& it) const {
+      *it++ = static_cast<char_type>('0');
+      *it++ = static_cast<char_type>('x');
+      it = internal::format_uint<4, char_type>(it, value, num_digits);
+    }
+  };
+
+ public:
+  /** Constructs a ``basic_writer`` object. */
+  explicit basic_writer(Range out,
+                        internal::locale_ref loc = internal::locale_ref())
+      : out_(out.begin()), locale_(loc) {}
+
+  iterator out() const { return out_; }
+
+  // Writes a value in the format
+  //   <left-padding><value><right-padding>
+  // where <value> is written by f(it).
+  template <typename F> void write_padded(const format_specs& specs, F&& f) {
+    // User-perceived width (in code points).
+    unsigned width = to_unsigned(specs.width);
+    size_t size = f.size();  // The number of code units.
+    size_t num_code_points = width != 0 ? f.width() : size;
+    if (width <= num_code_points) return f(reserve(size));
+    auto&& it = reserve(width + (size - num_code_points));
+    char_type fill = specs.fill[0];
+    std::size_t padding = width - num_code_points;
+    if (specs.align == align::right) {
+      it = std::fill_n(it, padding, fill);
+      f(it);
+    } else if (specs.align == align::center) {
+      std::size_t left_padding = padding / 2;
+      it = std::fill_n(it, left_padding, fill);
+      f(it);
+      it = std::fill_n(it, padding - left_padding, fill);
+    } else {
+      f(it);
+      it = std::fill_n(it, padding, fill);
+    }
+  }
+
+  void write(int value) { write_decimal(value); }
+  void write(long value) { write_decimal(value); }
+  void write(long long value) { write_decimal(value); }
+
+  void write(unsigned value) { write_decimal(value); }
+  void write(unsigned long value) { write_decimal(value); }
+  void write(unsigned long long value) { write_decimal(value); }
+
+  // Writes a formatted integer.
+  template <typename T, typename Spec>
+  void write_int(T value, const Spec& spec) {
+    internal::handle_int_type_spec(spec.type,
+                                   int_writer<T, Spec>(*this, value, spec));
+  }
+
+  void write(double value, const format_specs& specs = format_specs()) {
+    write_double(value, specs);
+  }
+
+  /**
+    \rst
+    Formats *value* using the general format for floating-point numbers
+    (``'g'``) and writes it to the buffer.
+    \endrst
+   */
+  void write(long double value, const format_specs& specs = format_specs()) {
+    write_double(value, specs);
+  }
+
+  // Formats a floating-point number (double or long double).
+  template <typename T, bool USE_GRISU = fmt::internal::use_grisu<T>()>
+  void write_double(T value, const format_specs& specs);
+
+  /** Writes a character to the buffer. */
+  void write(char value) {
+    auto&& it = reserve(1);
+    *it++ = value;
+  }
+
+  template <typename Char, FMT_ENABLE_IF(std::is_same<Char, char_type>::value)>
+  void write(Char value) {
+    auto&& it = reserve(1);
+    *it++ = value;
+  }
+
+  /**
+    \rst
+    Writes *value* to the buffer.
+    \endrst
+   */
+  void write(string_view value) {
+    auto&& it = reserve(value.size());
+    it = internal::copy_str<char_type>(value.begin(), value.end(), it);
+  }
+  void write(wstring_view value) {
+    static_assert(std::is_same<char_type, wchar_t>::value, "");
+    auto&& it = reserve(value.size());
+    it = std::copy(value.begin(), value.end(), it);
+  }
+
+  // Writes a formatted string.
+  template <typename Char>
+  void write(const Char* s, std::size_t size, const format_specs& specs) {
+    write_padded(specs, str_writer<Char>{s, size});
+  }
+
+  template <typename Char>
+  void write(basic_string_view<Char> s,
+             const format_specs& specs = format_specs()) {
+    const Char* data = s.data();
+    std::size_t size = s.size();
+    if (specs.precision >= 0 && internal::to_unsigned(specs.precision) < size)
+      size = internal::to_unsigned(specs.precision);
+    write(data, size, specs);
+  }
+
+  template <typename UIntPtr>
+  void write_pointer(UIntPtr value, const format_specs* specs) {
+    int num_digits = internal::count_digits<4>(value);
+    auto pw = pointer_writer<UIntPtr>{value, num_digits};
+    if (!specs) return pw(reserve(to_unsigned(num_digits) + 2));
+    format_specs specs_copy = *specs;
+    if (specs_copy.align == align::none) specs_copy.align = align::right;
+    write_padded(specs_copy, pw);
+  }
+};
+
+using writer = basic_writer<buffer_range<char>>;
+
+template <typename Range, typename ErrorHandler = internal::error_handler>
+class arg_formatter_base {
+ public:
+  using char_type = typename Range::value_type;
+  using iterator = typename Range::iterator;
+  using format_specs = basic_format_specs<char_type>;
+
+ private:
+  using writer_type = basic_writer<Range>;
+  writer_type writer_;
+  format_specs* specs_;
+
+  struct char_writer {
+    char_type value;
+
+    size_t size() const { return 1; }
+    size_t width() const { return 1; }
+
+    template <typename It> void operator()(It&& it) const { *it++ = value; }
+  };
+
+  void write_char(char_type value) {
+    if (specs_)
+      writer_.write_padded(*specs_, char_writer{value});
+    else
+      writer_.write(value);
+  }
+
+  void write_pointer(const void* p) {
+    writer_.write_pointer(internal::bit_cast<internal::uintptr_t>(p), specs_);
+  }
+
+ protected:
+  writer_type& writer() { return writer_; }
+  FMT_DEPRECATED format_specs* spec() { return specs_; }
+  format_specs* specs() { return specs_; }
+  iterator out() { return writer_.out(); }
+
+  void write(bool value) {
+    string_view sv(value ? "true" : "false");
+    specs_ ? writer_.write(sv, *specs_) : writer_.write(sv);
+  }
+
+  void write(const char_type* value) {
+    if (!value) {
+      FMT_THROW(format_error("string pointer is null"));
+    } else {
+      auto length = std::char_traits<char_type>::length(value);
+      basic_string_view<char_type> sv(value, length);
+      specs_ ? writer_.write(sv, *specs_) : writer_.write(sv);
+    }
+  }
+
+ public:
+  arg_formatter_base(Range r, format_specs* s, locale_ref loc)
+      : writer_(r, loc), specs_(s) {}
+
+  iterator operator()(monostate) {
+    FMT_ASSERT(false, "invalid argument type");
+    return out();
+  }
+
+  template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
+  iterator operator()(T value) {
+    if (specs_)
+      writer_.write_int(value, *specs_);
+    else
+      writer_.write(value);
+    return out();
+  }
+
+  iterator operator()(char_type value) {
+    internal::handle_char_specs(
+        specs_, char_spec_handler(*this, static_cast<char_type>(value)));
+    return out();
+  }
+
+  iterator operator()(bool value) {
+    if (specs_ && specs_->type) return (*this)(value ? 1 : 0);
+    write(value != 0);
+    return out();
+  }
+
+  template <typename T, FMT_ENABLE_IF(std::is_floating_point<T>::value)>
+  iterator operator()(T value) {
+    writer_.write_double(value, specs_ ? *specs_ : format_specs());
+    return out();
+  }
+
+  struct char_spec_handler : ErrorHandler {
+    arg_formatter_base& formatter;
+    char_type value;
+
+    char_spec_handler(arg_formatter_base& f, char_type val)
+        : formatter(f), value(val) {}
+
+    void on_int() {
+      if (formatter.specs_)
+        formatter.writer_.write_int(value, *formatter.specs_);
+      else
+        formatter.writer_.write(value);
+    }
+    void on_char() { formatter.write_char(value); }
+  };
+
+  struct cstring_spec_handler : internal::error_handler {
+    arg_formatter_base& formatter;
+    const char_type* value;
+
+    cstring_spec_handler(arg_formatter_base& f, const char_type* val)
+        : formatter(f), value(val) {}
+
+    void on_string() { formatter.write(value); }
+    void on_pointer() { formatter.write_pointer(value); }
+  };
+
+  iterator operator()(const char_type* value) {
+    if (!specs_) return write(value), out();
+    internal::handle_cstring_type_spec(specs_->type,
+                                       cstring_spec_handler(*this, value));
+    return out();
+  }
+
+  iterator operator()(basic_string_view<char_type> value) {
+    if (specs_) {
+      internal::check_string_type_spec(specs_->type, internal::error_handler());
+      writer_.write(value, *specs_);
+    } else {
+      writer_.write(value);
+    }
+    return out();
+  }
+
+  iterator operator()(const void* value) {
+    if (specs_)
+      check_pointer_type_spec(specs_->type, internal::error_handler());
+    write_pointer(value);
+    return out();
+  }
+};
+
+template <typename Char> FMT_CONSTEXPR bool is_name_start(Char c) {
+  return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || '_' == c;
+}
+
+// Parses the range [begin, end) as an unsigned integer. This function assumes
+// that the range is non-empty and the first character is a digit.
+template <typename Char, typename ErrorHandler>
+FMT_CONSTEXPR int parse_nonnegative_int(const Char*& begin, const Char* end,
+                                        ErrorHandler&& eh) {
+  assert(begin != end && '0' <= *begin && *begin <= '9');
+  if (*begin == '0') {
+    ++begin;
+    return 0;
+  }
+  unsigned value = 0;
+  // Convert to unsigned to prevent a warning.
+  constexpr unsigned max_int = (std::numeric_limits<int>::max)();
+  unsigned big = max_int / 10;
+  do {
+    // Check for overflow.
+    if (value > big) {
+      value = max_int + 1;
+      break;
+    }
+    value = value * 10 + unsigned(*begin - '0');
+    ++begin;
+  } while (begin != end && '0' <= *begin && *begin <= '9');
+  if (value > max_int) eh.on_error("number is too big");
+  return static_cast<int>(value);
+}
+
+template <typename Context> class custom_formatter {
+ private:
+  using char_type = typename Context::char_type;
+
+  basic_parse_context<char_type>& parse_ctx_;
+  Context& ctx_;
+
+ public:
+  explicit custom_formatter(basic_parse_context<char_type>& parse_ctx,
+                            Context& ctx)
+      : parse_ctx_(parse_ctx), ctx_(ctx) {}
+
+  bool operator()(typename basic_format_arg<Context>::handle h) const {
+    h.format(parse_ctx_, ctx_);
+    return true;
+  }
+
+  template <typename T> bool operator()(T) const { return false; }
+};
+
+template <typename T>
+using is_integer =
+    bool_constant<std::is_integral<T>::value && !std::is_same<T, bool>::value &&
+                  !std::is_same<T, char>::value &&
+                  !std::is_same<T, wchar_t>::value>;
+
+template <typename ErrorHandler> class width_checker {
+ public:
+  explicit FMT_CONSTEXPR width_checker(ErrorHandler& eh) : handler_(eh) {}
+
+  template <typename T, FMT_ENABLE_IF(is_integer<T>::value)>
+  FMT_CONSTEXPR unsigned long long operator()(T value) {
+    if (is_negative(value)) handler_.on_error("negative width");
+    return static_cast<unsigned long long>(value);
+  }
+
+  template <typename T, FMT_ENABLE_IF(!is_integer<T>::value)>
+  FMT_CONSTEXPR unsigned long long operator()(T) {
+    handler_.on_error("width is not integer");
+    return 0;
+  }
+
+ private:
+  ErrorHandler& handler_;
+};
+
+template <typename ErrorHandler> class precision_checker {
+ public:
+  explicit FMT_CONSTEXPR precision_checker(ErrorHandler& eh) : handler_(eh) {}
+
+  template <typename T, FMT_ENABLE_IF(is_integer<T>::value)>
+  FMT_CONSTEXPR unsigned long long operator()(T value) {
+    if (is_negative(value)) handler_.on_error("negative precision");
+    return static_cast<unsigned long long>(value);
+  }
+
+  template <typename T, FMT_ENABLE_IF(!is_integer<T>::value)>
+  FMT_CONSTEXPR unsigned long long operator()(T) {
+    handler_.on_error("precision is not integer");
+    return 0;
+  }
+
+ private:
+  ErrorHandler& handler_;
+};
+
+// A format specifier handler that sets fields in basic_format_specs.
+template <typename Char> class specs_setter {
+ public:
+  explicit FMT_CONSTEXPR specs_setter(basic_format_specs<Char>& specs)
+      : specs_(specs) {}
+
+  FMT_CONSTEXPR specs_setter(const specs_setter& other)
+      : specs_(other.specs_) {}
+
+  FMT_CONSTEXPR void on_align(align_t align) { specs_.align = align; }
+  FMT_CONSTEXPR void on_fill(Char fill) { specs_.fill[0] = fill; }
+  FMT_CONSTEXPR void on_plus() { specs_.sign = sign::plus; }
+  FMT_CONSTEXPR void on_minus() { specs_.sign = sign::minus; }
+  FMT_CONSTEXPR void on_space() { specs_.sign = sign::space; }
+  FMT_CONSTEXPR void on_hash() { specs_.alt = true; }
+
+  FMT_CONSTEXPR void on_zero() {
+    specs_.align = align::numeric;
+    specs_.fill[0] = Char('0');
+  }
+
+  FMT_CONSTEXPR void on_width(int width) { specs_.width = width; }
+  FMT_CONSTEXPR void on_precision(int precision) {
+    specs_.precision = precision;
+  }
+  FMT_CONSTEXPR void end_precision() {}
+
+  FMT_CONSTEXPR void on_type(Char type) {
+    specs_.type = static_cast<char>(type);
+  }
+
+ protected:
+  basic_format_specs<Char>& specs_;
+};
+
+template <typename ErrorHandler> class numeric_specs_checker {
+ public:
+  FMT_CONSTEXPR numeric_specs_checker(ErrorHandler& eh, internal::type arg_type)
+      : error_handler_(eh), arg_type_(arg_type) {}
+
+  FMT_CONSTEXPR void require_numeric_argument() {
+    if (!is_arithmetic(arg_type_))
+      error_handler_.on_error("format specifier requires numeric argument");
+  }
+
+  FMT_CONSTEXPR void check_sign() {
+    require_numeric_argument();
+    if (is_integral(arg_type_) && arg_type_ != int_type &&
+        arg_type_ != long_long_type && arg_type_ != internal::char_type) {
+      error_handler_.on_error("format specifier requires signed argument");
+    }
+  }
+
+  FMT_CONSTEXPR void check_precision() {
+    if (is_integral(arg_type_) || arg_type_ == internal::pointer_type)
+      error_handler_.on_error("precision not allowed for this argument type");
+  }
+
+ private:
+  ErrorHandler& error_handler_;
+  internal::type arg_type_;
+};
+
+// A format specifier handler that checks if specifiers are consistent with the
+// argument type.
+template <typename Handler> class specs_checker : public Handler {
+ public:
+  FMT_CONSTEXPR specs_checker(const Handler& handler, internal::type arg_type)
+      : Handler(handler), checker_(*this, arg_type) {}
+
+  FMT_CONSTEXPR specs_checker(const specs_checker& other)
+      : Handler(other), checker_(*this, other.arg_type_) {}
+
+  FMT_CONSTEXPR void on_align(align_t align) {
+    if (align == align::numeric) checker_.require_numeric_argument();
+    Handler::on_align(align);
+  }
+
+  FMT_CONSTEXPR void on_plus() {
+    checker_.check_sign();
+    Handler::on_plus();
+  }
+
+  FMT_CONSTEXPR void on_minus() {
+    checker_.check_sign();
+    Handler::on_minus();
+  }
+
+  FMT_CONSTEXPR void on_space() {
+    checker_.check_sign();
+    Handler::on_space();
+  }
+
+  FMT_CONSTEXPR void on_hash() {
+    checker_.require_numeric_argument();
+    Handler::on_hash();
+  }
+
+  FMT_CONSTEXPR void on_zero() {
+    checker_.require_numeric_argument();
+    Handler::on_zero();
+  }
+
+  FMT_CONSTEXPR void end_precision() { checker_.check_precision(); }
+
+ private:
+  numeric_specs_checker<Handler> checker_;
+};
+
+template <template <typename> class Handler, typename T, typename FormatArg,
+          typename ErrorHandler>
+FMT_CONSTEXPR void set_dynamic_spec(T& value, FormatArg arg, ErrorHandler eh) {
+  unsigned long long big_value =
+      visit_format_arg(Handler<ErrorHandler>(eh), arg);
+  if (big_value > to_unsigned((std::numeric_limits<int>::max)()))
+    eh.on_error("number is too big");
+  value = static_cast<T>(big_value);
+}
+
+struct auto_id {};
+
+template <typename Context>
+FMT_CONSTEXPR typename Context::format_arg get_arg(Context& ctx, int id) {
+  auto arg = ctx.arg(id);
+  if (!arg) ctx.on_error("argument index out of range");
+  return arg;
+}
+
+// The standard format specifier handler with checking.
+template <typename ParseContext, typename Context>
+class specs_handler : public specs_setter<typename Context::char_type> {
+ public:
+  using char_type = typename Context::char_type;
+
+  FMT_CONSTEXPR specs_handler(basic_format_specs<char_type>& specs,
+                              ParseContext& parse_ctx, Context& ctx)
+      : specs_setter<char_type>(specs),
+        parse_context_(parse_ctx),
+        context_(ctx) {}
+
+  template <typename Id> FMT_CONSTEXPR void on_dynamic_width(Id arg_id) {
+    set_dynamic_spec<width_checker>(this->specs_.width, get_arg(arg_id),
+                                    context_.error_handler());
+  }
+
+  template <typename Id> FMT_CONSTEXPR void on_dynamic_precision(Id arg_id) {
+    set_dynamic_spec<precision_checker>(this->specs_.precision, get_arg(arg_id),
+                                        context_.error_handler());
+  }
+
+  void on_error(const char* message) { context_.on_error(message); }
+
+ private:
+  // This is only needed for compatibility with gcc 4.4.
+  using format_arg = typename Context::format_arg;
+
+  FMT_CONSTEXPR format_arg get_arg(auto_id) {
+    return internal::get_arg(context_, parse_context_.next_arg_id());
+  }
+
+  FMT_CONSTEXPR format_arg get_arg(int arg_id) {
+    parse_context_.check_arg_id(arg_id);
+    return internal::get_arg(context_, arg_id);
+  }
+
+  FMT_CONSTEXPR format_arg get_arg(basic_string_view<char_type> arg_id) {
+    parse_context_.check_arg_id(arg_id);
+    return context_.arg(arg_id);
+  }
+
+  ParseContext& parse_context_;
+  Context& context_;
+};
+
+struct string_view_metadata {
+  FMT_CONSTEXPR string_view_metadata() : offset_(0u), size_(0u) {}
+  template <typename Char>
+  FMT_CONSTEXPR string_view_metadata(basic_string_view<Char> primary_string,
+                                     basic_string_view<Char> view)
+      : offset_(to_unsigned(view.data() - primary_string.data())),
+        size_(view.size()) {}
+  FMT_CONSTEXPR string_view_metadata(std::size_t offset, std::size_t size)
+      : offset_(offset), size_(size) {}
+  template <typename Char>
+  FMT_CONSTEXPR basic_string_view<Char> to_view(const Char* str) const {
+    return {str + offset_, size_};
+  }
+
+  std::size_t offset_;
+  std::size_t size_;
+};
+
+enum class arg_id_kind { none, index, name };
+
+// An argument reference.
+template <typename Char> struct arg_ref {
+  FMT_CONSTEXPR arg_ref() : kind(arg_id_kind::none), val() {}
+  FMT_CONSTEXPR explicit arg_ref(int index)
+      : kind(arg_id_kind::index), val(index) {}
+  FMT_CONSTEXPR explicit arg_ref(string_view_metadata name)
+      : kind(arg_id_kind::name), val(name) {}
+
+  FMT_CONSTEXPR arg_ref& operator=(int idx) {
+    kind = arg_id_kind::index;
+    val.index = idx;
+    return *this;
+  }
+
+  arg_id_kind kind;
+  union value {
+    FMT_CONSTEXPR value() : index(0u) {}
+    FMT_CONSTEXPR value(int id) : index(id) {}
+    FMT_CONSTEXPR value(string_view_metadata n) : name(n) {}
+
+    int index;
+    string_view_metadata name;
+  } val;
+};
+
+// Format specifiers with width and precision resolved at formatting rather
+// than parsing time to allow re-using the same parsed specifiers with
+// different sets of arguments (precompilation of format strings).
+template <typename Char>
+struct dynamic_format_specs : basic_format_specs<Char> {
+  arg_ref<Char> width_ref;
+  arg_ref<Char> precision_ref;
+};
+
+// Format spec handler that saves references to arguments representing dynamic
+// width and precision to be resolved at formatting time.
+template <typename ParseContext>
+class dynamic_specs_handler
+    : public specs_setter<typename ParseContext::char_type> {
+ public:
+  using char_type = typename ParseContext::char_type;
+
+  FMT_CONSTEXPR dynamic_specs_handler(dynamic_format_specs<char_type>& specs,
+                                      ParseContext& ctx)
+      : specs_setter<char_type>(specs), specs_(specs), context_(ctx) {}
+
+  FMT_CONSTEXPR dynamic_specs_handler(const dynamic_specs_handler& other)
+      : specs_setter<char_type>(other),
+        specs_(other.specs_),
+        context_(other.context_) {}
+
+  template <typename Id> FMT_CONSTEXPR void on_dynamic_width(Id arg_id) {
+    specs_.width_ref = make_arg_ref(arg_id);
+  }
+
+  template <typename Id> FMT_CONSTEXPR void on_dynamic_precision(Id arg_id) {
+    specs_.precision_ref = make_arg_ref(arg_id);
+  }
+
+  FMT_CONSTEXPR void on_error(const char* message) {
+    context_.on_error(message);
+  }
+
+ private:
+  using arg_ref_type = arg_ref<char_type>;
+
+  FMT_CONSTEXPR arg_ref_type make_arg_ref(int arg_id) {
+    context_.check_arg_id(arg_id);
+    return arg_ref_type(arg_id);
+  }
+
+  FMT_CONSTEXPR arg_ref_type make_arg_ref(auto_id) {
+    return arg_ref_type(context_.next_arg_id());
+  }
+
+  FMT_CONSTEXPR arg_ref_type make_arg_ref(basic_string_view<char_type> arg_id) {
+    context_.check_arg_id(arg_id);
+    basic_string_view<char_type> format_str(
+        context_.begin(), to_unsigned(context_.end() - context_.begin()));
+    const auto id_metadata = string_view_metadata(format_str, arg_id);
+    return arg_ref_type(id_metadata);
+  }
+
+  dynamic_format_specs<char_type>& specs_;
+  ParseContext& context_;
+};
+
+template <typename Char, typename IDHandler>
+FMT_CONSTEXPR const Char* parse_arg_id(const Char* begin, const Char* end,
+                                       IDHandler&& handler) {
+  assert(begin != end);
+  Char c = *begin;
+  if (c == '}' || c == ':') return handler(), begin;
+  if (c >= '0' && c <= '9') {
+    int index = parse_nonnegative_int(begin, end, handler);
+    if (begin == end || (*begin != '}' && *begin != ':'))
+      return handler.on_error("invalid format string"), begin;
+    handler(index);
+    return begin;
+  }
+  if (!is_name_start(c))
+    return handler.on_error("invalid format string"), begin;
+  auto it = begin;
+  do {
+    ++it;
+  } while (it != end && (is_name_start(c = *it) || ('0' <= c && c <= '9')));
+  handler(basic_string_view<Char>(begin, to_unsigned(it - begin)));
+  return it;
+}
+
+// Adapts SpecHandler to IDHandler API for dynamic width.
+template <typename SpecHandler, typename Char> struct width_adapter {
+  explicit FMT_CONSTEXPR width_adapter(SpecHandler& h) : handler(h) {}
+
+  FMT_CONSTEXPR void operator()() { handler.on_dynamic_width(auto_id()); }
+  FMT_CONSTEXPR void operator()(int id) { handler.on_dynamic_width(id); }
+  FMT_CONSTEXPR void operator()(basic_string_view<Char> id) {
+    handler.on_dynamic_width(id);
+  }
+
+  FMT_CONSTEXPR void on_error(const char* message) {
+    handler.on_error(message);
+  }
+
+  SpecHandler& handler;
+};
+
+// Adapts SpecHandler to IDHandler API for dynamic precision.
+template <typename SpecHandler, typename Char> struct precision_adapter {
+  explicit FMT_CONSTEXPR precision_adapter(SpecHandler& h) : handler(h) {}
+
+  FMT_CONSTEXPR void operator()() { handler.on_dynamic_precision(auto_id()); }
+  FMT_CONSTEXPR void operator()(int id) { handler.on_dynamic_precision(id); }
+  FMT_CONSTEXPR void operator()(basic_string_view<Char> id) {
+    handler.on_dynamic_precision(id);
+  }
+
+  FMT_CONSTEXPR void on_error(const char* message) {
+    handler.on_error(message);
+  }
+
+  SpecHandler& handler;
+};
+
+// Parses fill and alignment.
+template <typename Char, typename Handler>
+FMT_CONSTEXPR const Char* parse_align(const Char* begin, const Char* end,
+                                      Handler&& handler) {
+  FMT_ASSERT(begin != end, "");
+  auto align = align::none;
+  int i = 0;
+  if (begin + 1 != end) ++i;
+  do {
+    switch (static_cast<char>(begin[i])) {
+    case '<':
+      align = align::left;
+      break;
+    case '>':
+      align = align::right;
+      break;
+    case '=':
+      align = align::numeric;
+      break;
+    case '^':
+      align = align::center;
+      break;
+    }
+    if (align != align::none) {
+      if (i > 0) {
+        auto c = *begin;
+        if (c == '{')
+          return handler.on_error("invalid fill character '{'"), begin;
+        begin += 2;
+        handler.on_fill(c);
+      } else
+        ++begin;
+      handler.on_align(align);
+      break;
+    }
+  } while (i-- > 0);
+  return begin;
+}
+
+template <typename Char, typename Handler>
+FMT_CONSTEXPR const Char* parse_width(const Char* begin, const Char* end,
+                                      Handler&& handler) {
+  FMT_ASSERT(begin != end, "");
+  if ('0' <= *begin && *begin <= '9') {
+    handler.on_width(parse_nonnegative_int(begin, end, handler));
+  } else if (*begin == '{') {
+    ++begin;
+    if (begin != end)
+      begin = parse_arg_id(begin, end, width_adapter<Handler, Char>(handler));
+    if (begin == end || *begin != '}')
+      return handler.on_error("invalid format string"), begin;
+    ++begin;
+  }
+  return begin;
+}
+
+template <typename Char, typename Handler>
+FMT_CONSTEXPR const Char* parse_precision(const Char* begin, const Char* end,
+                                          Handler&& handler) {
+  ++begin;
+  auto c = begin != end ? *begin : Char();
+  if ('0' <= c && c <= '9') {
+    handler.on_precision(parse_nonnegative_int(begin, end, handler));
+  } else if (c == '{') {
+    ++begin;
+    if (begin != end) {
+      begin =
+          parse_arg_id(begin, end, precision_adapter<Handler, Char>(handler));
+    }
+    if (begin == end || *begin++ != '}')
+      return handler.on_error("invalid format string"), begin;
+  } else {
+    return handler.on_error("missing precision specifier"), begin;
+  }
+  handler.end_precision();
+  return begin;
+}
+
+// Parses standard format specifiers and sends notifications about parsed
+// components to handler.
+template <typename Char, typename SpecHandler>
+FMT_CONSTEXPR const Char* parse_format_specs(const Char* begin, const Char* end,
+                                             SpecHandler&& handler) {
+  if (begin == end || *begin == '}') return begin;
+
+  begin = parse_align(begin, end, handler);
+  if (begin == end) return begin;
+
+  // Parse sign.
+  switch (static_cast<char>(*begin)) {
+  case '+':
+    handler.on_plus();
+    ++begin;
+    break;
+  case '-':
+    handler.on_minus();
+    ++begin;
+    break;
+  case ' ':
+    handler.on_space();
+    ++begin;
+    break;
+  }
+  if (begin == end) return begin;
+
+  if (*begin == '#') {
+    handler.on_hash();
+    if (++begin == end) return begin;
+  }
+
+  // Parse zero flag.
+  if (*begin == '0') {
+    handler.on_zero();
+    if (++begin == end) return begin;
+  }
+
+  begin = parse_width(begin, end, handler);
+  if (begin == end) return begin;
+
+  // Parse precision.
+  if (*begin == '.') {
+    begin = parse_precision(begin, end, handler);
+  }
+
+  // Parse type.
+  if (begin != end && *begin != '}') handler.on_type(*begin++);
+  return begin;
+}
+
+// Return the result via the out param to workaround gcc bug 77539.
+template <bool IS_CONSTEXPR, typename T, typename Ptr = const T*>
+FMT_CONSTEXPR bool find(Ptr first, Ptr last, T value, Ptr& out) {
+  for (out = first; out != last; ++out) {
+    if (*out == value) return true;
+  }
+  return false;
+}
+
+template <>
+inline bool find<false, char>(const char* first, const char* last, char value,
+                              const char*& out) {
+  out = static_cast<const char*>(
+      std::memchr(first, value, internal::to_unsigned(last - first)));
+  return out != nullptr;
+}
+
+template <typename Handler, typename Char> struct id_adapter {
+  FMT_CONSTEXPR void operator()() { handler.on_arg_id(); }
+  FMT_CONSTEXPR void operator()(int id) { handler.on_arg_id(id); }
+  FMT_CONSTEXPR void operator()(basic_string_view<Char> id) {
+    handler.on_arg_id(id);
+  }
+  FMT_CONSTEXPR void on_error(const char* message) {
+    handler.on_error(message);
+  }
+  Handler& handler;
+};
+
+template <bool IS_CONSTEXPR, typename Char, typename Handler>
+FMT_CONSTEXPR void parse_format_string(basic_string_view<Char> format_str,
+                                       Handler&& handler) {
+  struct writer {
+    FMT_CONSTEXPR void operator()(const Char* begin, const Char* end) {
+      if (begin == end) return;
+      for (;;) {
+        const Char* p = nullptr;
+        if (!find<IS_CONSTEXPR>(begin, end, '}', p))
+          return handler_.on_text(begin, end);
+        ++p;
+        if (p == end || *p != '}')
+          return handler_.on_error("unmatched '}' in format string");
+        handler_.on_text(begin, p);
+        begin = p + 1;
+      }
+    }
+    Handler& handler_;
+  } write{handler};
+  auto begin = format_str.data();
+  auto end = begin + format_str.size();
+  while (begin != end) {
+    // Doing two passes with memchr (one for '{' and another for '}') is up to
+    // 2.5x faster than the naive one-pass implementation on big format strings.
+    const Char* p = begin;
+    if (*begin != '{' && !find<IS_CONSTEXPR>(begin, end, '{', p))
+      return write(begin, end);
+    write(begin, p);
+    ++p;
+    if (p == end) return handler.on_error("invalid format string");
+    if (static_cast<char>(*p) == '}') {
+      handler.on_arg_id();
+      handler.on_replacement_field(p);
+    } else if (*p == '{') {
+      handler.on_text(p, p + 1);
+    } else {
+      p = parse_arg_id(p, end, id_adapter<Handler, Char>{handler});
+      Char c = p != end ? *p : Char();
+      if (c == '}') {
+        handler.on_replacement_field(p);
+      } else if (c == ':') {
+        p = handler.on_format_specs(p + 1, end);
+        if (p == end || *p != '}')
+          return handler.on_error("unknown format specifier");
+      } else {
+        return handler.on_error("missing '}' in format string");
+      }
+    }
+    begin = p + 1;
+  }
+}
+
+template <typename T, typename ParseContext>
+FMT_CONSTEXPR const typename ParseContext::char_type* parse_format_specs(
+    ParseContext& ctx) {
+  using char_type = typename ParseContext::char_type;
+  using context = buffer_context<char_type>;
+  using mapped_type =
+      conditional_t<internal::mapped_type_constant<T, context>::value !=
+                        internal::custom_type,
+                    decltype(arg_mapper<context>().map(std::declval<T>())), T>;
+  conditional_t<has_formatter<mapped_type, context>::value,
+                formatter<mapped_type, char_type>,
+                internal::fallback_formatter<T, char_type>>
+      f;
+  return f.parse(ctx);
+}
+
+template <typename Char, typename ErrorHandler, typename... Args>
+class format_string_checker {
+ public:
+  explicit FMT_CONSTEXPR format_string_checker(
+      basic_string_view<Char> format_str, ErrorHandler eh)
+      : arg_id_((std::numeric_limits<unsigned>::max)()),
+        context_(format_str, eh),
+        parse_funcs_{&parse_format_specs<Args, parse_context_type>...} {}
+
+  FMT_CONSTEXPR void on_text(const Char*, const Char*) {}
+
+  FMT_CONSTEXPR void on_arg_id() {
+    arg_id_ = context_.next_arg_id();
+    check_arg_id();
+  }
+  FMT_CONSTEXPR void on_arg_id(int id) {
+    arg_id_ = id;
+    context_.check_arg_id(id);
+    check_arg_id();
+  }
+  FMT_CONSTEXPR void on_arg_id(basic_string_view<Char>) {
+    on_error("compile-time checks don't support named arguments");
+  }
+
+  FMT_CONSTEXPR void on_replacement_field(const Char*) {}
+
+  FMT_CONSTEXPR const Char* on_format_specs(const Char* begin, const Char*) {
+    advance_to(context_, begin);
+    return arg_id_ < num_args ? parse_funcs_[arg_id_](context_) : begin;
+  }
+
+  FMT_CONSTEXPR void on_error(const char* message) {
+    context_.on_error(message);
+  }
+
+ private:
+  using parse_context_type = basic_parse_context<Char, ErrorHandler>;
+  enum { num_args = sizeof...(Args) };
+
+  FMT_CONSTEXPR void check_arg_id() {
+    if (arg_id_ >= num_args) context_.on_error("argument index out of range");
+  }
+
+  // Format specifier parsing function.
+  using parse_func = const Char* (*)(parse_context_type&);
+
+  unsigned arg_id_;
+  parse_context_type context_;
+  parse_func parse_funcs_[num_args > 0 ? num_args : 1];
+};
+
+template <typename Char, typename ErrorHandler, typename... Args>
+FMT_CONSTEXPR bool do_check_format_string(basic_string_view<Char> s,
+                                          ErrorHandler eh = ErrorHandler()) {
+  format_string_checker<Char, ErrorHandler, Args...> checker(s, eh);
+  parse_format_string<true>(s, checker);
+  return true;
+}
+
+template <typename... Args, typename S,
+          enable_if_t<(is_compile_string<S>::value), int>>
+void check_format_string(S format_str) {
+  FMT_CONSTEXPR_DECL bool invalid_format =
+      internal::do_check_format_string<typename S::char_type,
+                                       internal::error_handler, Args...>(
+          to_string_view(format_str));
+  (void)invalid_format;
+}
+
+template <template <typename> class Handler, typename Spec, typename Context>
+void handle_dynamic_spec(Spec& value, arg_ref<typename Context::char_type> ref,
+                         Context& ctx,
+                         const typename Context::char_type* format_str) {
+  switch (ref.kind) {
+  case arg_id_kind::none:
+    break;
+  case arg_id_kind::index:
+    internal::set_dynamic_spec<Handler>(value, ctx.arg(ref.val.index),
+                                        ctx.error_handler());
+    break;
+  case arg_id_kind::name: {
+    const auto arg_id = ref.val.name.to_view(format_str);
+    internal::set_dynamic_spec<Handler>(value, ctx.arg(arg_id),
+                                        ctx.error_handler());
+    break;
+  }
+  }
+}
+}  // namespace internal
+
+template <typename Range>
+using basic_writer FMT_DEPRECATED = internal::basic_writer<Range>;
+using writer FMT_DEPRECATED = internal::writer;
+using wwriter FMT_DEPRECATED =
+    internal::basic_writer<internal::buffer_range<wchar_t>>;
+
+/** The default argument formatter. */
+template <typename Range>
+class arg_formatter : public internal::arg_formatter_base<Range> {
+ private:
+  using char_type = typename Range::value_type;
+  using base = internal::arg_formatter_base<Range>;
+  using context_type = basic_format_context<typename base::iterator, char_type>;
+
+  context_type& ctx_;
+  basic_parse_context<char_type>* parse_ctx_;
+
+ public:
+  using range = Range;
+  using iterator = typename base::iterator;
+  using format_specs = typename base::format_specs;
+
+  /**
+    \rst
+    Constructs an argument formatter object.
+    *ctx* is a reference to the formatting context,
+    *specs* contains format specifier information for standard argument types.
+    \endrst
+   */
+  explicit arg_formatter(context_type& ctx,
+                         basic_parse_context<char_type>* parse_ctx = nullptr,
+                         format_specs* specs = nullptr)
+      : base(Range(ctx.out()), specs, ctx.locale()),
+        ctx_(ctx),
+        parse_ctx_(parse_ctx) {}
+
+  using base::operator();
+
+  /** Formats an argument of a user-defined type. */
+  iterator operator()(typename basic_format_arg<context_type>::handle handle) {
+    handle.format(*parse_ctx_, ctx_);
+    return this->out();
+  }
+};
+
+/**
+ An error returned by an operating system or a language runtime,
+ for example a file opening error.
+*/
+class FMT_API system_error : public std::runtime_error {
+ private:
+  void init(int err_code, string_view format_str, format_args args);
+
+ protected:
+  int error_code_;
+
+  system_error() : std::runtime_error(""), error_code_(0) {}
+
+ public:
+  /**
+   \rst
+   Constructs a :class:`fmt::system_error` object with a description
+   formatted with `fmt::format_system_error`. *message* and additional
+   arguments passed into the constructor are formatted similarly to
+   `fmt::format`.
+
+   **Example**::
+
+     // This throws a system_error with the description
+     //   cannot open file 'madeup': No such file or directory
+     // or similar (system message may vary).
+     const char *filename = "madeup";
+     std::FILE *file = std::fopen(filename, "r");
+     if (!file)
+       throw fmt::system_error(errno, "cannot open file '{}'", filename);
+   \endrst
+  */
+  template <typename... Args>
+  system_error(int error_code, string_view message, const Args&... args)
+      : std::runtime_error("") {
+    init(error_code, message, make_format_args(args...));
+  }
+  ~system_error() FMT_NOEXCEPT;
+
+  int error_code() const { return error_code_; }
+};
+
+/**
+  \rst
+  Formats an error returned by an operating system or a language runtime,
+  for example a file opening error, and writes it to *out* in the following
+  form:
+
+  .. parsed-literal::
+     *<message>*: *<system-message>*
+
+  where *<message>* is the passed message and *<system-message>* is
+  the system message corresponding to the error code.
+  *error_code* is a system error code as given by ``errno``.
+  If *error_code* is not a valid error code such as -1, the system message
+  may look like "Unknown error -1" and is platform-dependent.
+  \endrst
+ */
+FMT_API void format_system_error(internal::buffer<char>& out, int error_code,
+                                 fmt::string_view message) FMT_NOEXCEPT;
+
+struct float_spec_handler {
+  char type;
+  bool upper;
+  bool fixed;
+  bool as_percentage;
+  bool use_locale;
+
+  explicit float_spec_handler(char t)
+      : type(t),
+        upper(false),
+        fixed(false),
+        as_percentage(false),
+        use_locale(false) {}
+
+  void on_general() {
+    if (type == 'G') upper = true;
+  }
+
+  void on_exp() {
+    if (type == 'E') upper = true;
+  }
+
+  void on_fixed() {
+    fixed = true;
+    if (type == 'F') upper = true;
+  }
+
+  void on_percent() {
+    fixed = true;
+    as_percentage = true;
+  }
+
+  void on_hex() {
+    if (type == 'A') upper = true;
+  }
+
+  void on_num() { use_locale = true; }
+
+  FMT_NORETURN void on_error() {
+    FMT_THROW(format_error("invalid type specifier"));
+  }
+};
+
+template <typename Range>
+template <typename T, bool USE_GRISU>
+void internal::basic_writer<Range>::write_double(T value,
+                                                 const format_specs& specs) {
+  // Check type.
+  float_spec_handler handler(static_cast<char>(specs.type));
+  internal::handle_float_type_spec(handler.type, handler);
+
+  char sign = 0;
+  // Use signbit instead of value < 0 since the latter is always false for NaN.
+  if (std::signbit(value)) {
+    sign = '-';
+    value = -value;
+  } else if (specs.sign != sign::none) {
+    if (specs.sign == sign::plus)
+      sign = '+';
+    else if (specs.sign == sign::space)
+      sign = ' ';
+  }
+
+  if (!std::isfinite(value)) {
+    // Format infinity and NaN ourselves because sprintf's output is not
+    // consistent across platforms.
+    const char* str = std::isinf(value) ? (handler.upper ? "INF" : "inf")
+                                        : (handler.upper ? "NAN" : "nan");
+    return write_padded(specs,
+                        inf_or_nan_writer{sign, handler.as_percentage, str});
+  }
+
+  if (handler.as_percentage) value *= 100;
+
+  memory_buffer buffer;
+  int exp = 0;
+  int precision = specs.precision >= 0 || !specs.type ? specs.precision : 6;
+  unsigned options = handler.fixed ? internal::grisu_options::fixed : 0;
+  bool use_grisu = USE_GRISU &&
+                   (specs.type != 'a' && specs.type != 'A' &&
+                    specs.type != 'e' && specs.type != 'E') &&
+                   internal::grisu_format(static_cast<double>(value), buffer,
+                                          precision, options, exp);
+  char* decimal_point_pos = nullptr;
+  if (!use_grisu)
+    decimal_point_pos = internal::sprintf_format(value, buffer, specs);
+
+  if (handler.as_percentage) {
+    buffer.push_back('%');
+    --exp;  // Adjust decimal place position.
+  }
+  format_specs as = specs;
+  if (specs.align == align::numeric) {
+    if (sign) {
+      auto&& it = reserve(1);
+      *it++ = static_cast<char_type>(sign);
+      sign = 0;
+      if (as.width) --as.width;
+    }
+    as.align = align::right;
+  } else if (specs.align == align::none) {
+    as.align = align::right;
+  }
+  char_type decimal_point = handler.use_locale
+                                ? internal::decimal_point<char_type>(locale_)
+                                : static_cast<char_type>('.');
+  if (use_grisu) {
+    auto params = internal::gen_digits_params();
+    params.fixed = handler.fixed;
+    params.num_digits = precision;
+    params.trailing_zeros =
+        (precision != 0 && (handler.fixed || !specs.type)) || specs.alt;
+    write_padded(as, grisu_writer(sign, buffer, exp, params, decimal_point));
+  } else {
+    write_padded(as,
+                 double_writer{sign, buffer, decimal_point_pos, decimal_point});
+  }
+}
+
+// Reports a system error without throwing an exception.
+// Can be used to report errors from destructors.
+FMT_API void report_system_error(int error_code,
+                                 string_view message) FMT_NOEXCEPT;
+
+#if FMT_USE_WINDOWS_H
+
+/** A Windows error. */
+class windows_error : public system_error {
+ private:
+  FMT_API void init(int error_code, string_view format_str, format_args args);
+
+ public:
+  /**
+   \rst
+   Constructs a :class:`fmt::windows_error` object with the description
+   of the form
+
+   .. parsed-literal::
+     *<message>*: *<system-message>*
+
+   where *<message>* is the formatted message and *<system-message>* is the
+   system message corresponding to the error code.
+   *error_code* is a Windows error code as given by ``GetLastError``.
+   If *error_code* is not a valid error code such as -1, the system message
+   will look like "error -1".
+
+   **Example**::
+
+     // This throws a windows_error with the description
+     //   cannot open file 'madeup': The system cannot find the file specified.
+     // or similar (system message may vary).
+     const char *filename = "madeup";
+     LPOFSTRUCT of = LPOFSTRUCT();
+     HFILE file = OpenFile(filename, &of, OF_READ);
+     if (file == HFILE_ERROR) {
+       throw fmt::windows_error(GetLastError(),
+                                "cannot open file '{}'", filename);
+     }
+   \endrst
+  */
+  template <typename... Args>
+  windows_error(int error_code, string_view message, const Args&... args) {
+    init(error_code, message, make_format_args(args...));
+  }
+};
+
+// Reports a Windows error without throwing an exception.
+// Can be used to report errors from destructors.
+FMT_API void report_windows_error(int error_code,
+                                  string_view message) FMT_NOEXCEPT;
+
+#endif
+
+/** Fast integer formatter. */
+class format_int {
+ private:
+  // Buffer should be large enough to hold all digits (digits10 + 1),
+  // a sign and a null character.
+  enum { buffer_size = std::numeric_limits<unsigned long long>::digits10 + 3 };
+  mutable char buffer_[buffer_size];
+  char* str_;
+
+  // Formats value in reverse and returns a pointer to the beginning.
+  char* format_decimal(unsigned long long value) {
+    char* ptr = buffer_ + (buffer_size - 1);  // Parens to workaround MSVC bug.
+    while (value >= 100) {
+      // Integer division is slow so do it for a group of two digits instead
+      // of for every digit. The idea comes from the talk by Alexandrescu
+      // "Three Optimization Tips for C++". See speed-test for a comparison.
+      unsigned index = static_cast<unsigned>((value % 100) * 2);
+      value /= 100;
+      *--ptr = internal::data::digits[index + 1];
+      *--ptr = internal::data::digits[index];
+    }
+    if (value < 10) {
+      *--ptr = static_cast<char>('0' + value);
+      return ptr;
+    }
+    unsigned index = static_cast<unsigned>(value * 2);
+    *--ptr = internal::data::digits[index + 1];
+    *--ptr = internal::data::digits[index];
+    return ptr;
+  }
+
+  void format_signed(long long value) {
+    unsigned long long abs_value = static_cast<unsigned long long>(value);
+    bool negative = value < 0;
+    if (negative) abs_value = 0 - abs_value;
+    str_ = format_decimal(abs_value);
+    if (negative) *--str_ = '-';
+  }
+
+ public:
+  explicit format_int(int value) { format_signed(value); }
+  explicit format_int(long value) { format_signed(value); }
+  explicit format_int(long long value) { format_signed(value); }
+  explicit format_int(unsigned value) : str_(format_decimal(value)) {}
+  explicit format_int(unsigned long value) : str_(format_decimal(value)) {}
+  explicit format_int(unsigned long long value) : str_(format_decimal(value)) {}
+
+  /** Returns the number of characters written to the output buffer. */
+  std::size_t size() const {
+    return internal::to_unsigned(buffer_ - str_ + buffer_size - 1);
+  }
+
+  /**
+    Returns a pointer to the output buffer content. No terminating null
+    character is appended.
+   */
+  const char* data() const { return str_; }
+
+  /**
+    Returns a pointer to the output buffer content with terminating null
+    character appended.
+   */
+  const char* c_str() const {
+    buffer_[buffer_size - 1] = '\0';
+    return str_;
+  }
+
+  /**
+    \rst
+    Returns the content of the output buffer as an ``std::string``.
+    \endrst
+   */
+  std::string str() const { return std::string(str_, size()); }
+};
+
+// A formatter specialization for the core types corresponding to internal::type
+// constants.
+template <typename T, typename Char>
+struct formatter<T, Char,
+                 enable_if_t<internal::type_constant<T, Char>::value !=
+                             internal::custom_type>> {
+  FMT_CONSTEXPR formatter() : format_str_(nullptr) {}
+
+  // Parses format specifiers stopping either at the end of the range or at the
+  // terminating '}'.
+  template <typename ParseContext>
+  FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
+    format_str_ = ctx.begin();
+    using handler_type = internal::dynamic_specs_handler<ParseContext>;
+    auto type = internal::type_constant<T, Char>::value;
+    internal::specs_checker<handler_type> handler(handler_type(specs_, ctx),
+                                                  type);
+    auto it = parse_format_specs(ctx.begin(), ctx.end(), handler);
+    auto eh = ctx.error_handler();
+    switch (type) {
+    case internal::none_type:
+    case internal::named_arg_type:
+      FMT_ASSERT(false, "invalid argument type");
+      break;
+    case internal::int_type:
+    case internal::uint_type:
+    case internal::long_long_type:
+    case internal::ulong_long_type:
+    case internal::bool_type:
+      handle_int_type_spec(specs_.type,
+                           internal::int_type_checker<decltype(eh)>(eh));
+      break;
+    case internal::char_type:
+      handle_char_specs(
+          &specs_, internal::char_specs_checker<decltype(eh)>(specs_.type, eh));
+      break;
+    case internal::double_type:
+    case internal::long_double_type:
+      handle_float_type_spec(specs_.type,
+                             internal::float_type_checker<decltype(eh)>(eh));
+      break;
+    case internal::cstring_type:
+      internal::handle_cstring_type_spec(
+          specs_.type, internal::cstring_type_checker<decltype(eh)>(eh));
+      break;
+    case internal::string_type:
+      internal::check_string_type_spec(specs_.type, eh);
+      break;
+    case internal::pointer_type:
+      internal::check_pointer_type_spec(specs_.type, eh);
+      break;
+    case internal::custom_type:
+      // Custom format specifiers should be checked in parse functions of
+      // formatter specializations.
+      break;
+    }
+    return it;
+  }
+
+  template <typename FormatContext>
+  auto format(const T& val, FormatContext& ctx) -> decltype(ctx.out()) {
+    internal::handle_dynamic_spec<internal::width_checker>(
+        specs_.width, specs_.width_ref, ctx, format_str_);
+    internal::handle_dynamic_spec<internal::precision_checker>(
+        specs_.precision, specs_.precision_ref, ctx, format_str_);
+    using range_type =
+        internal::output_range<typename FormatContext::iterator,
+                               typename FormatContext::char_type>;
+    return visit_format_arg(arg_formatter<range_type>(ctx, nullptr, &specs_),
+                            internal::make_arg<FormatContext>(val));
+  }
+
+ private:
+  internal::dynamic_format_specs<Char> specs_;
+  const Char* format_str_;
+};
+
+#define FMT_FORMAT_AS(Type, Base)                                             \
+  template <typename Char>                                                    \
+  struct formatter<Type, Char> : formatter<Base, Char> {                      \
+    template <typename FormatContext>                                         \
+    auto format(const Type& val, FormatContext& ctx) -> decltype(ctx.out()) { \
+      return formatter<Base, Char>::format(val, ctx);                         \
+    }                                                                         \
+  }
+
+FMT_FORMAT_AS(signed char, int);
+FMT_FORMAT_AS(unsigned char, unsigned);
+FMT_FORMAT_AS(short, int);
+FMT_FORMAT_AS(unsigned short, unsigned);
+FMT_FORMAT_AS(long, long long);
+FMT_FORMAT_AS(unsigned long, unsigned long long);
+FMT_FORMAT_AS(float, double);
+FMT_FORMAT_AS(Char*, const Char*);
+FMT_FORMAT_AS(std::basic_string<Char>, basic_string_view<Char>);
+FMT_FORMAT_AS(std::nullptr_t, const void*);
+FMT_FORMAT_AS(internal::std_string_view<Char>, basic_string_view<Char>);
+
+template <typename Char>
+struct formatter<void*, Char> : formatter<const void*, Char> {
+  template <typename FormatContext>
+  auto format(void* val, FormatContext& ctx) -> decltype(ctx.out()) {
+    return formatter<const void*, Char>::format(val, ctx);
+  }
+};
+
+template <typename Char, size_t N>
+struct formatter<Char[N], Char> : formatter<basic_string_view<Char>, Char> {
+  template <typename FormatContext>
+  auto format(const Char* val, FormatContext& ctx) -> decltype(ctx.out()) {
+    return formatter<basic_string_view<Char>, Char>::format(val, ctx);
+  }
+};
+
+// A formatter for types known only at run time such as variant alternatives.
+//
+// Usage:
+//   using variant = std::variant<int, std::string>;
+//   template <>
+//   struct formatter<variant>: dynamic_formatter<> {
+//     void format(buffer &buf, const variant &v, context &ctx) {
+//       visit([&](const auto &val) { format(buf, val, ctx); }, v);
+//     }
+//   };
+template <typename Char = char> class dynamic_formatter {
+ private:
+  struct null_handler : internal::error_handler {
+    void on_align(align_t) {}
+    void on_plus() {}
+    void on_minus() {}
+    void on_space() {}
+    void on_hash() {}
+  };
+
+ public:
+  template <typename ParseContext>
+  auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
+    format_str_ = ctx.begin();
+    // Checks are deferred to formatting time when the argument type is known.
+    internal::dynamic_specs_handler<ParseContext> handler(specs_, ctx);
+    return parse_format_specs(ctx.begin(), ctx.end(), handler);
+  }
+
+  template <typename T, typename FormatContext>
+  auto format(const T& val, FormatContext& ctx) -> decltype(ctx.out()) {
+    handle_specs(ctx);
+    internal::specs_checker<null_handler> checker(
+        null_handler(),
+        internal::mapped_type_constant<T, FormatContext>::value);
+    checker.on_align(specs_.align);
+    switch (specs_.sign) {
+    case sign::none:
+      break;
+    case sign::plus:
+      checker.on_plus();
+      break;
+    case sign::minus:
+      checker.on_minus();
+      break;
+    case sign::space:
+      checker.on_space();
+      break;
+    }
+    if (specs_.alt) checker.on_hash();
+    if (specs_.precision >= 0) checker.end_precision();
+    using range = internal::output_range<typename FormatContext::iterator,
+                                         typename FormatContext::char_type>;
+    visit_format_arg(arg_formatter<range>(ctx, nullptr, &specs_),
+                     internal::make_arg<FormatContext>(val));
+    return ctx.out();
+  }
+
+ private:
+  template <typename Context> void handle_specs(Context& ctx) {
+    internal::handle_dynamic_spec<internal::width_checker>(
+        specs_.width, specs_.width_ref, ctx, format_str_);
+    internal::handle_dynamic_spec<internal::precision_checker>(
+        specs_.precision, specs_.precision_ref, ctx, format_str_);
+  }
+
+  internal::dynamic_format_specs<Char> specs_;
+  const Char* format_str_;
+};
+
+template <typename Range, typename Char>
+typename basic_format_context<Range, Char>::format_arg
+basic_format_context<Range, Char>::arg(basic_string_view<char_type> name) {
+  map_.init(args_);
+  format_arg arg = map_.find(name);
+  if (arg.type() == internal::none_type) this->on_error("argument not found");
+  return arg;
+}
+
+template <typename Char, typename ErrorHandler>
+FMT_CONSTEXPR void advance_to(basic_parse_context<Char, ErrorHandler>& ctx,
+                              const Char* p) {
+  ctx.advance_to(ctx.begin() + (p - &*ctx.begin()));
+}
+
+template <typename ArgFormatter, typename Char, typename Context>
+struct format_handler : internal::error_handler {
+  using range = typename ArgFormatter::range;
+
+  format_handler(range r, basic_string_view<Char> str,
+                 basic_format_args<Context> format_args,
+                 internal::locale_ref loc)
+      : parse_context(str), context(r.begin(), format_args, loc) {}
+
+  void on_text(const Char* begin, const Char* end) {
+    auto size = internal::to_unsigned(end - begin);
+    auto out = context.out();
+    auto&& it = internal::reserve(out, size);
+    it = std::copy_n(begin, size, it);
+    context.advance_to(out);
+  }
+
+  void get_arg(int id) { arg = internal::get_arg(context, id); }
+
+  void on_arg_id() { get_arg(parse_context.next_arg_id()); }
+  void on_arg_id(int id) {
+    parse_context.check_arg_id(id);
+    get_arg(id);
+  }
+  void on_arg_id(basic_string_view<Char> id) { arg = context.arg(id); }
+
+  void on_replacement_field(const Char* p) {
+    advance_to(parse_context, p);
+    internal::custom_formatter<Context> f(parse_context, context);
+    if (!visit_format_arg(f, arg))
+      context.advance_to(
+          visit_format_arg(ArgFormatter(context, &parse_context), arg));
+  }
+
+  const Char* on_format_specs(const Char* begin, const Char* end) {
+    advance_to(parse_context, begin);
+    internal::custom_formatter<Context> f(parse_context, context);
+    if (visit_format_arg(f, arg)) return parse_context.begin();
+    basic_format_specs<Char> specs;
+    using internal::specs_handler;
+    using parse_context_t = basic_parse_context<Char>;
+    internal::specs_checker<specs_handler<parse_context_t, Context>> handler(
+        specs_handler<parse_context_t, Context>(specs, parse_context, context),
+        arg.type());
+    begin = parse_format_specs(begin, end, handler);
+    if (begin == end || *begin != '}') on_error("missing '}' in format string");
+    advance_to(parse_context, begin);
+    context.advance_to(
+        visit_format_arg(ArgFormatter(context, &parse_context, &specs), arg));
+    return begin;
+  }
+
+  basic_parse_context<Char> parse_context;
+  Context context;
+  basic_format_arg<Context> arg;
+};
+
+/** Formats arguments and writes the output to the range. */
+template <typename ArgFormatter, typename Char, typename Context>
+typename Context::iterator vformat_to(
+    typename ArgFormatter::range out, basic_string_view<Char> format_str,
+    basic_format_args<Context> args,
+    internal::locale_ref loc = internal::locale_ref()) {
+  format_handler<ArgFormatter, Char, Context> h(out, format_str, args, loc);
+  internal::parse_format_string<false>(format_str, h);
+  return h.context.out();
+}
+
+// Casts ``p`` to ``const void*`` for pointer formatting.
+// Example:
+//   auto s = format("{}", ptr(p));
+template <typename T> inline const void* ptr(const T* p) { return p; }
+template <typename T> inline const void* ptr(const std::unique_ptr<T>& p) {
+  return p.get();
+}
+template <typename T> inline const void* ptr(const std::shared_ptr<T>& p) {
+  return p.get();
+}
+
+template <typename It, typename Char> struct arg_join : internal::view {
+  It begin;
+  It end;
+  basic_string_view<Char> sep;
+
+  arg_join(It b, It e, basic_string_view<Char> s) : begin(b), end(e), sep(s) {}
+};
+
+template <typename It, typename Char>
+struct formatter<arg_join<It, Char>, Char>
+    : formatter<typename std::iterator_traits<It>::value_type, Char> {
+  template <typename FormatContext>
+  auto format(const arg_join<It, Char>& value, FormatContext& ctx)
+      -> decltype(ctx.out()) {
+    using base = formatter<typename std::iterator_traits<It>::value_type, Char>;
+    auto it = value.begin;
+    auto out = ctx.out();
+    if (it != value.end) {
+      out = base::format(*it++, ctx);
+      while (it != value.end) {
+        out = std::copy(value.sep.begin(), value.sep.end(), out);
+        ctx.advance_to(out);
+        out = base::format(*it++, ctx);
+      }
+    }
+    return out;
+  }
+};
+
+/**
+  Returns an object that formats the iterator range `[begin, end)` with elements
+  separated by `sep`.
+ */
+template <typename It>
+arg_join<It, char> join(It begin, It end, string_view sep) {
+  return {begin, end, sep};
+}
+
+template <typename It>
+arg_join<It, wchar_t> join(It begin, It end, wstring_view sep) {
+  return {begin, end, sep};
+}
+
+/**
+  \rst
+  Returns an object that formats `range` with elements separated by `sep`.
+
+  **Example**::
+
+    std::vector<int> v = {1, 2, 3};
+    fmt::print("{}", fmt::join(v, ", "));
+    // Output: "1, 2, 3"
+  \endrst
+ */
+template <typename Range>
+arg_join<internal::iterator_t<const Range>, char> join(const Range& range,
+                                                       string_view sep) {
+  return join(std::begin(range), std::end(range), sep);
+}
+
+template <typename Range>
+arg_join<internal::iterator_t<const Range>, wchar_t> join(const Range& range,
+                                                          wstring_view sep) {
+  return join(std::begin(range), std::end(range), sep);
+}
+
+/**
+  \rst
+  Converts *value* to ``std::string`` using the default format for type *T*.
+  It doesn't support user-defined types with custom formatters.
+
+  **Example**::
+
+    #include <fmt/format.h>
+
+    std::string answer = fmt::to_string(42);
+  \endrst
+ */
+template <typename T> inline std::string to_string(const T& value) {
+  return format("{}", value);
+}
+
+/**
+  Converts *value* to ``std::wstring`` using the default format for type *T*.
+ */
+template <typename T> inline std::wstring to_wstring(const T& value) {
+  return format(L"{}", value);
+}
+
+template <typename Char, std::size_t SIZE>
+std::basic_string<Char> to_string(const basic_memory_buffer<Char, SIZE>& buf) {
+  return std::basic_string<Char>(buf.data(), buf.size());
+}
+
+template <typename Char>
+typename buffer_context<Char>::iterator internal::vformat_to(
+    internal::buffer<Char>& buf, basic_string_view<Char> format_str,
+    basic_format_args<buffer_context<Char>> args) {
+  using range = buffer_range<Char>;
+  return vformat_to<arg_formatter<range>>(buf, to_string_view(format_str),
+                                          args);
+}
+
+template <typename S, typename Char = char_t<S>,
+          FMT_ENABLE_IF(internal::is_string<S>::value)>
+inline typename buffer_context<Char>::iterator vformat_to(
+    internal::buffer<Char>& buf, const S& format_str,
+    basic_format_args<buffer_context<Char>> args) {
+  return internal::vformat_to(buf, to_string_view(format_str), args);
+}
+
+template <typename S, typename... Args, std::size_t SIZE = inline_buffer_size,
+          typename Char = enable_if_t<internal::is_string<S>::value, char_t<S>>>
+inline typename buffer_context<Char>::iterator format_to(
+    basic_memory_buffer<Char, SIZE>& buf, const S& format_str, Args&&... args) {
+  internal::check_format_string<Args...>(format_str);
+  using context = buffer_context<Char>;
+  return internal::vformat_to(buf, to_string_view(format_str),
+                              {make_format_args<context>(args...)});
+}
+
+template <typename OutputIt, typename Char = char>
+using format_context_t = basic_format_context<OutputIt, Char>;
+
+template <typename OutputIt, typename Char = char>
+using format_args_t = basic_format_args<format_context_t<OutputIt, Char>>;
+
+template <typename S, typename OutputIt, typename... Args,
+          FMT_ENABLE_IF(
+              internal::is_output_iterator<OutputIt>::value &&
+              !internal::is_contiguous_back_insert_iterator<OutputIt>::value)>
+inline OutputIt vformat_to(OutputIt out, const S& format_str,
+                           format_args_t<OutputIt, char_t<S>> args) {
+  using range = internal::output_range<OutputIt, char_t<S>>;
+  return vformat_to<arg_formatter<range>>(range(out),
+                                          to_string_view(format_str), args);
+}
+
+/**
+ \rst
+ Formats arguments, writes the result to the output iterator ``out`` and returns
+ the iterator past the end of the output range.
+
+ **Example**::
+
+   std::vector<char> out;
+   fmt::format_to(std::back_inserter(out), "{}", 42);
+ \endrst
+ */
+template <typename OutputIt, typename S, typename... Args,
+          FMT_ENABLE_IF(
+              internal::is_output_iterator<OutputIt>::value &&
+              !internal::is_contiguous_back_insert_iterator<OutputIt>::value &&
+              internal::is_string<S>::value)>
+inline OutputIt format_to(OutputIt out, const S& format_str, Args&&... args) {
+  internal::check_format_string<Args...>(format_str);
+  using context = format_context_t<OutputIt, char_t<S>>;
+  return vformat_to(out, to_string_view(format_str),
+                    {make_format_args<context>(args...)});
+}
+
+template <typename OutputIt> struct format_to_n_result {
+  /** Iterator past the end of the output range. */
+  OutputIt out;
+  /** Total (not truncated) output size. */
+  std::size_t size;
+};
+
+template <typename OutputIt, typename Char = typename OutputIt::value_type>
+using format_to_n_context =
+    format_context_t<fmt::internal::truncating_iterator<OutputIt>, Char>;
+
+template <typename OutputIt, typename Char = typename OutputIt::value_type>
+using format_to_n_args = basic_format_args<format_to_n_context<OutputIt, Char>>;
+
+template <typename OutputIt, typename Char, typename... Args>
+inline format_arg_store<format_to_n_context<OutputIt, Char>, Args...>
+make_format_to_n_args(const Args&... args) {
+  return format_arg_store<format_to_n_context<OutputIt, Char>, Args...>(
+      args...);
+}
+
+template <typename OutputIt, typename Char, typename... Args,
+          FMT_ENABLE_IF(internal::is_output_iterator<OutputIt>::value)>
+inline format_to_n_result<OutputIt> vformat_to_n(
+    OutputIt out, std::size_t n, basic_string_view<Char> format_str,
+    format_to_n_args<OutputIt, Char> args) {
+  auto it = vformat_to(internal::truncating_iterator<OutputIt>(out, n),
+                       format_str, args);
+  return {it.base(), it.count()};
+}
+
+/**
+ \rst
+ Formats arguments, writes up to ``n`` characters of the result to the output
+ iterator ``out`` and returns the total output size and the iterator past the
+ end of the output range.
+ \endrst
+ */
+template <typename OutputIt, typename S, typename... Args,
+          FMT_ENABLE_IF(internal::is_string<S>::value&&
+                            internal::is_output_iterator<OutputIt>::value)>
+inline format_to_n_result<OutputIt> format_to_n(OutputIt out, std::size_t n,
+                                                const S& format_str,
+                                                const Args&... args) {
+  internal::check_format_string<Args...>(format_str);
+  using context = format_to_n_context<OutputIt, char_t<S>>;
+  return vformat_to_n(out, n, to_string_view(format_str),
+                      {make_format_args<context>(args...)});
+}
+
+template <typename Char>
+inline std::basic_string<Char> internal::vformat(
+    basic_string_view<Char> format_str,
+    basic_format_args<buffer_context<Char>> args) {
+  basic_memory_buffer<Char> buffer;
+  internal::vformat_to(buffer, format_str, args);
+  return fmt::to_string(buffer);
+}
+
+/**
+  Returns the number of characters in the output of
+  ``format(format_str, args...)``.
+ */
+template <typename... Args>
+inline std::size_t formatted_size(string_view format_str, const Args&... args) {
+  auto it = format_to(internal::counting_iterator<char>(), format_str, args...);
+  return it.count();
+}
+
+#if FMT_USE_USER_DEFINED_LITERALS
+namespace internal {
+
+#  if FMT_USE_UDL_TEMPLATE
+template <typename Char, Char... CHARS> class udl_formatter {
+ public:
+  template <typename... Args>
+  std::basic_string<Char> operator()(Args&&... args) const {
+    FMT_CONSTEXPR_DECL Char s[] = {CHARS..., '\0'};
+    FMT_CONSTEXPR_DECL bool invalid_format =
+        do_check_format_string<Char, error_handler, Args...>(
+            basic_string_view<Char>(s, sizeof...(CHARS)));
+    (void)invalid_format;
+    return format(s, std::forward<Args>(args)...);
+  }
+};
+#  else
+template <typename Char> struct udl_formatter {
+  basic_string_view<Char> str;
+
+  template <typename... Args>
+  std::basic_string<Char> operator()(Args&&... args) const {
+    return format(str, std::forward<Args>(args)...);
+  }
+};
+#  endif  // FMT_USE_UDL_TEMPLATE
+
+template <typename Char> struct udl_arg {
+  basic_string_view<Char> str;
+
+  template <typename T> named_arg<T, Char> operator=(T&& value) const {
+    return {str, std::forward<T>(value)};
+  }
+};
+
+}  // namespace internal
+
+inline namespace literals {
+#  if FMT_USE_UDL_TEMPLATE
+#    pragma GCC diagnostic push
+#    if FMT_CLANG_VERSION
+#      pragma GCC diagnostic ignored "-Wgnu-string-literal-operator-template"
+#    endif
+template <typename Char, Char... CHARS>
+FMT_CONSTEXPR internal::udl_formatter<Char, CHARS...> operator""_format() {
+  return {};
+}
+#    pragma GCC diagnostic pop
+#  else
+/**
+  \rst
+  User-defined literal equivalent of :func:`fmt::format`.
+
+  **Example**::
+
+    using namespace fmt::literals;
+    std::string message = "The answer is {}"_format(42);
+  \endrst
+ */
+FMT_CONSTEXPR internal::udl_formatter<char> operator"" _format(const char* s,
+                                                               std::size_t n) {
+  return {{s, n}};
+}
+FMT_CONSTEXPR internal::udl_formatter<wchar_t> operator"" _format(
+    const wchar_t* s, std::size_t n) {
+  return {{s, n}};
+}
+#  endif  // FMT_USE_UDL_TEMPLATE
+
+/**
+  \rst
+  User-defined literal equivalent of :func:`fmt::arg`.
+
+  **Example**::
+
+    using namespace fmt::literals;
+    fmt::print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
+  \endrst
+ */
+FMT_CONSTEXPR internal::udl_arg<char> operator"" _a(const char* s,
+                                                    std::size_t n) {
+  return {{s, n}};
+}
+FMT_CONSTEXPR internal::udl_arg<wchar_t> operator"" _a(const wchar_t* s,
+                                                       std::size_t n) {
+  return {{s, n}};
+}
+}  // namespace literals
+#endif  // FMT_USE_USER_DEFINED_LITERALS
+FMT_END_NAMESPACE
+
+/**
+  \rst
+  Constructs a compile-time format string.
+
+  **Example**::
+
+    // A compile-time error because 'd' is an invalid specifier for strings.
+    std::string s = format(FMT_STRING("{:d}"), "foo");
+  \endrst
+ */
+#define FMT_STRING(s)                                                    \
+  [] {                                                                   \
+    struct str : fmt::compile_string {                                   \
+      using char_type = typename std::remove_cv<std::remove_pointer<     \
+          typename std::decay<decltype(s)>::type>::type>::type;          \
+      FMT_CONSTEXPR operator fmt::basic_string_view<char_type>() const { \
+        return {s, sizeof(s) / sizeof(char_type) - 1};                   \
+      }                                                                  \
+    } result;                                                            \
+    /* Suppress Qt Creator warning about unused operator. */             \
+    (void)static_cast<fmt::basic_string_view<typename str::char_type>>(  \
+        result);                                                         \
+    return result;                                                       \
+  }()
+
+#if defined(FMT_STRING_ALIAS) && FMT_STRING_ALIAS
+/**
+  \rst
+  Constructs a compile-time format string. This macro is disabled by default to
+  prevent potential name collisions. To enable it define ``FMT_STRING_ALIAS`` to
+  1 before including ``fmt/format.h``.
+
+  **Example**::
+
+    #define FMT_STRING_ALIAS 1
+    #include <fmt/format.h>
+    // A compile-time error because 'd' is an invalid specifier for strings.
+    std::string s = format(fmt("{:d}"), "foo");
+  \endrst
+ */
+#  define fmt(s) FMT_STRING(s)
+#endif
+
+#ifdef FMT_HEADER_ONLY
+#  define FMT_FUNC inline
+#  include "format-inl.h"
+#else
+#  define FMT_FUNC
+#endif
+
+#endif  // FMT_FORMAT_H_

--- a/contrib/fmt/include/fmt/locale.h
+++ b/contrib/fmt/include/fmt/locale.h
@@ -1,0 +1,77 @@
+// Formatting library for C++ - std::locale support
+//
+// Copyright (c) 2012 - present, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_LOCALE_H_
+#define FMT_LOCALE_H_
+
+#include <locale>
+#include "format.h"
+
+FMT_BEGIN_NAMESPACE
+
+namespace internal {
+template <typename Char>
+typename buffer_context<Char>::iterator vformat_to(
+    const std::locale& loc, buffer<Char>& buf,
+    basic_string_view<Char> format_str,
+    basic_format_args<buffer_context<Char>> args) {
+  using range = buffer_range<Char>;
+  return vformat_to<arg_formatter<range>>(buf, to_string_view(format_str), args,
+                                          internal::locale_ref(loc));
+}
+
+template <typename Char>
+std::basic_string<Char> vformat(const std::locale& loc,
+                                basic_string_view<Char> format_str,
+                                basic_format_args<buffer_context<Char>> args) {
+  basic_memory_buffer<Char> buffer;
+  internal::vformat_to(loc, buffer, format_str, args);
+  return fmt::to_string(buffer);
+}
+}  // namespace internal
+
+template <typename S, typename Char = char_t<S>>
+inline std::basic_string<Char> vformat(
+    const std::locale& loc, const S& format_str,
+    basic_format_args<buffer_context<Char>> args) {
+  return internal::vformat(loc, to_string_view(format_str), args);
+}
+
+template <typename S, typename... Args, typename Char = char_t<S>>
+inline std::basic_string<Char> format(const std::locale& loc,
+                                      const S& format_str, Args&&... args) {
+  return internal::vformat(
+      loc, to_string_view(format_str),
+      {internal::make_args_checked<Args...>(format_str, args...)});
+}
+
+template <typename S, typename OutputIt, typename... Args,
+          typename Char = enable_if_t<
+              internal::is_output_iterator<OutputIt>::value, char_t<S>>>
+inline OutputIt vformat_to(OutputIt out, const std::locale& loc,
+                           const S& format_str,
+                           format_args_t<OutputIt, Char> args) {
+  using range = internal::output_range<OutputIt, Char>;
+  return vformat_to<arg_formatter<range>>(
+      range(out), to_string_view(format_str), args, internal::locale_ref(loc));
+}
+
+template <typename OutputIt, typename S, typename... Args,
+          FMT_ENABLE_IF(internal::is_output_iterator<OutputIt>::value&&
+                            internal::is_string<S>::value)>
+inline OutputIt format_to(OutputIt out, const std::locale& loc,
+                          const S& format_str, Args&&... args) {
+  internal::check_format_string<Args...>(format_str);
+  using context = format_context_t<OutputIt, char_t<S>>;
+  format_arg_store<context, Args...> as{args...};
+  return vformat_to(out, loc, to_string_view(format_str),
+                    basic_format_args<context>(as));
+}
+
+FMT_END_NAMESPACE
+
+#endif  // FMT_LOCALE_H_

--- a/contrib/fmt/include/fmt/ostream.h
+++ b/contrib/fmt/include/fmt/ostream.h
@@ -1,0 +1,136 @@
+// Formatting library for C++ - std::ostream support
+//
+// Copyright (c) 2012 - present, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_OSTREAM_H_
+#define FMT_OSTREAM_H_
+
+#include <ostream>
+#include "format.h"
+
+FMT_BEGIN_NAMESPACE
+namespace internal {
+
+template <class Char> class formatbuf : public std::basic_streambuf<Char> {
+ private:
+  using int_type = typename std::basic_streambuf<Char>::int_type;
+  using traits_type = typename std::basic_streambuf<Char>::traits_type;
+
+  buffer<Char>& buffer_;
+
+ public:
+  formatbuf(buffer<Char>& buf) : buffer_(buf) {}
+
+ protected:
+  // The put-area is actually always empty. This makes the implementation
+  // simpler and has the advantage that the streambuf and the buffer are always
+  // in sync and sputc never writes into uninitialized memory. The obvious
+  // disadvantage is that each call to sputc always results in a (virtual) call
+  // to overflow. There is no disadvantage here for sputn since this always
+  // results in a call to xsputn.
+
+  int_type overflow(int_type ch = traits_type::eof()) FMT_OVERRIDE {
+    if (!traits_type::eq_int_type(ch, traits_type::eof()))
+      buffer_.push_back(static_cast<Char>(ch));
+    return ch;
+  }
+
+  std::streamsize xsputn(const Char* s, std::streamsize count) FMT_OVERRIDE {
+    buffer_.append(s, s + count);
+    return count;
+  }
+};
+
+template <typename Char> struct test_stream : std::basic_ostream<Char> {
+ private:
+  struct null;
+  // Hide all operator<< from std::basic_ostream<Char>.
+  void operator<<(null);
+};
+
+// Checks if T has a user-defined operator<< (e.g. not a member of
+// std::ostream).
+template <typename T, typename Char> class is_streamable {
+ private:
+  template <typename U>
+  static decltype((void)(std::declval<test_stream<Char>&>()
+                         << std::declval<U>()),
+                  std::true_type())
+  test(int);
+
+  template <typename> static std::false_type test(...);
+
+  using result = decltype(test<T>(0));
+
+ public:
+  static const bool value = result::value;
+};
+
+// Write the content of buf to os.
+template <typename Char>
+void write(std::basic_ostream<Char>& os, buffer<Char>& buf) {
+  const Char* buf_data = buf.data();
+  using unsigned_streamsize = std::make_unsigned<std::streamsize>::type;
+  unsigned_streamsize size = buf.size();
+  unsigned_streamsize max_size =
+      to_unsigned((std::numeric_limits<std::streamsize>::max)());
+  do {
+    unsigned_streamsize n = size <= max_size ? size : max_size;
+    os.write(buf_data, static_cast<std::streamsize>(n));
+    buf_data += n;
+    size -= n;
+  } while (size != 0);
+}
+
+template <typename Char, typename T>
+void format_value(buffer<Char>& buf, const T& value) {
+  formatbuf<Char> format_buf(buf);
+  std::basic_ostream<Char> output(&format_buf);
+  output.exceptions(std::ios_base::failbit | std::ios_base::badbit);
+  output << value;
+  buf.resize(buf.size());
+}
+
+// Formats an object of type T that has an overloaded ostream operator<<.
+template <typename T, typename Char>
+struct fallback_formatter<T, Char, enable_if_t<is_streamable<T, Char>::value>>
+    : formatter<basic_string_view<Char>, Char> {
+  template <typename Context>
+  auto format(const T& value, Context& ctx) -> decltype(ctx.out()) {
+    basic_memory_buffer<Char> buffer;
+    format_value(buffer, value);
+    basic_string_view<Char> str(buffer.data(), buffer.size());
+    return formatter<basic_string_view<Char>, Char>::format(str, ctx);
+  }
+};
+}  // namespace internal
+
+template <typename Char>
+void vprint(std::basic_ostream<Char>& os, basic_string_view<Char> format_str,
+            basic_format_args<buffer_context<Char>> args) {
+  basic_memory_buffer<Char> buffer;
+  internal::vformat_to(buffer, format_str, args);
+  internal::write(os, buffer);
+}
+
+/**
+  \rst
+  Prints formatted data to the stream *os*.
+
+  **Example**::
+
+    fmt::print(cerr, "Don't {}!", "panic");
+  \endrst
+ */
+template <typename S, typename... Args,
+          typename Char = enable_if_t<internal::is_string<S>::value, char_t<S>>>
+void print(std::basic_ostream<Char>& os, const S& format_str, Args&&... args) {
+  vprint(os, to_string_view(format_str),
+         {internal::make_args_checked<Args...>(format_str, args...)});
+}
+FMT_END_NAMESPACE
+
+#endif  // FMT_OSTREAM_H_

--- a/contrib/fmt/include/fmt/posix.h
+++ b/contrib/fmt/include/fmt/posix.h
@@ -1,0 +1,311 @@
+// A C++ interface to POSIX functions.
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_POSIX_H_
+#define FMT_POSIX_H_
+
+#if defined(__MINGW32__) || defined(__CYGWIN__)
+// Workaround MinGW bug https://sourceforge.net/p/mingw/bugs/2024/.
+#  undef __STRICT_ANSI__
+#endif
+
+#include <errno.h>
+#include <fcntl.h>   // for O_RDONLY
+#include <locale.h>  // for locale_t
+#include <stdio.h>
+#include <stdlib.h>  // for strtod_l
+
+#include <cstddef>
+
+#if defined __APPLE__ || defined(__FreeBSD__)
+#  include <xlocale.h>  // for LC_NUMERIC_MASK on OS X
+#endif
+
+#include "format.h"
+
+#ifndef FMT_POSIX
+#  if defined(_WIN32) && !defined(__MINGW32__)
+// Fix warnings about deprecated symbols.
+#    define FMT_POSIX(call) _##call
+#  else
+#    define FMT_POSIX(call) call
+#  endif
+#endif
+
+// Calls to system functions are wrapped in FMT_SYSTEM for testability.
+#ifdef FMT_SYSTEM
+#  define FMT_POSIX_CALL(call) FMT_SYSTEM(call)
+#else
+#  define FMT_SYSTEM(call) call
+#  ifdef _WIN32
+// Fix warnings about deprecated symbols.
+#    define FMT_POSIX_CALL(call) ::_##call
+#  else
+#    define FMT_POSIX_CALL(call) ::call
+#  endif
+#endif
+
+// Retries the expression while it evaluates to error_result and errno
+// equals to EINTR.
+#ifndef _WIN32
+#  define FMT_RETRY_VAL(result, expression, error_result) \
+    do {                                                  \
+      result = (expression);                              \
+    } while (result == error_result && errno == EINTR)
+#else
+#  define FMT_RETRY_VAL(result, expression, error_result) result = (expression)
+#endif
+
+#define FMT_RETRY(result, expression) FMT_RETRY_VAL(result, expression, -1)
+
+FMT_BEGIN_NAMESPACE
+
+/**
+  \rst
+  A reference to a null-terminated string. It can be constructed from a C
+  string or ``std::string``.
+
+  You can use one of the following type aliases for common character types:
+
+  +---------------+-----------------------------+
+  | Type          | Definition                  |
+  +===============+=============================+
+  | cstring_view  | basic_cstring_view<char>    |
+  +---------------+-----------------------------+
+  | wcstring_view | basic_cstring_view<wchar_t> |
+  +---------------+-----------------------------+
+
+  This class is most useful as a parameter type to allow passing
+  different types of strings to a function, for example::
+
+    template <typename... Args>
+    std::string format(cstring_view format_str, const Args & ... args);
+
+    format("{}", 42);
+    format(std::string("{}"), 42);
+  \endrst
+ */
+template <typename Char> class basic_cstring_view {
+ private:
+  const Char* data_;
+
+ public:
+  /** Constructs a string reference object from a C string. */
+  basic_cstring_view(const Char* s) : data_(s) {}
+
+  /**
+    \rst
+    Constructs a string reference from an ``std::string`` object.
+    \endrst
+   */
+  basic_cstring_view(const std::basic_string<Char>& s) : data_(s.c_str()) {}
+
+  /** Returns the pointer to a C string. */
+  const Char* c_str() const { return data_; }
+};
+
+using cstring_view = basic_cstring_view<char>;
+using wcstring_view = basic_cstring_view<wchar_t>;
+
+// An error code.
+class error_code {
+ private:
+  int value_;
+
+ public:
+  explicit error_code(int value = 0) FMT_NOEXCEPT : value_(value) {}
+
+  int get() const FMT_NOEXCEPT { return value_; }
+};
+
+// A buffered file.
+class buffered_file {
+ private:
+  FILE* file_;
+
+  friend class file;
+
+  explicit buffered_file(FILE* f) : file_(f) {}
+
+ public:
+  // Constructs a buffered_file object which doesn't represent any file.
+  buffered_file() FMT_NOEXCEPT : file_(nullptr) {}
+
+  // Destroys the object closing the file it represents if any.
+  FMT_API ~buffered_file() FMT_NOEXCEPT;
+
+ private:
+  buffered_file(const buffered_file&) = delete;
+  void operator=(const buffered_file&) = delete;
+
+ public:
+  buffered_file(buffered_file&& other) FMT_NOEXCEPT : file_(other.file_) {
+    other.file_ = nullptr;
+  }
+
+  buffered_file& operator=(buffered_file&& other) {
+    close();
+    file_ = other.file_;
+    other.file_ = nullptr;
+    return *this;
+  }
+
+  // Opens a file.
+  FMT_API buffered_file(cstring_view filename, cstring_view mode);
+
+  // Closes the file.
+  FMT_API void close();
+
+  // Returns the pointer to a FILE object representing this file.
+  FILE* get() const FMT_NOEXCEPT { return file_; }
+
+  // We place parentheses around fileno to workaround a bug in some versions
+  // of MinGW that define fileno as a macro.
+  FMT_API int(fileno)() const;
+
+  void vprint(string_view format_str, format_args args) {
+    fmt::vprint(file_, format_str, args);
+  }
+
+  template <typename... Args>
+  inline void print(string_view format_str, const Args&... args) {
+    vprint(format_str, make_format_args(args...));
+  }
+};
+
+// A file. Closed file is represented by a file object with descriptor -1.
+// Methods that are not declared with FMT_NOEXCEPT may throw
+// fmt::system_error in case of failure. Note that some errors such as
+// closing the file multiple times will cause a crash on Windows rather
+// than an exception. You can get standard behavior by overriding the
+// invalid parameter handler with _set_invalid_parameter_handler.
+class file {
+ private:
+  int fd_;  // File descriptor.
+
+  // Constructs a file object with a given descriptor.
+  explicit file(int fd) : fd_(fd) {}
+
+ public:
+  // Possible values for the oflag argument to the constructor.
+  enum {
+    RDONLY = FMT_POSIX(O_RDONLY),  // Open for reading only.
+    WRONLY = FMT_POSIX(O_WRONLY),  // Open for writing only.
+    RDWR = FMT_POSIX(O_RDWR)       // Open for reading and writing.
+  };
+
+  // Constructs a file object which doesn't represent any file.
+  file() FMT_NOEXCEPT : fd_(-1) {}
+
+  // Opens a file and constructs a file object representing this file.
+  FMT_API file(cstring_view path, int oflag);
+
+ private:
+  file(const file&) = delete;
+  void operator=(const file&) = delete;
+
+ public:
+  file(file&& other) FMT_NOEXCEPT : fd_(other.fd_) { other.fd_ = -1; }
+
+  file& operator=(file&& other) {
+    close();
+    fd_ = other.fd_;
+    other.fd_ = -1;
+    return *this;
+  }
+
+  // Destroys the object closing the file it represents if any.
+  FMT_API ~file() FMT_NOEXCEPT;
+
+  // Returns the file descriptor.
+  int descriptor() const FMT_NOEXCEPT { return fd_; }
+
+  // Closes the file.
+  FMT_API void close();
+
+  // Returns the file size. The size has signed type for consistency with
+  // stat::st_size.
+  FMT_API long long size() const;
+
+  // Attempts to read count bytes from the file into the specified buffer.
+  FMT_API std::size_t read(void* buffer, std::size_t count);
+
+  // Attempts to write count bytes from the specified buffer to the file.
+  FMT_API std::size_t write(const void* buffer, std::size_t count);
+
+  // Duplicates a file descriptor with the dup function and returns
+  // the duplicate as a file object.
+  FMT_API static file dup(int fd);
+
+  // Makes fd be the copy of this file descriptor, closing fd first if
+  // necessary.
+  FMT_API void dup2(int fd);
+
+  // Makes fd be the copy of this file descriptor, closing fd first if
+  // necessary.
+  FMT_API void dup2(int fd, error_code& ec) FMT_NOEXCEPT;
+
+  // Creates a pipe setting up read_end and write_end file objects for reading
+  // and writing respectively.
+  FMT_API static void pipe(file& read_end, file& write_end);
+
+  // Creates a buffered_file object associated with this file and detaches
+  // this file object from the file.
+  FMT_API buffered_file fdopen(const char* mode);
+};
+
+// Returns the memory page size.
+long getpagesize();
+
+#ifdef FMT_LOCALE
+// A "C" numeric locale.
+class Locale {
+ private:
+#  ifdef _WIN32
+  using locale_t = _locale_t;
+
+  enum { LC_NUMERIC_MASK = LC_NUMERIC };
+
+  static locale_t newlocale(int category_mask, const char* locale, locale_t) {
+    return _create_locale(category_mask, locale);
+  }
+
+  static void freelocale(locale_t locale) { _free_locale(locale); }
+
+  static double strtod_l(const char* nptr, char** endptr, _locale_t locale) {
+    return _strtod_l(nptr, endptr, locale);
+  }
+#  endif
+
+  locale_t locale_;
+
+  Locale(const Locale&) = delete;
+  void operator=(const Locale&) = delete;
+
+ public:
+  using type = locale_t;
+
+  Locale() : locale_(newlocale(LC_NUMERIC_MASK, "C", nullptr)) {
+    if (!locale_) FMT_THROW(system_error(errno, "cannot create locale"));
+  }
+  ~Locale() { freelocale(locale_); }
+
+  type get() const { return locale_; }
+
+  // Converts string to floating-point number and advances str past the end
+  // of the parsed input.
+  double strtod(const char*& str) const {
+    char* end = nullptr;
+    double result = strtod_l(str, &end, locale_);
+    str = end;
+    return result;
+  }
+};
+#endif  // FMT_LOCALE
+FMT_END_NAMESPACE
+
+#endif  // FMT_POSIX_H_

--- a/contrib/fmt/include/fmt/printf.h
+++ b/contrib/fmt/include/fmt/printf.h
@@ -1,0 +1,715 @@
+// Formatting library for C++
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_PRINTF_H_
+#define FMT_PRINTF_H_
+
+#include <algorithm>  // std::fill_n
+#include <limits>     // std::numeric_limits
+
+#include "ostream.h"
+
+FMT_BEGIN_NAMESPACE
+namespace internal {
+
+// A helper function to suppress bogus "conditional expression is constant"
+// warnings.
+template <typename T> inline T const_check(T value) { return value; }
+
+// Checks if a value fits in int - used to avoid warnings about comparing
+// signed and unsigned integers.
+template <bool IsSigned> struct int_checker {
+  template <typename T> static bool fits_in_int(T value) {
+    unsigned max = std::numeric_limits<int>::max();
+    return value <= max;
+  }
+  static bool fits_in_int(bool) { return true; }
+};
+
+template <> struct int_checker<true> {
+  template <typename T> static bool fits_in_int(T value) {
+    return value >= std::numeric_limits<int>::min() &&
+           value <= std::numeric_limits<int>::max();
+  }
+  static bool fits_in_int(int) { return true; }
+};
+
+class printf_precision_handler {
+ public:
+  template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
+  int operator()(T value) {
+    if (!int_checker<std::numeric_limits<T>::is_signed>::fits_in_int(value))
+      FMT_THROW(format_error("number is too big"));
+    return (std::max)(static_cast<int>(value), 0);
+  }
+
+  template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
+  int operator()(T) {
+    FMT_THROW(format_error("precision is not integer"));
+    return 0;
+  }
+};
+
+// An argument visitor that returns true iff arg is a zero integer.
+class is_zero_int {
+ public:
+  template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
+  bool operator()(T value) {
+    return value == 0;
+  }
+
+  template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
+  bool operator()(T) {
+    return false;
+  }
+};
+
+template <typename T> struct make_unsigned_or_bool : std::make_unsigned<T> {};
+
+template <> struct make_unsigned_or_bool<bool> { using type = bool; };
+
+template <typename T, typename Context> class arg_converter {
+ private:
+  using char_type = typename Context::char_type;
+
+  basic_format_arg<Context>& arg_;
+  char_type type_;
+
+ public:
+  arg_converter(basic_format_arg<Context>& arg, char_type type)
+      : arg_(arg), type_(type) {}
+
+  void operator()(bool value) {
+    if (type_ != 's') operator()<bool>(value);
+  }
+
+  template <typename U, FMT_ENABLE_IF(std::is_integral<U>::value)>
+  void operator()(U value) {
+    bool is_signed = type_ == 'd' || type_ == 'i';
+    using target_type = conditional_t<std::is_same<T, void>::value, U, T>;
+    if (const_check(sizeof(target_type) <= sizeof(int))) {
+      // Extra casts are used to silence warnings.
+      if (is_signed) {
+        arg_ = internal::make_arg<Context>(
+            static_cast<int>(static_cast<target_type>(value)));
+      } else {
+        using unsigned_type = typename make_unsigned_or_bool<target_type>::type;
+        arg_ = internal::make_arg<Context>(
+            static_cast<unsigned>(static_cast<unsigned_type>(value)));
+      }
+    } else {
+      if (is_signed) {
+        // glibc's printf doesn't sign extend arguments of smaller types:
+        //   std::printf("%lld", -42);  // prints "4294967254"
+        // but we don't have to do the same because it's a UB.
+        arg_ = internal::make_arg<Context>(static_cast<long long>(value));
+      } else {
+        arg_ = internal::make_arg<Context>(
+            static_cast<typename make_unsigned_or_bool<U>::type>(value));
+      }
+    }
+  }
+
+  template <typename U, FMT_ENABLE_IF(!std::is_integral<U>::value)>
+  void operator()(U) {}  // No conversion needed for non-integral types.
+};
+
+// Converts an integer argument to T for printf, if T is an integral type.
+// If T is void, the argument is converted to corresponding signed or unsigned
+// type depending on the type specifier: 'd' and 'i' - signed, other -
+// unsigned).
+template <typename T, typename Context, typename Char>
+void convert_arg(basic_format_arg<Context>& arg, Char type) {
+  visit_format_arg(arg_converter<T, Context>(arg, type), arg);
+}
+
+// Converts an integer argument to char for printf.
+template <typename Context> class char_converter {
+ private:
+  basic_format_arg<Context>& arg_;
+
+ public:
+  explicit char_converter(basic_format_arg<Context>& arg) : arg_(arg) {}
+
+  template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
+  void operator()(T value) {
+    arg_ = internal::make_arg<Context>(
+        static_cast<typename Context::char_type>(value));
+  }
+
+  template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
+  void operator()(T) {}  // No conversion needed for non-integral types.
+};
+
+// Checks if an argument is a valid printf width specifier and sets
+// left alignment if it is negative.
+template <typename Char> class printf_width_handler {
+ private:
+  using format_specs = basic_format_specs<Char>;
+
+  format_specs& specs_;
+
+ public:
+  explicit printf_width_handler(format_specs& specs) : specs_(specs) {}
+
+  template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
+  unsigned operator()(T value) {
+    auto width = static_cast<uint32_or_64_t<T>>(value);
+    if (internal::is_negative(value)) {
+      specs_.align = align::left;
+      width = 0 - width;
+    }
+    unsigned int_max = std::numeric_limits<int>::max();
+    if (width > int_max) FMT_THROW(format_error("number is too big"));
+    return static_cast<unsigned>(width);
+  }
+
+  template <typename T, FMT_ENABLE_IF(!std::is_integral<T>::value)>
+  unsigned operator()(T) {
+    FMT_THROW(format_error("width is not integer"));
+    return 0;
+  }
+};
+
+template <typename Char, typename Context>
+void printf(buffer<Char>& buf, basic_string_view<Char> format,
+            basic_format_args<Context> args) {
+  Context(std::back_inserter(buf), format, args).format();
+}
+
+template <typename OutputIt, typename Char, typename Context>
+internal::truncating_iterator<OutputIt> printf(
+    internal::truncating_iterator<OutputIt> it, basic_string_view<Char> format,
+    basic_format_args<Context> args) {
+  return Context(it, format, args).format();
+}
+}  // namespace internal
+
+using internal::printf;  // For printing into memory_buffer.
+
+template <typename Range> class printf_arg_formatter;
+
+template <typename OutputIt, typename Char> class basic_printf_context;
+
+/**
+  \rst
+  The ``printf`` argument formatter.
+  \endrst
+ */
+template <typename Range>
+class printf_arg_formatter : public internal::arg_formatter_base<Range> {
+ public:
+  using iterator = typename Range::iterator;
+
+ private:
+  using char_type = typename Range::value_type;
+  using base = internal::arg_formatter_base<Range>;
+  using context_type = basic_printf_context<iterator, char_type>;
+
+  context_type& context_;
+
+  void write_null_pointer(char) {
+    this->specs()->type = 0;
+    this->write("(nil)");
+  }
+
+  void write_null_pointer(wchar_t) {
+    this->specs()->type = 0;
+    this->write(L"(nil)");
+  }
+
+ public:
+  using format_specs = typename base::format_specs;
+
+  /**
+    \rst
+    Constructs an argument formatter object.
+    *buffer* is a reference to the output buffer and *specs* contains format
+    specifier information for standard argument types.
+    \endrst
+   */
+  printf_arg_formatter(iterator iter, format_specs& specs, context_type& ctx)
+      : base(Range(iter), &specs, internal::locale_ref()), context_(ctx) {}
+
+  template <typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
+  iterator operator()(T value) {
+    // MSVC2013 fails to compile separate overloads for bool and char_type so
+    // use std::is_same instead.
+    if (std::is_same<T, bool>::value) {
+      format_specs& fmt_specs = *this->specs();
+      if (fmt_specs.type != 's') return base::operator()(value ? 1 : 0);
+      fmt_specs.type = 0;
+      this->write(value != 0);
+    } else if (std::is_same<T, char_type>::value) {
+      format_specs& fmt_specs = *this->specs();
+      if (fmt_specs.type && fmt_specs.type != 'c')
+        return (*this)(static_cast<int>(value));
+      fmt_specs.sign = sign::none;
+      fmt_specs.alt = false;
+      fmt_specs.align = align::right;
+      return base::operator()(value);
+    } else {
+      return base::operator()(value);
+    }
+    return this->out();
+  }
+
+  template <typename T, FMT_ENABLE_IF(std::is_floating_point<T>::value)>
+  iterator operator()(T value) {
+    return base::operator()(value);
+  }
+
+  /** Formats a null-terminated C string. */
+  iterator operator()(const char* value) {
+    if (value)
+      base::operator()(value);
+    else if (this->specs()->type == 'p')
+      write_null_pointer(char_type());
+    else
+      this->write("(null)");
+    return this->out();
+  }
+
+  /** Formats a null-terminated wide C string. */
+  iterator operator()(const wchar_t* value) {
+    if (value)
+      base::operator()(value);
+    else if (this->specs()->type == 'p')
+      write_null_pointer(char_type());
+    else
+      this->write(L"(null)");
+    return this->out();
+  }
+
+  iterator operator()(basic_string_view<char_type> value) {
+    return base::operator()(value);
+  }
+
+  iterator operator()(monostate value) { return base::operator()(value); }
+
+  /** Formats a pointer. */
+  iterator operator()(const void* value) {
+    if (value) return base::operator()(value);
+    this->specs()->type = 0;
+    write_null_pointer(char_type());
+    return this->out();
+  }
+
+  /** Formats an argument of a custom (user-defined) type. */
+  iterator operator()(typename basic_format_arg<context_type>::handle handle) {
+    handle.format(context_.parse_context(), context_);
+    return this->out();
+  }
+};
+
+template <typename T> struct printf_formatter {
+  template <typename ParseContext>
+  auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(const T& value, FormatContext& ctx) -> decltype(ctx.out()) {
+    internal::format_value(internal::get_container(ctx.out()), value);
+    return ctx.out();
+  }
+};
+
+/** This template formats data and writes the output to a writer. */
+template <typename OutputIt, typename Char> class basic_printf_context {
+ public:
+  /** The character type for the output. */
+  using char_type = Char;
+  using format_arg = basic_format_arg<basic_printf_context>;
+  template <typename T> using formatter_type = printf_formatter<T>;
+
+ private:
+  using format_specs = basic_format_specs<char_type>;
+
+  OutputIt out_;
+  basic_format_args<basic_printf_context> args_;
+  basic_parse_context<Char> parse_ctx_;
+
+  static void parse_flags(format_specs& specs, const Char*& it,
+                          const Char* end);
+
+  // Returns the argument with specified index or, if arg_index is equal
+  // to the maximum unsigned value, the next argument.
+  format_arg get_arg(unsigned arg_index = std::numeric_limits<unsigned>::max());
+
+  // Parses argument index, flags and width and returns the argument index.
+  unsigned parse_header(const Char*& it, const Char* end, format_specs& specs);
+
+ public:
+  /**
+   \rst
+   Constructs a ``printf_context`` object. References to the arguments and
+   the writer are stored in the context object so make sure they have
+   appropriate lifetimes.
+   \endrst
+   */
+  basic_printf_context(OutputIt out, basic_string_view<char_type> format_str,
+                       basic_format_args<basic_printf_context> args)
+      : out_(out), args_(args), parse_ctx_(format_str) {}
+
+  OutputIt out() { return out_; }
+  void advance_to(OutputIt it) { out_ = it; }
+
+  format_arg arg(unsigned id) const { return args_.get(id); }
+
+  basic_parse_context<Char>& parse_context() { return parse_ctx_; }
+
+  FMT_CONSTEXPR void on_error(const char* message) {
+    parse_ctx_.on_error(message);
+  }
+
+  /** Formats stored arguments and writes the output to the range. */
+  template <typename ArgFormatter =
+                printf_arg_formatter<internal::buffer_range<Char>>>
+  OutputIt format();
+};
+
+template <typename OutputIt, typename Char>
+void basic_printf_context<OutputIt, Char>::parse_flags(format_specs& specs,
+                                                       const Char*& it,
+                                                       const Char* end) {
+  for (; it != end; ++it) {
+    switch (*it) {
+    case '-':
+      specs.align = align::left;
+      break;
+    case '+':
+      specs.sign = sign::plus;
+      break;
+    case '0':
+      specs.fill[0] = '0';
+      break;
+    case ' ':
+      specs.sign = sign::space;
+      break;
+    case '#':
+      specs.alt = true;
+      break;
+    default:
+      return;
+    }
+  }
+}
+
+template <typename OutputIt, typename Char>
+typename basic_printf_context<OutputIt, Char>::format_arg
+basic_printf_context<OutputIt, Char>::get_arg(unsigned arg_index) {
+  if (arg_index == std::numeric_limits<unsigned>::max())
+    arg_index = parse_ctx_.next_arg_id();
+  else
+    parse_ctx_.check_arg_id(--arg_index);
+  return internal::get_arg(*this, arg_index);
+}
+
+template <typename OutputIt, typename Char>
+unsigned basic_printf_context<OutputIt, Char>::parse_header(
+    const Char*& it, const Char* end, format_specs& specs) {
+  unsigned arg_index = std::numeric_limits<unsigned>::max();
+  char_type c = *it;
+  if (c >= '0' && c <= '9') {
+    // Parse an argument index (if followed by '$') or a width possibly
+    // preceded with '0' flag(s).
+    internal::error_handler eh;
+    unsigned value = parse_nonnegative_int(it, end, eh);
+    if (it != end && *it == '$') {  // value is an argument index
+      ++it;
+      arg_index = value;
+    } else {
+      if (c == '0') specs.fill[0] = '0';
+      if (value != 0) {
+        // Nonzero value means that we parsed width and don't need to
+        // parse it or flags again, so return now.
+        specs.width = value;
+        return arg_index;
+      }
+    }
+  }
+  parse_flags(specs, it, end);
+  // Parse width.
+  if (it != end) {
+    if (*it >= '0' && *it <= '9') {
+      internal::error_handler eh;
+      specs.width = parse_nonnegative_int(it, end, eh);
+    } else if (*it == '*') {
+      ++it;
+      specs.width = visit_format_arg(
+          internal::printf_width_handler<char_type>(specs), get_arg());
+    }
+  }
+  return arg_index;
+}
+
+template <typename OutputIt, typename Char>
+template <typename ArgFormatter>
+OutputIt basic_printf_context<OutputIt, Char>::format() {
+  auto out = this->out();
+  const Char* start = parse_ctx_.begin();
+  const Char* end = parse_ctx_.end();
+  auto it = start;
+  while (it != end) {
+    char_type c = *it++;
+    if (c != '%') continue;
+    if (it != end && *it == c) {
+      out = std::copy(start, it, out);
+      start = ++it;
+      continue;
+    }
+    out = std::copy(start, it - 1, out);
+
+    format_specs specs;
+    specs.align = align::right;
+
+    // Parse argument index, flags and width.
+    unsigned arg_index = parse_header(it, end, specs);
+
+    // Parse precision.
+    if (it != end && *it == '.') {
+      ++it;
+      c = it != end ? *it : 0;
+      if ('0' <= c && c <= '9') {
+        internal::error_handler eh;
+        specs.precision = static_cast<int>(parse_nonnegative_int(it, end, eh));
+      } else if (c == '*') {
+        ++it;
+        specs.precision =
+            visit_format_arg(internal::printf_precision_handler(), get_arg());
+      } else {
+        specs.precision = 0;
+      }
+    }
+
+    format_arg arg = get_arg(arg_index);
+    if (specs.alt && visit_format_arg(internal::is_zero_int(), arg))
+      specs.alt = false;
+    if (specs.fill[0] == '0') {
+      if (arg.is_arithmetic())
+        specs.align = align::numeric;
+      else
+        specs.fill[0] = ' ';  // Ignore '0' flag for non-numeric types.
+    }
+
+    // Parse length and convert the argument to the required type.
+    c = it != end ? *it++ : 0;
+    char_type t = it != end ? *it : 0;
+    using internal::convert_arg;
+    switch (c) {
+    case 'h':
+      if (t == 'h') {
+        ++it;
+        t = it != end ? *it : 0;
+        convert_arg<signed char>(arg, t);
+      } else {
+        convert_arg<short>(arg, t);
+      }
+      break;
+    case 'l':
+      if (t == 'l') {
+        ++it;
+        t = it != end ? *it : 0;
+        convert_arg<long long>(arg, t);
+      } else {
+        convert_arg<long>(arg, t);
+      }
+      break;
+    case 'j':
+      convert_arg<intmax_t>(arg, t);
+      break;
+    case 'z':
+      convert_arg<std::size_t>(arg, t);
+      break;
+    case 't':
+      convert_arg<std::ptrdiff_t>(arg, t);
+      break;
+    case 'L':
+      // printf produces garbage when 'L' is omitted for long double, no
+      // need to do the same.
+      break;
+    default:
+      --it;
+      convert_arg<void>(arg, c);
+    }
+
+    // Parse type.
+    if (it == end) FMT_THROW(format_error("invalid format string"));
+    specs.type = static_cast<char>(*it++);
+    if (arg.is_integral()) {
+      // Normalize type.
+      switch (specs.type) {
+      case 'i':
+      case 'u':
+        specs.type = 'd';
+        break;
+      case 'c':
+        visit_format_arg(internal::char_converter<basic_printf_context>(arg),
+                         arg);
+        break;
+      }
+    }
+
+    start = it;
+
+    // Format argument.
+    visit_format_arg(ArgFormatter(out, specs, *this), arg);
+  }
+  return std::copy(start, it, out);
+}
+
+template <typename Char>
+using basic_printf_context_t =
+    basic_printf_context<std::back_insert_iterator<internal::buffer<Char>>,
+                         Char>;
+
+using printf_context = basic_printf_context_t<char>;
+using wprintf_context = basic_printf_context_t<wchar_t>;
+
+using printf_args = basic_format_args<printf_context>;
+using wprintf_args = basic_format_args<wprintf_context>;
+
+/**
+  \rst
+  Constructs an `~fmt::format_arg_store` object that contains references to
+  arguments and can be implicitly converted to `~fmt::printf_args`.
+  \endrst
+ */
+template <typename... Args>
+inline format_arg_store<printf_context, Args...> make_printf_args(
+    const Args&... args) {
+  return {args...};
+}
+
+/**
+  \rst
+  Constructs an `~fmt::format_arg_store` object that contains references to
+  arguments and can be implicitly converted to `~fmt::wprintf_args`.
+  \endrst
+ */
+template <typename... Args>
+inline format_arg_store<wprintf_context, Args...> make_wprintf_args(
+    const Args&... args) {
+  return {args...};
+}
+
+template <typename S, typename Char = char_t<S>>
+inline std::basic_string<Char> vsprintf(
+    const S& format, basic_format_args<basic_printf_context_t<Char>> args) {
+  basic_memory_buffer<Char> buffer;
+  printf(buffer, to_string_view(format), args);
+  return to_string(buffer);
+}
+
+/**
+  \rst
+  Formats arguments and returns the result as a string.
+
+  **Example**::
+
+    std::string message = fmt::sprintf("The answer is %d", 42);
+  \endrst
+*/
+template <typename S, typename... Args,
+          typename Char = enable_if_t<internal::is_string<S>::value, char_t<S>>>
+inline std::basic_string<Char> sprintf(const S& format, const Args&... args) {
+  using context = basic_printf_context_t<Char>;
+  return vsprintf(to_string_view(format), {make_format_args<context>(args...)});
+}
+
+template <typename S, typename Char = char_t<S>>
+inline int vfprintf(std::FILE* f, const S& format,
+                    basic_format_args<basic_printf_context_t<Char>> args) {
+  basic_memory_buffer<Char> buffer;
+  printf(buffer, to_string_view(format), args);
+  std::size_t size = buffer.size();
+  return std::fwrite(buffer.data(), sizeof(Char), size, f) < size
+             ? -1
+             : static_cast<int>(size);
+}
+
+/**
+  \rst
+  Prints formatted data to the file *f*.
+
+  **Example**::
+
+    fmt::fprintf(stderr, "Don't %s!", "panic");
+  \endrst
+ */
+template <typename S, typename... Args,
+          typename Char = enable_if_t<internal::is_string<S>::value, char_t<S>>>
+inline int fprintf(std::FILE* f, const S& format, const Args&... args) {
+  using context = basic_printf_context_t<Char>;
+  return vfprintf(f, to_string_view(format),
+                  {make_format_args<context>(args...)});
+}
+
+template <typename S, typename Char = char_t<S>>
+inline int vprintf(const S& format,
+                   basic_format_args<basic_printf_context_t<Char>> args) {
+  return vfprintf(stdout, to_string_view(format), args);
+}
+
+/**
+  \rst
+  Prints formatted data to ``stdout``.
+
+  **Example**::
+
+    fmt::printf("Elapsed time: %.2f seconds", 1.23);
+  \endrst
+ */
+template <typename S, typename... Args,
+          FMT_ENABLE_IF(internal::is_string<S>::value)>
+inline int printf(const S& format_str, const Args&... args) {
+  using context = basic_printf_context_t<char_t<S>>;
+  return vprintf(to_string_view(format_str),
+                 {make_format_args<context>(args...)});
+}
+
+template <typename S, typename Char = char_t<S>>
+inline int vfprintf(std::basic_ostream<Char>& os, const S& format,
+                    basic_format_args<basic_printf_context_t<Char>> args) {
+  basic_memory_buffer<Char> buffer;
+  printf(buffer, to_string_view(format), args);
+  internal::write(os, buffer);
+  return static_cast<int>(buffer.size());
+}
+
+/** Formats arguments and writes the output to the range. */
+template <typename ArgFormatter, typename Char,
+          typename Context =
+              basic_printf_context<typename ArgFormatter::iterator, Char>>
+typename ArgFormatter::iterator vprintf(internal::buffer<Char>& out,
+                                        basic_string_view<Char> format_str,
+                                        basic_format_args<Context> args) {
+  typename ArgFormatter::iterator iter(out);
+  Context(iter, format_str, args).template format<ArgFormatter>();
+  return iter;
+}
+
+/**
+  \rst
+  Prints formatted data to the stream *os*.
+
+  **Example**::
+
+    fmt::fprintf(cerr, "Don't %s!", "panic");
+  \endrst
+ */
+template <typename S, typename... Args, typename Char = char_t<S>>
+inline int fprintf(std::basic_ostream<Char>& os, const S& format_str,
+                   const Args&... args) {
+  using context = basic_printf_context_t<Char>;
+  return vfprintf(os, to_string_view(format_str),
+                  {make_format_args<context>(args...)});
+}
+FMT_END_NAMESPACE
+
+#endif  // FMT_PRINTF_H_

--- a/contrib/fmt/include/fmt/ranges.h
+++ b/contrib/fmt/include/fmt/ranges.h
@@ -1,0 +1,288 @@
+// Formatting library for C++ - experimental range support
+//
+// Copyright (c) 2012 - present, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+//
+// Copyright (c) 2018 - present, Remotion (Igor Schulz)
+// All Rights Reserved
+// {fmt} support for ranges, containers and types tuple interface.
+
+#ifndef FMT_RANGES_H_
+#define FMT_RANGES_H_
+
+#include <type_traits>
+#include "format.h"
+
+// output only up to N items from the range.
+#ifndef FMT_RANGE_OUTPUT_LENGTH_LIMIT
+#  define FMT_RANGE_OUTPUT_LENGTH_LIMIT 256
+#endif
+
+FMT_BEGIN_NAMESPACE
+
+template <typename Char> struct formatting_base {
+  template <typename ParseContext>
+  FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
+    return ctx.begin();
+  }
+};
+
+template <typename Char, typename Enable = void>
+struct formatting_range : formatting_base<Char> {
+  static FMT_CONSTEXPR_DECL const std::size_t range_length_limit =
+      FMT_RANGE_OUTPUT_LENGTH_LIMIT;  // output only up to N items from the
+                                      // range.
+  Char prefix;
+  Char delimiter;
+  Char postfix;
+  formatting_range() : prefix('{'), delimiter(','), postfix('}') {}
+  static FMT_CONSTEXPR_DECL const bool add_delimiter_spaces = true;
+  static FMT_CONSTEXPR_DECL const bool add_prepostfix_space = false;
+};
+
+template <typename Char, typename Enable = void>
+struct formatting_tuple : formatting_base<Char> {
+  Char prefix;
+  Char delimiter;
+  Char postfix;
+  formatting_tuple() : prefix('('), delimiter(','), postfix(')') {}
+  static FMT_CONSTEXPR_DECL const bool add_delimiter_spaces = true;
+  static FMT_CONSTEXPR_DECL const bool add_prepostfix_space = false;
+};
+
+namespace internal {
+
+template <typename RangeT, typename OutputIterator>
+OutputIterator copy(const RangeT& range, OutputIterator out) {
+  for (auto it = range.begin(), end = range.end(); it != end; ++it)
+    *out++ = *it;
+  return out;
+}
+
+template <typename OutputIterator>
+OutputIterator copy(const char* str, OutputIterator out) {
+  while (*str) *out++ = *str++;
+  return out;
+}
+
+template <typename OutputIterator>
+OutputIterator copy(char ch, OutputIterator out) {
+  *out++ = ch;
+  return out;
+}
+
+/// Return true value if T has std::string interface, like std::string_view.
+template <typename T> class is_like_std_string {
+  template <typename U>
+  static auto check(U* p)
+      -> decltype((void)p->find('a'), p->length(), (void)p->data(), int());
+  template <typename> static void check(...);
+
+ public:
+  static FMT_CONSTEXPR_DECL const bool value =
+      is_string<T>::value || !std::is_void<decltype(check<T>(nullptr))>::value;
+};
+
+template <typename Char>
+struct is_like_std_string<fmt::basic_string_view<Char>> : std::true_type {};
+
+template <typename... Ts> struct conditional_helper {};
+
+template <typename T, typename _ = void> struct is_range_ : std::false_type {};
+
+#if !FMT_MSC_VER || FMT_MSC_VER > 1800
+template <typename T>
+struct is_range_<
+    T, conditional_t<false,
+                     conditional_helper<decltype(std::declval<T>().begin()),
+                                        decltype(std::declval<T>().end())>,
+                     void>> : std::true_type {};
+#endif
+
+/// tuple_size and tuple_element check.
+template <typename T> class is_tuple_like_ {
+  template <typename U>
+  static auto check(U* p)
+      -> decltype(std::tuple_size<U>::value,
+                  (void)std::declval<typename std::tuple_element<0, U>::type>(),
+                  int());
+  template <typename> static void check(...);
+
+ public:
+  static FMT_CONSTEXPR_DECL const bool value =
+      !std::is_void<decltype(check<T>(nullptr))>::value;
+};
+
+// Check for integer_sequence
+#if defined(__cpp_lib_integer_sequence) || FMT_MSC_VER >= 1900
+template <typename T, T... N>
+using integer_sequence = std::integer_sequence<T, N...>;
+template <std::size_t... N> using index_sequence = std::index_sequence<N...>;
+template <std::size_t N>
+using make_index_sequence = std::make_index_sequence<N>;
+#else
+template <typename T, T... N> struct integer_sequence {
+  using value_type = T;
+
+  static FMT_CONSTEXPR std::size_t size() { return sizeof...(N); }
+};
+
+template <std::size_t... N>
+using index_sequence = integer_sequence<std::size_t, N...>;
+
+template <typename T, std::size_t N, T... Ns>
+struct make_integer_sequence : make_integer_sequence<T, N - 1, N - 1, Ns...> {};
+template <typename T, T... Ns>
+struct make_integer_sequence<T, 0, Ns...> : integer_sequence<T, Ns...> {};
+
+template <std::size_t N>
+using make_index_sequence = make_integer_sequence<std::size_t, N>;
+#endif
+
+template <class Tuple, class F, size_t... Is>
+void for_each(index_sequence<Is...>, Tuple&& tup, F&& f) FMT_NOEXCEPT {
+  using std::get;
+  // using free function get<I>(T) now.
+  const int _[] = {0, ((void)f(get<Is>(tup)), 0)...};
+  (void)_;  // blocks warnings
+}
+
+template <class T>
+FMT_CONSTEXPR make_index_sequence<std::tuple_size<T>::value> get_indexes(
+    T const&) {
+  return {};
+}
+
+template <class Tuple, class F> void for_each(Tuple&& tup, F&& f) {
+  const auto indexes = get_indexes(tup);
+  for_each(indexes, std::forward<Tuple>(tup), std::forward<F>(f));
+}
+
+template <typename Arg, FMT_ENABLE_IF(!is_like_std_string<
+                                      typename std::decay<Arg>::type>::value)>
+FMT_CONSTEXPR const char* format_str_quoted(bool add_space, const Arg&) {
+  return add_space ? " {}" : "{}";
+}
+
+template <typename Arg, FMT_ENABLE_IF(is_like_std_string<
+                                      typename std::decay<Arg>::type>::value)>
+FMT_CONSTEXPR const char* format_str_quoted(bool add_space, const Arg&) {
+  return add_space ? " \"{}\"" : "\"{}\"";
+}
+
+FMT_CONSTEXPR const char* format_str_quoted(bool add_space, const char*) {
+  return add_space ? " \"{}\"" : "\"{}\"";
+}
+FMT_CONSTEXPR const wchar_t* format_str_quoted(bool add_space, const wchar_t*) {
+  return add_space ? L" \"{}\"" : L"\"{}\"";
+}
+
+FMT_CONSTEXPR const char* format_str_quoted(bool add_space, const char) {
+  return add_space ? " '{}'" : "'{}'";
+}
+FMT_CONSTEXPR const wchar_t* format_str_quoted(bool add_space, const wchar_t) {
+  return add_space ? L" '{}'" : L"'{}'";
+}
+
+}  // namespace internal
+
+template <typename T> struct is_tuple_like {
+  static FMT_CONSTEXPR_DECL const bool value =
+      internal::is_tuple_like_<T>::value && !internal::is_range_<T>::value;
+};
+
+template <typename TupleT, typename Char>
+struct formatter<TupleT, Char, enable_if_t<fmt::is_tuple_like<TupleT>::value>> {
+ private:
+  // C++11 generic lambda for format()
+  template <typename FormatContext> struct format_each {
+    template <typename T> void operator()(const T& v) {
+      if (i > 0) {
+        if (formatting.add_prepostfix_space) {
+          *out++ = ' ';
+        }
+        out = internal::copy(formatting.delimiter, out);
+      }
+      out = format_to(out,
+                      internal::format_str_quoted(
+                          (formatting.add_delimiter_spaces && i > 0), v),
+                      v);
+      ++i;
+    }
+
+    formatting_tuple<Char>& formatting;
+    std::size_t& i;
+    typename std::add_lvalue_reference<decltype(
+        std::declval<FormatContext>().out())>::type out;
+  };
+
+ public:
+  formatting_tuple<Char> formatting;
+
+  template <typename ParseContext>
+  FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
+    return formatting.parse(ctx);
+  }
+
+  template <typename FormatContext = format_context>
+  auto format(const TupleT& values, FormatContext& ctx) -> decltype(ctx.out()) {
+    auto out = ctx.out();
+    std::size_t i = 0;
+    internal::copy(formatting.prefix, out);
+
+    internal::for_each(values, format_each<FormatContext>{formatting, i, out});
+    if (formatting.add_prepostfix_space) {
+      *out++ = ' ';
+    }
+    internal::copy(formatting.postfix, out);
+
+    return ctx.out();
+  }
+};
+
+template <typename T, typename Char> struct is_range {
+  static FMT_CONSTEXPR_DECL const bool value =
+      internal::is_range_<T>::value &&
+      !internal::is_like_std_string<T>::value &&
+      !std::is_convertible<T, std::basic_string<Char>>::value;
+};
+
+template <typename RangeT, typename Char>
+struct formatter<RangeT, Char,
+                 enable_if_t<fmt::is_range<RangeT, Char>::value>> {
+  formatting_range<Char> formatting;
+
+  template <typename ParseContext>
+  FMT_CONSTEXPR auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
+    return formatting.parse(ctx);
+  }
+
+  template <typename FormatContext>
+  typename FormatContext::iterator format(const RangeT& values,
+                                          FormatContext& ctx) {
+    auto out = internal::copy(formatting.prefix, ctx.out());
+    std::size_t i = 0;
+    for (auto it = values.begin(), end = values.end(); it != end; ++it) {
+      if (i > 0) {
+        if (formatting.add_prepostfix_space) *out++ = ' ';
+        out = internal::copy(formatting.delimiter, out);
+      }
+      out = format_to(out,
+                      internal::format_str_quoted(
+                          (formatting.add_delimiter_spaces && i > 0), *it),
+                      *it);
+      if (++i > formatting.range_length_limit) {
+        out = format_to(out, " ... <other elements>");
+        break;
+      }
+    }
+    if (formatting.add_prepostfix_space) *out++ = ' ';
+    return internal::copy(formatting.postfix, out);
+  }
+};
+
+FMT_END_NAMESPACE
+
+#endif  // FMT_RANGES_H_

--- a/contrib/fmt/include/fmt/safe-duration-cast.h
+++ b/contrib/fmt/include/fmt/safe-duration-cast.h
@@ -1,0 +1,293 @@
+/*
+ * For conversion between std::chrono::durations without undefined
+ * behaviour or erroneous results.
+ * This is a stripped down version of duration_cast, for inclusion in fmt.
+ * See https://github.com/pauldreik/safe_duration_cast
+ *
+ * Copyright Paul Dreik 2019
+ *
+ * This file is licensed under the fmt license, see format.h
+ */
+
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <type_traits>
+
+#include "format.h"
+
+FMT_BEGIN_NAMESPACE
+
+namespace safe_duration_cast {
+
+template <typename To, typename From,
+          FMT_ENABLE_IF(!std::is_same<From, To>::value &&
+                        std::numeric_limits<From>::is_signed ==
+                            std::numeric_limits<To>::is_signed)>
+FMT_CONSTEXPR To lossless_integral_conversion(const From from, int& ec) {
+  ec = 0;
+  using F = std::numeric_limits<From>;
+  using T = std::numeric_limits<To>;
+  static_assert(F::is_integer, "From must be integral");
+  static_assert(T::is_integer, "To must be integral");
+
+  // A and B are both signed, or both unsigned.
+  if (F::digits <= T::digits) {
+    // From fits in To without any problem.
+  } else {
+    // From does not always fit in To, resort to a dynamic check.
+    if (from < T::min() || from > T::max()) {
+      // outside range.
+      ec = 1;
+      return {};
+    }
+  }
+  return static_cast<To>(from);
+}
+
+/**
+ * converts From to To, without loss. If the dynamic value of from
+ * can't be converted to To without loss, ec is set.
+ */
+template <typename To, typename From,
+          FMT_ENABLE_IF(!std::is_same<From, To>::value &&
+                        std::numeric_limits<From>::is_signed !=
+                            std::numeric_limits<To>::is_signed)>
+FMT_CONSTEXPR To lossless_integral_conversion(const From from, int& ec) {
+  ec = 0;
+  using F = std::numeric_limits<From>;
+  using T = std::numeric_limits<To>;
+  static_assert(F::is_integer, "From must be integral");
+  static_assert(T::is_integer, "To must be integral");
+
+  if (F::is_signed && !T::is_signed) {
+    // From may be negative, not allowed!
+    if (from < 0) {
+      ec = 1;
+      return {};
+    }
+
+    // From is positive. Can it always fit in To?
+    if (F::digits <= T::digits) {
+      // yes, From always fits in To.
+    } else {
+      // from may not fit in To, we have to do a dynamic check
+      if (from > static_cast<From>(T::max())) {
+        ec = 1;
+        return {};
+      }
+    }
+  }
+
+  if (!F::is_signed && T::is_signed) {
+    // can from be held in To?
+    if (F::digits < T::digits) {
+      // yes, From always fits in To.
+    } else {
+      // from may not fit in To, we have to do a dynamic check
+      if (from > static_cast<From>(T::max())) {
+        // outside range.
+        ec = 1;
+        return {};
+      }
+    }
+  }
+
+  // reaching here means all is ok for lossless conversion.
+  return static_cast<To>(from);
+
+}  // function
+
+template <typename To, typename From,
+          FMT_ENABLE_IF(std::is_same<From, To>::value)>
+FMT_CONSTEXPR To lossless_integral_conversion(const From from, int& ec) {
+  ec = 0;
+  return from;
+}  // function
+
+// clang-format off
+/**
+ * converts From to To if possible, otherwise ec is set.
+ *
+ * input                            |    output
+ * ---------------------------------|---------------
+ * NaN                              | NaN
+ * Inf                              | Inf
+ * normal, fits in output           | converted (possibly lossy)
+ * normal, does not fit in output   | ec is set
+ * subnormal                        | best effort
+ * -Inf                             | -Inf
+ */
+// clang-format on
+template <typename To, typename From,
+          FMT_ENABLE_IF(!std::is_same<From, To>::value)>
+FMT_CONSTEXPR To safe_float_conversion(const From from, int& ec) {
+  ec = 0;
+  using T = std::numeric_limits<To>;
+  static_assert(std::is_floating_point<From>::value, "From must be floating");
+  static_assert(std::is_floating_point<To>::value, "To must be floating");
+
+  // catch the only happy case
+  if (std::isfinite(from)) {
+    if (from >= T::lowest() && from <= T::max()) {
+      return static_cast<To>(from);
+    }
+    // not within range.
+    ec = 1;
+    return {};
+  }
+
+  // nan and inf will be preserved
+  return static_cast<To>(from);
+}  // function
+
+template <typename To, typename From,
+          FMT_ENABLE_IF(std::is_same<From, To>::value)>
+FMT_CONSTEXPR To safe_float_conversion(const From from, int& ec) {
+  ec = 0;
+  static_assert(std::is_floating_point<From>::value, "From must be floating");
+  return from;
+}
+
+/**
+ * safe duration cast between integral durations
+ */
+template <typename To, typename FromRep, typename FromPeriod,
+          FMT_ENABLE_IF(std::is_integral<FromRep>::value),
+          FMT_ENABLE_IF(std::is_integral<typename To::rep>::value)>
+To safe_duration_cast(std::chrono::duration<FromRep, FromPeriod> from,
+                      int& ec) {
+  using From = std::chrono::duration<FromRep, FromPeriod>;
+  ec = 0;
+  // the basic idea is that we need to convert from count() in the from type
+  // to count() in the To type, by multiplying it with this:
+  using Factor = std::ratio_divide<typename From::period, typename To::period>;
+
+  static_assert(Factor::num > 0, "num must be positive");
+  static_assert(Factor::den > 0, "den must be positive");
+
+  // the conversion is like this: multiply from.count() with Factor::num
+  // /Factor::den and convert it to To::rep, all this without
+  // overflow/underflow. let's start by finding a suitable type that can hold
+  // both To, From and Factor::num
+  using IntermediateRep =
+      typename std::common_type<typename From::rep, typename To::rep,
+                                decltype(Factor::num)>::type;
+
+  // safe conversion to IntermediateRep
+  IntermediateRep count =
+      lossless_integral_conversion<IntermediateRep>(from.count(), ec);
+  if (ec) {
+    return {};
+  }
+  // multiply with Factor::num without overflow or underflow
+  if (Factor::num != 1) {
+    constexpr auto max1 =
+        std::numeric_limits<IntermediateRep>::max() / Factor::num;
+    if (count > max1) {
+      ec = 1;
+      return {};
+    }
+    constexpr auto min1 =
+        std::numeric_limits<IntermediateRep>::min() / Factor::num;
+    if (count < min1) {
+      ec = 1;
+      return {};
+    }
+    count *= Factor::num;
+  }
+
+  // this can't go wrong, right? den>0 is checked earlier.
+  if (Factor::den != 1) {
+    count /= Factor::den;
+  }
+  // convert to the to type, safely
+  using ToRep = typename To::rep;
+  const ToRep tocount = lossless_integral_conversion<ToRep>(count, ec);
+  if (ec) {
+    return {};
+  }
+  return To{tocount};
+}
+
+/**
+ * safe duration_cast between floating point durations
+ */
+template <typename To, typename FromRep, typename FromPeriod,
+          FMT_ENABLE_IF(std::is_floating_point<FromRep>::value),
+          FMT_ENABLE_IF(std::is_floating_point<typename To::rep>::value)>
+To safe_duration_cast(std::chrono::duration<FromRep, FromPeriod> from,
+                      int& ec) {
+  using From = std::chrono::duration<FromRep, FromPeriod>;
+  ec = 0;
+  if (std::isnan(from.count())) {
+    // nan in, gives nan out. easy.
+    return To{std::numeric_limits<typename To::rep>::quiet_NaN()};
+  }
+  // maybe we should also check if from is denormal, and decide what to do about
+  // it.
+
+  // +-inf should be preserved.
+  if (std::isinf(from.count())) {
+    return To{from.count()};
+  }
+
+  // the basic idea is that we need to convert from count() in the from type
+  // to count() in the To type, by multiplying it with this:
+  using Factor = std::ratio_divide<typename From::period, typename To::period>;
+
+  static_assert(Factor::num > 0, "num must be positive");
+  static_assert(Factor::den > 0, "den must be positive");
+
+  // the conversion is like this: multiply from.count() with Factor::num
+  // /Factor::den and convert it to To::rep, all this without
+  // overflow/underflow. let's start by finding a suitable type that can hold
+  // both To, From and Factor::num
+  using IntermediateRep =
+      typename std::common_type<typename From::rep, typename To::rep,
+                                decltype(Factor::num)>::type;
+
+  // force conversion of From::rep -> IntermediateRep to be safe,
+  // even if it will never happen be narrowing in this context.
+  IntermediateRep count =
+      safe_float_conversion<IntermediateRep>(from.count(), ec);
+  if (ec) {
+    return {};
+  }
+
+  // multiply with Factor::num without overflow or underflow
+  if (Factor::num != 1) {
+    constexpr auto max1 = std::numeric_limits<IntermediateRep>::max() /
+                          static_cast<IntermediateRep>(Factor::num);
+    if (count > max1) {
+      ec = 1;
+      return {};
+    }
+    constexpr auto min1 = std::numeric_limits<IntermediateRep>::lowest() /
+                          static_cast<IntermediateRep>(Factor::num);
+    if (count < min1) {
+      ec = 1;
+      return {};
+    }
+    count *= static_cast<IntermediateRep>(Factor::num);
+  }
+
+  // this can't go wrong, right? den>0 is checked earlier.
+  if (Factor::den != 1) {
+    using common_t = typename std::common_type<IntermediateRep, intmax_t>::type;
+    count /= static_cast<common_t>(Factor::den);
+  }
+
+  // convert to the to type, safely
+  using ToRep = typename To::rep;
+
+  const ToRep tocount = safe_float_conversion<ToRep>(count, ec);
+  if (ec) {
+    return {};
+  }
+  return To{tocount};
+}
+
+}  // namespace safe_duration_cast
+
+FMT_END_NAMESPACE

--- a/src/db-copy.cpp
+++ b/src/db-copy.cpp
@@ -1,4 +1,3 @@
-#include <boost/format.hpp>
 #include <cassert>
 #include <cstdio>
 #include <future>
@@ -6,8 +5,6 @@
 
 #include "db-copy.hpp"
 #include "pgsql.hpp"
-
-using fmt = boost::format;
 
 db_copy_thread_t::db_copy_thread_t(std::string const &conninfo)
 : m_conninfo(conninfo)

--- a/src/expire-tiles.cpp
+++ b/src/expire-tiles.cpp
@@ -14,9 +14,8 @@
 #include <cstring>
 #include <string>
 
-#include <boost/format.hpp>
-
 #include "expire-tiles.hpp"
+#include "format.hpp"
 #include "options.hpp"
 #include "reprojection.hpp"
 #include "table.hpp"
@@ -423,19 +422,15 @@ int expire_tiles::from_db(table_t *table, osmid_t osm_id)
 void expire_tiles::merge_and_destroy(expire_tiles &other)
 {
     if (map_width != other.map_width) {
-        throw std::runtime_error(
-            (boost::format("Unable to merge tile expiry sets when "
-                           "map_width does not match: %1% != %2%.") %
-             map_width % other.map_width)
-                .str());
+        throw std::runtime_error{"Unable to merge tile expiry sets when "
+                                 "map_width does not match: {} != {}."_format(
+                                     map_width, other.map_width)};
     }
 
     if (tile_width != other.tile_width) {
-        throw std::runtime_error(
-            (boost::format("Unable to merge tile expiry sets when "
-                           "tile_width does not match: %1% != %2%.") %
-             tile_width % other.tile_width)
-                .str());
+        throw std::runtime_error{"Unable to merge tile expiry sets when "
+                                 "tile_width does not match: {} != {}."_format(
+                                     tile_width, other.tile_width)};
     }
 
     if (m_dirty_tiles.size() == 0) {

--- a/src/format.hpp
+++ b/src/format.hpp
@@ -1,0 +1,9 @@
+#ifndef OSM2PGSQL_FORMAT_HPP
+#define OSM2PGSQL_FORMAT_HPP
+
+#define FMT_HEADER_ONLY
+#include <fmt/format.h>
+
+using namespace fmt::literals;
+
+#endif // OSM2PGSQL_FORMAT_HPP

--- a/src/gazetteer-style.hpp
+++ b/src/gazetteer-style.hpp
@@ -6,7 +6,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/format.hpp>
 #include <osmium/osm/metadata_options.hpp>
 
 #include "db-copy.hpp"

--- a/src/geometry-processor.cpp
+++ b/src/geometry-processor.cpp
@@ -1,3 +1,4 @@
+#include "format.hpp"
 #include "geometry-processor.hpp"
 #include "middle.hpp"
 #include "options.hpp"
@@ -6,8 +7,6 @@
 #include "processor-polygon.hpp"
 #include "reprojection.hpp"
 
-#include <boost/format.hpp>
-#include <boost/optional.hpp>
 #include <memory>
 #include <stdexcept>
 
@@ -23,11 +22,9 @@ geometry_processor::create(const std::string &type, const options_t *options)
     } else if (type == "polygon") {
         ptr = std::make_shared<processor_polygon>(options->projection);
     } else {
-        throw std::runtime_error(
-            (boost::format("Unable to construct geometry processor "
-                           "because type `%1%' is not known.") %
-             type)
-                .str());
+        throw std::runtime_error{
+            "Unable to construct geometry processor "
+            "because type `{}' is not known."_format(type)};
     }
 
     return ptr;

--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -16,12 +16,12 @@
 #include <ctime>
 #include <functional>
 
-#include <boost/format.hpp>
 #include <osmium/builder/osm_object_builder.hpp>
 #include <osmium/memory/buffer.hpp>
 
 #include <libpq-fe.h>
 
+#include "format.hpp"
 #include "middle-pgsql.hpp"
 #include "node-persistent-cache.hpp"
 #include "node-ram-cache.hpp"
@@ -178,7 +178,7 @@ void middle_pgsql_t::table_desc::stop(std::string conninfo, bool droptemp,
     pg_conn_t sql_conn(conninfo);
 
     if (droptemp) {
-        sql_conn.exec("DROP TABLE %1%", name());
+        sql_conn.exec("DROP TABLE {}"_format(name()));
     } else if (build_indexes && !m_array_indexes.empty()) {
         fprintf(stderr, "Building index on table: %s\n", name());
         sql_conn.exec(m_array_indexes);
@@ -682,7 +682,7 @@ idlist_t middle_query_pgsql_t::relations_using_way(osmid_t way_id) const
 void middle_pgsql_t::analyze()
 {
     for (auto &t : tables) {
-        m_query_conn->exec("ANALYZE %1%", t.name());
+        m_query_conn->exec("ANALYZE {}"_format(t.name()));
     }
 }
 
@@ -722,8 +722,8 @@ void middle_pgsql_t::start()
         m_query_conn->exec("SET client_min_messages = WARNING");
         for (auto &table : tables) {
             fprintf(stderr, "Setting up table: %s\n", table.name());
-            m_query_conn->exec("DROP TABLE IF EXISTS %1% CASCADE",
-                               table.name());
+            m_query_conn->exec(
+                "DROP TABLE IF EXISTS {} CASCADE"_format(table.name()));
             m_query_conn->exec(table.m_create);
         }
 

--- a/src/node-ram-cache.cpp
+++ b/src/node-ram-cache.cpp
@@ -4,18 +4,15 @@
 */
 
 #include "config.h"
-
-#include <new>
-#include <stdexcept>
-
-#include <cstdio>
-#include <cstdlib>
-
-#include <boost/format.hpp>
-
+#include "format.hpp"
 #include "node-ram-cache.hpp"
 #include "osmtypes.hpp"
 #include "util.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <new>
+#include <stdexcept>
 
 /* Here we use a similar storage structure as middle-ram, except we allow
  * the array to be lossy so we can cap the total memory usage. Hence it is a
@@ -458,12 +455,9 @@ void node_ram_cache::set(osmid_t id, const osmium::Location &coord)
         set_sparse(id, coord);
     } else {
         // Command line options always have ALLOC_DENSE | ALLOC_SPARSE
-        throw std::logic_error(
-            (boost::format(
-                 "Unexpected cache strategy in node_ram_cache::set with "
-                 "allocStrategy %1%") %
-             allocStrategy)
-                .str());
+        throw std::logic_error{
+            "Unexpected cache strategy in node_ram_cache::set with "
+            "allocStrategy {}"_format(allocStrategy)};
     }
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,8 +1,8 @@
+#include "format.hpp"
 #include "options.hpp"
 #include "sprompt.hpp"
 
 #include <algorithm>
-#include <boost/format.hpp>
 #include <cstdio>
 #include <cstring>
 #include <getopt.h>
@@ -81,11 +81,8 @@ const struct option long_options[] = {
 
 void short_usage(char *arg0)
 {
-    throw std::runtime_error(
-        (boost::format("Usage error. For further information see:\n\t%1% "
-                       "-h|--help\n") %
-         program_name(arg0))
-            .str());
+    throw std::runtime_error{"Usage error. For further information see:\n"
+                             "\t{} -h|--help\n"_format(program_name(arg0))};
 }
 
 void long_usage(char *arg0, bool verbose = false)
@@ -476,10 +473,8 @@ options_t::options_t(int argc, char *argv[]) : options_t()
             } else if (strcmp(optarg, "optimized") == 0) {
                 alloc_chunkwise = ALLOC_DENSE | ALLOC_SPARSE;
             } else {
-                throw std::runtime_error(
-                    (boost::format("Unrecognized cache strategy %1%.\n") %
-                     optarg)
-                        .str());
+                throw std::runtime_error{
+                    "Unrecognized cache strategy {}.\n"_format(optarg)};
             }
             break;
         case 205:

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -42,7 +42,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/format.hpp>
 #include <libpq-fe.h>
 
 int main(int argc, char *argv[])

--- a/src/output-gazetteer.cpp
+++ b/src/output-gazetteer.cpp
@@ -1,6 +1,6 @@
-#include <boost/format.hpp>
 #include <libpq-fe.h>
 
+#include "format.hpp"
 #include "middle.hpp"
 #include "options.hpp"
 #include "osmtypes.hpp"
@@ -42,9 +42,9 @@ void output_gazetteer_t::delete_unused_classes(char const *osm_type,
     if (!clslist.empty()) {
         clslist[clslist.size() - 1] = '\0';
         // Delete places where classes have disappeared for this object.
-        m_conn->exec("DELETE FROM place WHERE osm_type = '%1%' "
-                     "AND osm_id = %2% and class = any(ARRAY[%3%])",
-                     osm_type, osm_id, clslist);
+        m_conn->exec("DELETE FROM place WHERE osm_type = '{}'"
+                     " AND osm_id = {} and class = any(ARRAY[{}])"_format(
+                         osm_type, osm_id, clslist));
     }
 }
 
@@ -85,9 +85,7 @@ int output_gazetteer_t::start()
             "  admin_level SMALLINT,"
             "  address HSTORE,"
             "  extratags HSTORE," +
-            (boost::format("  geometry Geometry(Geometry,%1%) NOT NULL") % srid)
-                .str() +
-            ")";
+            "  geometry Geometry(Geometry,{}) NOT NULL"_format(srid) + ")";
         if (m_options.tblsmain_data) {
             sql += " TABLESPACE " + m_options.tblsmain_data.get();
         }

--- a/src/output-gazetteer.hpp
+++ b/src/output-gazetteer.hpp
@@ -4,7 +4,6 @@
 #include <memory>
 #include <string>
 
-#include <boost/format.hpp>
 #include <osmium/memory/buffer.hpp>
 
 #include "db-copy.hpp"

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1,15 +1,15 @@
-#include "output.hpp"
 #include "db-copy.hpp"
+#include "format.hpp"
 #include "output-gazetteer.hpp"
 #include "output-multi.hpp"
 #include "output-null.hpp"
 #include "output-pgsql.hpp"
+#include "output.hpp"
 #include "taginfo-impl.hpp"
 
 #include <cstring>
 #include <stdexcept>
 
-#include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 
@@ -121,10 +121,9 @@ parse_multi_config(std::shared_ptr<middle_query_t> const &mid,
         }
 
     } catch (const std::exception &e) {
-        throw std::runtime_error(
-            (boost::format("Unable to parse multi config file `%1%': %2%") %
-             file_name % e.what())
-                .str());
+        throw std::runtime_error{
+            "Unable to parse multi config file `{}': {}"_format(file_name,
+                                                                e.what())};
     }
 
     return outputs;
@@ -155,11 +154,10 @@ output_t::create_outputs(std::shared_ptr<middle_query_t> const &mid,
         outputs = parse_multi_config(mid, options, copy_thread);
 
     } else {
-        throw std::runtime_error(
-            (boost::format("Output backend `%1%' not recognised. Should be one "
-                           "of [pgsql, gazetteer, null, multi].\n") %
-             options.output_backend)
-                .str());
+        throw std::runtime_error{
+            "Output backend `{}' not recognised. Should be one "
+            "of [pgsql, gazetteer, null, multi].\n"_format(
+                options.output_backend)};
     }
 
     return outputs;

--- a/src/parse-osmium.cpp
+++ b/src/parse-osmium.cpp
@@ -20,8 +20,7 @@
 #-----------------------------------------------------------------------------
 */
 
-#include <boost/format.hpp>
-
+#include "format.hpp"
 #include "osmdata.hpp"
 #include "parse-osmium.hpp"
 #include "reprojection.hpp"
@@ -135,10 +134,10 @@ void parse_osmium_t::stream_file(const std::string &filename,
     osmium::io::File infile(filename, osmium_format);
 
     if (infile.format() == osmium::io::file_format::unknown) {
-        throw std::runtime_error(
+        throw std::runtime_error{
             fmt == "auto"
-                ? "Cannot detect file format. Try using -r."
-                : ((boost::format("Unknown file format '%1%'.") % fmt).str()));
+                ? std::string{"Cannot detect file format. Try using -r."}
+                : "Unknown file format '{}'."_format(fmt)};
     }
 
     fprintf(stderr, "Using %s parser.\n",

--- a/src/pgsql.cpp
+++ b/src/pgsql.cpp
@@ -1,7 +1,6 @@
 /* Helper functions for the postgresql connections */
 #include "pgsql.hpp"
 
-#include <boost/format.hpp>
 #include <cstdarg>
 #include <cstdio>
 

--- a/src/pgsql.hpp
+++ b/src/pgsql.hpp
@@ -3,7 +3,6 @@
 
 /* Helper functions for PostgreSQL access */
 
-#include <boost/format.hpp>
 #include <cstring>
 #include <libpq-fe.h>
 #include <memory>
@@ -42,39 +41,11 @@ public:
 
     pg_result_t query(ExecStatusType expect, std::string const &sql) const;
 
-    template <typename... ARGS>
-    pg_result_t query(ExecStatusType expect, std::string const &fmt,
-                      ARGS &&... args) const
-    {
-        boost::format formatter{fmt};
-        format_sql(formatter, std::forward<ARGS>(args)...);
-        return query(expect, formatter.str());
-    }
-
     void exec(char const *sql) const;
 
     void exec(std::string const &sql) const;
 
-    template <typename... ARGS>
-    void exec(char const *fmt, ARGS &&... args) const
-    {
-        query(PGRES_COMMAND_OK, fmt, std::forward<ARGS>(args)...);
-    }
-
 private:
-    template <typename T, typename... ARGS>
-    static void format_sql(boost::format &fmt, T arg, ARGS &&... args)
-    {
-        fmt % arg;
-        format_sql(fmt, std::forward<ARGS>(args)...);
-    }
-
-    template <typename T>
-    static void format_sql(boost::format &fmt, T arg)
-    {
-        fmt % arg;
-    }
-
     PGconn *m_conn;
 };
 

--- a/src/processor-point.cpp
+++ b/src/processor-point.cpp
@@ -1,7 +1,5 @@
 #include <memory>
 
-#include <boost/format.hpp>
-
 #include "processor-point.hpp"
 #include "util.hpp"
 

--- a/src/taginfo.cpp
+++ b/src/taginfo.cpp
@@ -1,7 +1,7 @@
+#include "format.hpp"
 #include "taginfo-impl.hpp"
 #include "util.hpp"
 
-#include <boost/format.hpp>
 #include <cassert>
 #include <cerrno>
 #include <cstring>
@@ -120,10 +120,8 @@ int read_style_file(const std::string &filename, export_list *exlist)
 
     in = fopen(filename.c_str(), "rt");
     if (!in) {
-        throw std::runtime_error(
-            (boost::format("Couldn't open style file '%1%': %2%") % filename %
-             strerror(errno))
-                .str());
+        throw std::runtime_error{"Couldn't open style file '{}': {}"_format(
+            filename, std::strerror(errno))};
     }
 
     //for each line of the style file
@@ -197,9 +195,8 @@ int read_style_file(const std::string &filename, export_list *exlist)
         //do we really want to completely quit on an unusable line?
         if (!kept) {
             fclose(in);
-            throw std::runtime_error(
-                (boost::format("Weird style line %1%:%2%") % filename % lineno)
-                    .str());
+            throw std::runtime_error{
+                "Weird style line {}:{}"_format(filename, lineno)};
         }
         num_read++;
     }
@@ -207,8 +204,7 @@ int read_style_file(const std::string &filename, export_list *exlist)
     if (ferror(in)) {
         int err = errno;
         fclose(in);
-        throw std::runtime_error(
-            (boost::format("%1%: %2%") % filename % strerror(err)).str());
+        throw std::runtime_error{"{}: {}"_format(filename, std::strerror(err))};
     }
     fclose(in);
     if (num_read == 0) {

--- a/src/tagtransform-lua.cpp
+++ b/src/tagtransform-lua.cpp
@@ -5,8 +5,8 @@ extern "C"
 }
 
 #include <boost/filesystem.hpp>
-#include <boost/format.hpp>
 
+#include "format.hpp"
 #include "options.hpp"
 #include "tagtransform-lua.hpp"
 
@@ -38,10 +38,8 @@ void lua_tagtransform_t::open_style()
     L = luaL_newstate();
     luaL_openlibs(L);
     if (luaL_dofile(L, m_lua_file.c_str())) {
-        throw std::runtime_error(
-            (boost::format("Lua tag transform style error: %1%") %
-             lua_tostring(L, -1))
-                .str());
+        throw std::runtime_error{
+            "Lua tag transform style error: {}"_format(lua_tostring(L, -1))};
     }
 
     check_lua_function_exists(m_node_func);
@@ -64,11 +62,9 @@ void lua_tagtransform_t::check_lua_function_exists(const std::string &func_name)
 {
     lua_getglobal(L, func_name.c_str());
     if (!lua_isfunction(L, -1)) {
-        throw std::runtime_error(
-            (boost::format(
-                 "Tag transform style does not contain a function %1%") %
-             func_name)
-                .str());
+        throw std::runtime_error{
+            "Tag transform style does not contain a function {}"_format(
+                func_name)};
     }
     lua_pop(L, 1);
 }
@@ -114,11 +110,8 @@ bool lua_tagtransform_t::filter_tags(osmium::OSMObject const &o, int *polygon,
 
     if (lua_pcall(L, 2, (o.type() == osmium::item_type::way) ? 4 : 2, 0)) {
         /* lua function failed */
-        throw std::runtime_error(
-            (boost::format("Failed to execute lua function for basic tag "
-                           "processing: %1%") %
-             lua_tostring(L, -1))
-                .str());
+        throw std::runtime_error{"Failed to execute lua function for basic tag "
+                                 "processing: {}"_format(lua_tostring(L, -1))};
     }
 
     if (o.type() == osmium::item_type::way) {
@@ -138,21 +131,17 @@ bool lua_tagtransform_t::filter_tags(osmium::OSMObject const &o, int *polygon,
         const char *value = lua_tostring(L, -1);
         if (key == nullptr) {
             int ltype = lua_type(L, -2);
-            throw std::runtime_error(
-                (boost::format(
-                     "Basic tag processing returned NULL key. Possibly this is "
-                     "due an incorrect data type '%1%'.") %
-                 lua_typename(L, ltype))
-                    .str());
+            throw std::runtime_error{
+                "Basic tag processing returned NULL key. Possibly this is "
+                "due an incorrect data type '{}'."_format(
+                    lua_typename(L, ltype))};
         }
         if (value == nullptr) {
             int ltype = lua_type(L, -1);
-            throw std::runtime_error(
-                (boost::format(
-                     "Basic tag processing returned NULL value. Possibly this "
-                     "is due an incorrect data type '%1%'.") %
-                 lua_typename(L, ltype))
-                    .str());
+            throw std::runtime_error{
+                "Basic tag processing returned NULL value. Possibly this "
+                "is due an incorrect data type '{}'."_format(
+                    lua_typename(L, ltype))};
         }
         out_tags.add_tag(key, value);
         lua_pop(L, 1);
@@ -207,11 +196,9 @@ bool lua_tagtransform_t::filter_rel_member_tags(
 
     if (lua_pcall(L, 4, 6, 0)) {
         /* lua function failed */
-        throw std::runtime_error(
-            (boost::format("Failed to execute lua function for relation tag "
-                           "processing: %1%") %
-             lua_tostring(L, -1))
-                .str());
+        throw std::runtime_error{
+            "Failed to execute lua function for relation tag "
+            "processing: {}"_format(lua_tostring(L, -1))};
     }
 
     *roads = (int)lua_tointeger(L, -1);

--- a/tests/test-db-copy-mgr.cpp
+++ b/tests/test-db-copy-mgr.cpp
@@ -13,8 +13,8 @@ static std::shared_ptr<db_target_descr_t> setup_table(std::string const &cols)
 {
     auto conn = db.connect();
     conn.exec("DROP TABLE IF EXISTS test_copy_mgr");
-    conn.exec(boost::format("CREATE TABLE test_copy_mgr (id int8%1%%2%)") %
-              (cols.empty() ? "" : ",") % cols);
+    conn.exec("CREATE TABLE test_copy_mgr (id int8{}{})"_format(
+        cols.empty() ? "" : ",", cols));
 
     auto table = std::make_shared<db_target_descr_t>();
     table->name = "test_copy_mgr";
@@ -182,9 +182,9 @@ TEST_CASE("db_copy_mgr_t")
 
         auto c = db.connect();
 
-        auto sql = boost::format("SELECT h->'%1%' from test_copy_mgr");
         for (auto const &v : values) {
-            auto res = c.require_scalar<std::string>((sql % v.first).str());
+            auto const res = c.require_scalar<std::string>(
+                "SELECT h->'{}' FROM test_copy_mgr"_format(v.first));
             CHECK(res == v.second);
         }
     }

--- a/tests/test-output-gazetteer.cpp
+++ b/tests/test-output-gazetteer.cpp
@@ -1,7 +1,5 @@
 #include <catch.hpp>
 
-#include <boost/format.hpp>
-
 #include "common-import.hpp"
 #include "common-options.hpp"
 
@@ -12,18 +10,19 @@ static options_t options() { return testing::opt_t().gazetteer(); }
 static pg::result_t require_place(pg::conn_t const &conn, char type, osmid_t id,
                                   char const *cls, char const *typ)
 {
-    auto sql = boost::format("SELECT * FROM place"
-                             " WHERE osm_type = '%1%' AND osm_id = %2%"
-                             " AND class = '%3%' AND type = '%4%'");
-    return conn.require_row((sql % type % id % cls % typ).str());
+    return conn.require_row(
+        "SELECT * FROM place"
+        " WHERE osm_type = '{}' AND osm_id = {}"
+        " AND class = '{}' AND type = '{}'"_format(type, id, cls, typ));
 }
 
 static void require_place_not(pg::conn_t const &conn, char type, osmid_t id,
                               char const *cls)
 {
-    auto where = boost::format("osm_type = '%1%' AND osm_id = %2%"
-                               " AND class = '%3%'");
-    REQUIRE(conn.get_count("place", (where % type % id % cls).str()) == 0);
+    REQUIRE(
+        conn.get_count(
+            "place", "osm_type = '{}' AND osm_id = {} AND class = '{}'"_format(
+                         type, id, cls)) == 0);
 }
 
 TEST_CASE("output_gazetteer_t import")

--- a/tests/test-output-multi-point-multi-table.cpp
+++ b/tests/test-output-multi-point-multi-table.cpp
@@ -33,7 +33,7 @@ TEST_CASE("parse point")
 
     // let's make lots of tables!
     for (int i = 0; i < 10; ++i) {
-        std::string name = (boost::format("foobar_%d") % i).str();
+        std::string const name{"foobar_{}"_format(i)};
 
         auto processor = geometry_processor::create("point", &options);
 
@@ -51,7 +51,7 @@ TEST_CASE("parse point")
     auto conn = db.db().connect();
 
     for (int i = 0; i < 10; ++i) {
-        std::string buf = (boost::format("foobar_%d") % i).str();
+        std::string const buf{"foobar_{}"_format(i)};
         char const *name = buf.c_str();
 
         conn.require_has_table(name);

--- a/tests/test-output-pgsql-z_order.cpp
+++ b/tests/test-output-pgsql-z_order.cpp
@@ -16,11 +16,10 @@ TEST_CASE("compute Z order")
                               "tertiary"};
 
     for (unsigned i = 0; i < 5; ++i) {
-        auto sql = boost::format("SELECT highway FROM osm2pgsql_test_line"
-                                 " WHERE layer IS NULL ORDER BY z_order DESC"
-                                 " LIMIT 1 OFFSET %1%") %
-                   i;
-        REQUIRE(expected[i] == conn.require_scalar<std::string>(sql.str()));
+        auto const sql = "SELECT highway FROM osm2pgsql_test_line"
+                         " WHERE layer IS NULL ORDER BY z_order DESC"
+                         " LIMIT 1 OFFSET {}"_format(i);
+        REQUIRE(expected[i] == conn.require_scalar<std::string>(sql));
     }
 
     REQUIRE("residential" == conn.require_scalar<std::string>(


### PR DESCRIPTION
The fmt library is included in contrib. Boost::format is not needed any more.

See #398 