### PR TITLE
Fix deletion on update in gazetteer

### DIFF
--- a/src/db-copy-mgr.hpp
+++ b/src/db-copy-mgr.hpp
@@ -250,12 +250,13 @@ public:
      * Mark an OSM object for deletion in the current table.
      *
      * The object is guaranteed to be deleted before any lines
-     * following the delete_id() are inserted.
+     * following the delete_object() are inserted.
      */
-    void delete_id(osmid_t osm_id)
+    template <typename... ARGS>
+    void delete_object(ARGS &&... args)
     {
         assert(m_current);
-        m_current->add_deletable(osm_id);
+        m_current->add_deletable(std::forward<ARGS>(args)...);
     }
 
     /**

--- a/src/db-copy-mgr.hpp
+++ b/src/db-copy-mgr.hpp
@@ -1,0 +1,349 @@
+#ifndef OSM2PGSQL_DB_COPY_MGR_HPP
+#define OSM2PGSQL_DB_COPY_MGR_HPP
+
+#include <memory>
+#include <string>
+
+#include "db-copy.hpp"
+
+/**
+ * Management class that fills and manages copy buffers.
+ */
+template <typename DELETER>
+class db_copy_mgr_t
+{
+public:
+    db_copy_mgr_t(std::shared_ptr<db_copy_thread_t> const &processor)
+    : m_processor(processor)
+    {}
+
+    /**
+     * Start a new table row.
+     *
+     * Also starts a new buffer if either the table is not the same as
+     * the table of currently buffered data or no buffer is pending.
+     */
+    void new_line(std::shared_ptr<db_target_descr_t> const &table)
+    {
+        if (!m_current || !m_current->target->same_copy_target(*table.get())) {
+            if (m_current) {
+                m_processor->add_buffer(std::move(m_current));
+            }
+
+            m_current.reset(new db_cmd_copy_delete_t<DELETER>(table));
+        }
+    }
+
+    /**
+     * Finish a table row.
+     *
+     * Adds the row delimiter to the buffer. If the buffer is at capacity
+     * it will be forwarded to the copy thread.
+     */
+    void finish_line()
+    {
+        assert(m_current);
+
+        auto &buf = m_current->buffer;
+        assert(!buf.empty());
+
+        // Expect that a column has been written last which ended in a '\t'.
+        // Replace it with the row delimiter '\n'.
+        auto sz = buf.size();
+        assert(buf[sz - 1] == '\t');
+        buf[sz - 1] = '\n';
+
+        if (sz > db_cmd_copy_t::Max_buf_size - 100) {
+            m_processor->add_buffer(std::move(m_current));
+        }
+    }
+
+    /**
+     * Add many simple columns.
+     *
+     * See add_column().
+     */
+    template <typename T, typename... ARGS>
+    void add_columns(T value, ARGS &&... args)
+    {
+        add_column(value);
+        add_columns(args...);
+    }
+
+    template <typename T>
+    void add_columns(T value)
+    {
+        add_column(value);
+    }
+
+    /**
+     * Add a column entry of simple type.
+     *
+     * Writes the column with the escaping apporpriate for the type and
+     * a column delimiter.
+     */
+    template <typename T>
+    void add_column(T value)
+    {
+        add_value(value);
+        m_current->buffer += '\t';
+    }
+
+    /**
+     * Add an empty column.
+     *
+     * Adds a NULL value for the column.
+     */
+    void add_null_column() { m_current->buffer += "\\N\t"; }
+
+    /**
+     * Start an array column.
+     *
+     * An array is a list of simple elements of the same type.
+     *
+     * Must be finished with a call to finish_array().
+     */
+    void new_array() { m_current->buffer += "{"; }
+
+    /**
+     * Add a single value to an array column.
+     *
+     * Adds the value in the format appropriate for an array and a value
+     * separator.
+     */
+    template <typename T>
+    void add_array_elem(T value)
+    {
+        add_value(value);
+        m_current->buffer += ',';
+    }
+
+    void add_array_elem(std::string const &s) { add_array_elem(s.c_str()); }
+
+    void add_array_elem(char const *s)
+    {
+        assert(m_current);
+        m_current->buffer += '"';
+        add_escaped_string(s);
+        m_current->buffer += "\",";
+    }
+
+    /**
+     * Finish an array column previously started with new_array().
+     *
+     * The array may be empty. If it does contain elements, the separator after
+     * the final element is replaced with the closing array bracket.
+     */
+    void finish_array()
+    {
+        auto idx = m_current->buffer.size() - 1;
+        if (m_current->buffer[idx] == '{')
+            m_current->buffer += '}';
+        else
+            m_current->buffer[idx] = '}';
+        m_current->buffer += '\t';
+    }
+
+    /**
+     * Start a hash column.
+     *
+     * A hash column contains a list of key/value pairs. May be represented
+     * by a hstore or json in Postgresql.
+     *
+     * currently a hstore column is written which does not have any start
+     * markers.
+     *
+     * Must be closed with a finish_hash() call.
+     */
+    void new_hash()
+    { /* nothing */
+    }
+
+    void add_hash_elem(std::string const &k, std::string const &v)
+    {
+        add_hash_elem(k.c_str(), v.c_str());
+    }
+
+    /**
+     * Add a key/value pair to a hash column.
+     *
+     * Key and value must be strings and will be appropriately escaped.
+     * A separator for the next pair is added at the end.
+     */
+    void add_hash_elem(char const *k, char const *v)
+    {
+        m_current->buffer += '"';
+        add_escaped_string(k);
+        m_current->buffer += "\"=>\"";
+        add_escaped_string(v);
+        m_current->buffer += "\",";
+    }
+
+    /**
+     * Add a key/value pair to a hash column without escaping.
+     *
+     * Key and value must be strings and will NOT be appropriately escaped.
+     * A separator for the next pair is added at the end.
+     */
+    void add_hash_elem_noescape(char const *k, char const *v)
+    {
+        m_current->buffer += '"';
+        m_current->buffer += k;
+        m_current->buffer += "\"=>\"";
+        m_current->buffer += v;
+        m_current->buffer += "\",";
+    }
+
+    /**
+     * Add a key (unescaped) and a numeric value to a hash column.
+     *
+     * Key must be string and come from a safe source because it will NOT be
+     * escaped! The value should be convertible using std::to_string.
+     * A separator for the next pair is added at the end.
+     *
+     * This method is suitable to insert safe input, e.g. numeric OSM metadata
+     * (eg. uid) but not unsafe input like user names.
+     */
+    template <typename T>
+    void add_hstore_num_noescape(char const *k, T const value)
+    {
+        m_current->buffer += '"';
+        m_current->buffer += k;
+        m_current->buffer += "\"=>\"";
+        m_current->buffer += std::to_string(value);
+        m_current->buffer += "\",";
+    }
+
+    /**
+     * Close a hash previously started with new_hash().
+     *
+     * The hash may be empty. If elements were present, the separator
+     * of the final element is overwritten with the closing \t.
+     */
+    void finish_hash()
+    {
+        auto idx = m_current->buffer.size() - 1;
+        if (!m_current->buffer.empty() && m_current->buffer[idx] == ',') {
+            m_current->buffer[idx] = '\t';
+        } else {
+            m_current->buffer += '\t';
+        }
+    }
+
+    /**
+     * Add a column with the given WKB geometry in WKB hex format.
+     *
+     * The geometry is converted on-the-fly from WKB binary to WKB hex.
+     */
+    void add_hex_geom(std::string const &wkb)
+    {
+        char const *lookup_hex = "0123456789ABCDEF";
+
+        for (char c : wkb) {
+            m_current->buffer += lookup_hex[(c >> 4) & 0xf];
+            m_current->buffer += lookup_hex[c & 0xf];
+        }
+        m_current->buffer += '\t';
+    }
+
+    /**
+     * Mark an OSM object for deletion in the current table.
+     *
+     * The object is guaranteed to be deleted before any lines
+     * following the delete_id() are inserted.
+     */
+    void delete_id(osmid_t osm_id)
+    {
+        assert(m_current);
+        m_current->add_deletable(osm_id);
+    }
+
+    /**
+     * Synchronize with worker.
+     *
+     * Only returns when all previously issued commands are done.
+     */
+    void sync()
+    {
+        // finish any ongoing copy operations
+        if (m_current) {
+            m_processor->add_buffer(std::move(m_current));
+        }
+
+        m_processor->sync_and_wait();
+    }
+
+private:
+    template <typename T>
+    void add_value(T value)
+    {
+        m_current->buffer += std::to_string(value);
+    }
+
+    void add_value(double value)
+    {
+        char tmp[32];
+        snprintf(tmp, sizeof(tmp), "%g", value);
+        m_current->buffer += tmp;
+    }
+
+    void add_value(std::string const &s) { add_value(s.c_str()); }
+
+    void add_value(char const *s)
+    {
+        assert(m_current);
+        for (char const *c = s; *c; ++c) {
+            switch (*c) {
+            case '"':
+                m_current->buffer += "\\\"";
+                break;
+            case '\\':
+                m_current->buffer += "\\\\";
+                break;
+            case '\n':
+                m_current->buffer += "\\n";
+                break;
+            case '\r':
+                m_current->buffer += "\\r";
+                break;
+            case '\t':
+                m_current->buffer += "\\t";
+                break;
+            default:
+                m_current->buffer += *c;
+                break;
+            }
+        }
+    }
+
+    void add_escaped_string(char const *s)
+    {
+        for (char const *c = s; *c; ++c) {
+            switch (*c) {
+            case '"':
+                m_current->buffer += "\\\\\"";
+                break;
+            case '\\':
+                m_current->buffer += "\\\\\\\\";
+                break;
+            case '\n':
+                m_current->buffer += "\\n";
+                break;
+            case '\r':
+                m_current->buffer += "\\r";
+                break;
+            case '\t':
+                m_current->buffer += "\\t";
+                break;
+            default:
+                m_current->buffer += *c;
+                break;
+            }
+        }
+    }
+
+    std::shared_ptr<db_copy_thread_t> m_processor;
+    std::unique_ptr<db_cmd_copy_delete_t<DELETER>> m_current;
+};
+
+#endif // OSM2PGSQL_DB_COPY_MGR_HPP

--- a/src/db-copy.cpp
+++ b/src/db-copy.cpp
@@ -4,6 +4,7 @@
 #include <thread>
 
 #include "db-copy.hpp"
+#include "format.hpp"
 #include "pgsql.hpp"
 
 db_copy_thread_t::db_copy_thread_t(std::string const &conninfo)
@@ -103,13 +104,14 @@ void db_copy_thread_t::disconnect() { m_conn.reset(); }
 
 void db_copy_thread_t::write_to_db(db_cmd_copy_t *buffer)
 {
-    if (!buffer->deletables.empty() ||
+    if (buffer->deleter.has_data() ||
         (m_inflight && !buffer->target->same_copy_target(*m_inflight.get()))) {
         finish_copy();
     }
 
-    if (!buffer->deletables.empty()) {
-        delete_rows(buffer);
+    if (buffer->deleter.has_data()) {
+        buffer->deleter.delete_rows(buffer->target->name, buffer->target->id,
+                                    m_conn.get());
     }
 
     if (!m_inflight) {
@@ -119,24 +121,19 @@ void db_copy_thread_t::write_to_db(db_cmd_copy_t *buffer)
     m_conn->copy_data(buffer->buffer, buffer->target->name);
 }
 
-void db_copy_thread_t::delete_rows(db_cmd_copy_t *buffer)
+void db_deleter_by_id_t::delete_rows(std::string const &table,
+                                     std::string const &column, pg_conn_t *conn)
 {
-    assert(!m_inflight);
+    std::string sql = "DELETE FROM {} WHERE {} IN ("_format(table, column);
+    sql.reserve(m_deletables.size() * 15 + sql.size());
 
-    std::string sql = "DELETE FROM ";
-    sql.reserve(buffer->target->name.size() + buffer->deletables.size() * 15 +
-                30);
-    sql += buffer->target->name;
-    sql += " WHERE ";
-    sql += buffer->target->id;
-    sql += " IN (";
-    for (auto id : buffer->deletables) {
-        sql += std::to_string(id);
+    for (auto id : m_deletables) {
+        sql += fmt::to_string(id);
         sql += ',';
     }
     sql[sql.size() - 1] = ')';
 
-    m_conn->exec(sql);
+    conn->exec(sql);
 }
 
 void db_copy_thread_t::start_copy(
@@ -184,7 +181,7 @@ void db_copy_mgr_t::new_line(std::shared_ptr<db_target_descr_t> const &table)
 void db_copy_mgr_t::delete_id(osmid_t osm_id)
 {
     assert(m_current);
-    m_current->deletables.push_back(osm_id);
+    m_current->deleter.add(osm_id);
 }
 
 void db_copy_mgr_t::sync()

--- a/src/db-copy.hpp
+++ b/src/db-copy.hpp
@@ -98,18 +98,49 @@ struct db_cmd_copy_t : public db_cmd_t
          */
         Max_buffers = 10
     };
+
     /// Name of the target table for the copy operation
     std::shared_ptr<db_target_descr_t> target;
     /// actual copy buffer
     std::string buffer;
-    /// Deleter class for old items
-    db_deleter_by_id_t deleter;
+
+    virtual bool has_deletables() const noexcept = 0;
+    virtual void delete_data(pg_conn_t *conn) = 0;
 
     explicit db_cmd_copy_t(std::shared_ptr<db_target_descr_t> const &t)
     : db_cmd_t(db_cmd_t::Cmd_copy), target(t)
     {
         buffer.reserve(Max_buf_size);
     }
+};
+
+template <typename DELETER>
+class db_cmd_copy_delete_t : public db_cmd_copy_t
+{
+public:
+    using db_cmd_copy_t::db_cmd_copy_t;
+
+    bool has_deletables() const noexcept override
+    {
+        return m_deleter.has_data();
+    }
+
+    void delete_data(pg_conn_t *conn) override
+    {
+        if (m_deleter.has_data()) {
+            m_deleter.delete_rows(target->name, target->id, conn);
+        }
+    }
+
+    template <typename... ARGS>
+    void add_deletable(ARGS &&... args)
+    {
+        m_deleter.add(std::forward<ARGS>(args)...);
+    }
+
+private:
+    /// Deleter class for old items
+    DELETER m_deleter;
 };
 
 struct db_cmd_sync_t : public db_cmd_t
@@ -175,306 +206,6 @@ private:
 
     // Target for copy operation currently ongoing.
     std::shared_ptr<db_target_descr_t> m_inflight;
-};
-
-/**
- * Management class that fills and manages copy buffers.
- */
-class db_copy_mgr_t
-{
-public:
-    db_copy_mgr_t(std::shared_ptr<db_copy_thread_t> const &processor);
-
-    /**
-     * Start a new table row.
-     *
-     * Also starts a new buffer if either the table is not the same as
-     * the table of currently buffered data or no buffer is pending.
-     */
-    void new_line(std::shared_ptr<db_target_descr_t> const &table);
-
-    /**
-     * Finish a table row.
-     *
-     * Adds the row delimiter to the buffer. If the buffer is at capacity
-     * it will be forwarded to the copy thread.
-     */
-    void finish_line();
-
-    /**
-     * Add many simple columns.
-     *
-     * See add_column().
-     */
-    template <typename T, typename... ARGS>
-    void add_columns(T value, ARGS &&... args)
-    {
-        add_column(value);
-        add_columns(args...);
-    }
-
-    template <typename T>
-    void add_columns(T value)
-    {
-        add_column(value);
-    }
-
-    /**
-     * Add a column entry of simple type.
-     *
-     * Writes the column with the escaping apporpriate for the type and
-     * a column delimiter.
-     */
-    template <typename T>
-    void add_column(T value)
-    {
-        add_value(value);
-        m_current->buffer += '\t';
-    }
-
-    /**
-     * Add an empty column.
-     *
-     * Adds a NULL value for the column.
-     */
-    void add_null_column() { m_current->buffer += "\\N\t"; }
-
-    /**
-     * Start an array column.
-     *
-     * An array is a list of simple elements of the same type.
-     *
-     * Must be finished with a call to finish_array().
-     */
-    void new_array() { m_current->buffer += "{"; }
-
-    /**
-     * Add a single value to an array column.
-     *
-     * Adds the value in the format appropriate for an array and a value
-     * separator.
-     */
-    template <typename T>
-    void add_array_elem(T value)
-    {
-        add_value(value);
-        m_current->buffer += ',';
-    }
-
-    void add_array_elem(std::string const &s) { add_array_elem(s.c_str()); }
-
-    void add_array_elem(char const *s)
-    {
-        assert(m_current);
-        m_current->buffer += '"';
-        add_escaped_string(s);
-        m_current->buffer += "\",";
-    }
-
-    /**
-     * Finish an array column previously started with new_array().
-     *
-     * The array may be empty. If it does contain elements, the separator after
-     * the final element is replaced with the closing array bracket.
-     */
-    void finish_array()
-    {
-        auto idx = m_current->buffer.size() - 1;
-        if (m_current->buffer[idx] == '{')
-            m_current->buffer += '}';
-        else
-            m_current->buffer[idx] = '}';
-        m_current->buffer += '\t';
-    }
-
-    /**
-     * Start a hash column.
-     *
-     * A hash column contains a list of key/value pairs. May be represented
-     * by a hstore or json in Postgresql.
-     *
-     * currently a hstore column is written which does not have any start
-     * markers.
-     *
-     * Must be closed with a finish_hash() call.
-     */
-    void new_hash()
-    { /* nothing */
-    }
-
-    void add_hash_elem(std::string const &k, std::string const &v)
-    {
-        add_hash_elem(k.c_str(), v.c_str());
-    }
-
-    /**
-     * Add a key/value pair to a hash column.
-     *
-     * Key and value must be strings and will be appropriately escaped.
-     * A separator for the next pair is added at the end.
-     */
-    void add_hash_elem(char const *k, char const *v)
-    {
-        m_current->buffer += '"';
-        add_escaped_string(k);
-        m_current->buffer += "\"=>\"";
-        add_escaped_string(v);
-        m_current->buffer += "\",";
-    }
-
-    /**
-     * Add a key/value pair to a hash column without escaping.
-     *
-     * Key and value must be strings and will NOT be appropriately escaped.
-     * A separator for the next pair is added at the end.
-     */
-    void add_hash_elem_noescape(char const *k, char const *v)
-    {
-        m_current->buffer += '"';
-        m_current->buffer += k;
-        m_current->buffer += "\"=>\"";
-        m_current->buffer += v;
-        m_current->buffer += "\",";
-    }
-
-    /**
-     * Add a key (unescaped) and a numeric value to a hash column.
-     *
-     * Key must be string and come from a safe source because it will NOT be
-     * escaped! The value should be convertible using std::to_string.
-     * A separator for the next pair is added at the end.
-     *
-     * This method is suitable to insert safe input, e.g. numeric OSM metadata
-     * (eg. uid) but not unsafe input like user names.
-     */
-    template <typename T>
-    void add_hstore_num_noescape(char const *k, T const value)
-    {
-        m_current->buffer += '"';
-        m_current->buffer += k;
-        m_current->buffer += "\"=>\"";
-        m_current->buffer += std::to_string(value);
-        m_current->buffer += "\",";
-    }
-
-    /**
-     * Close a hash previously started with new_hash().
-     *
-     * The hash may be empty. If elements were present, the separator
-     * of the final element is overwritten with the closing \t.
-     */
-    void finish_hash()
-    {
-        auto idx = m_current->buffer.size() - 1;
-        if (!m_current->buffer.empty() && m_current->buffer[idx] == ',') {
-            m_current->buffer[idx] = '\t';
-        } else {
-            m_current->buffer += '\t';
-        }
-    }
-
-    /**
-     * Add a column with the given WKB geometry in WKB hex format.
-     *
-     * The geometry is converted on-the-fly from WKB binary to WKB hex.
-     */
-    void add_hex_geom(std::string const &wkb)
-    {
-        char const *lookup_hex = "0123456789ABCDEF";
-
-        for (char c : wkb) {
-            m_current->buffer += lookup_hex[(c >> 4) & 0xf];
-            m_current->buffer += lookup_hex[c & 0xf];
-        }
-        m_current->buffer += '\t';
-    }
-
-    /**
-     * Mark an OSM object for deletion in the current table.
-     *
-     * The object is guaranteed to be deleted before any lines
-     * following the delete_id() are inserted.
-     */
-    void delete_id(osmid_t osm_id);
-
-    /**
-     * Synchronize with worker.
-     *
-     * Only returns when all previously issued commands are done.
-     */
-    void sync();
-
-private:
-    template <typename T>
-    void add_value(T value)
-    {
-        m_current->buffer += std::to_string(value);
-    }
-
-    void add_value(double value)
-    {
-        char tmp[32];
-        snprintf(tmp, sizeof(tmp), "%g", value);
-        m_current->buffer += tmp;
-    }
-
-    void add_value(std::string const &s) { add_value(s.c_str()); }
-
-    void add_value(char const *s)
-    {
-        assert(m_current);
-        for (char const *c = s; *c; ++c) {
-            switch (*c) {
-            case '"':
-                m_current->buffer += "\\\"";
-                break;
-            case '\\':
-                m_current->buffer += "\\\\";
-                break;
-            case '\n':
-                m_current->buffer += "\\n";
-                break;
-            case '\r':
-                m_current->buffer += "\\r";
-                break;
-            case '\t':
-                m_current->buffer += "\\t";
-                break;
-            default:
-                m_current->buffer += *c;
-                break;
-            }
-        }
-    }
-
-    void add_escaped_string(char const *s)
-    {
-        for (char const *c = s; *c; ++c) {
-            switch (*c) {
-            case '"':
-                m_current->buffer += "\\\\\"";
-                break;
-            case '\\':
-                m_current->buffer += "\\\\\\\\";
-                break;
-            case '\n':
-                m_current->buffer += "\\n";
-                break;
-            case '\r':
-                m_current->buffer += "\\r";
-                break;
-            case '\t':
-                m_current->buffer += "\\t";
-                break;
-            default:
-                m_current->buffer += *c;
-                break;
-            }
-        }
-    }
-
-    std::shared_ptr<db_copy_thread_t> m_processor;
-    std::unique_ptr<db_cmd_copy_t> m_current;
 };
 
 #endif // OSM2PGSQL_DB_COPY_HPP

--- a/src/gazetteer-style.cpp
+++ b/src/gazetteer-style.cpp
@@ -4,6 +4,7 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <osmium/osm.hpp>
 
+#include "format.hpp"
 #include "gazetteer-style.hpp"
 #include "pgsql.hpp"
 #include "wkb.hpp"
@@ -34,8 +35,21 @@ domain_names(char const *cls, osmium::TagList const &tags)
 
 namespace pt = boost::property_tree;
 
-static auto place_table =
-    std::make_shared<db_target_descr_t>("place", "place_id");
+void db_deleter_place_t::delete_rows(std::string const &table,
+                                     std::string const &, pg_conn_t *conn)
+{
+    for (auto const &i : m_deletables) {
+        if (i.classes.empty()) {
+            conn->exec(
+                "DELETE FROM {} WHERE osm_type = '{}' AND osm_id = {}"_format(
+                    table, i.osm_type, i.osm_id));
+        } else {
+            conn->exec("DELETE FROM {} WHERE osm_type = '{}' AND osm_id = {}"
+                       "AND class NOT IN ({})"_format(table, i.osm_type,
+                                                      i.osm_id, i.classes));
+        }
+    }
+}
 
 void gazetteer_style_t::clear()
 {
@@ -48,20 +62,26 @@ void gazetteer_style_t::clear()
     m_is_named = false;
 }
 
-bool gazetteer_style_t::has_place(std::string const &cls) const
+std::string gazetteer_style_t::class_list() const
 {
-    return std::any_of(m_main.begin(), m_main.end(), [&](pmaintag_t const &e) {
-        if (strcmp(std::get<0>(e), cls.c_str()) == 0) {
-            if (std::get<2>(e) & SF_MAIN_NAMED) {
-                return !m_names.empty();
-            }
-            // XXX should handle SF_MAIN_NAMED_KEY as well
+    std::string l;
 
-            return true;
+    for (auto const &m : m_main) {
+        bool do_include = true;
+        if (std::get<2>(m) & SF_MAIN_NAMED) {
+            do_include = !m_names.empty();
         }
+        // XXX should handle SF_MAIN_NAMED_KEY as well
 
-        return false;
-    });
+        if (do_include) {
+            l += "'{}',"_format(std::get<0>(m));
+        }
+    }
+
+    if (!l.empty())
+        l.resize(l.size() - 1);
+
+    return l;
 }
 
 void gazetteer_style_t::load_style(std::string const &filename)
@@ -437,7 +457,6 @@ bool gazetteer_style_t::copy_out_maintag(pmaintag_t const &tag,
         }
     }
 
-    buffer.new_line(place_table);
     // osm_id
     buffer.add_column(o.id());
     // osm_type

--- a/src/gazetteer-style.cpp
+++ b/src/gazetteer-style.cpp
@@ -395,7 +395,7 @@ void gazetteer_style_t::process_tags(osmium::OSMObject const &o)
 }
 
 bool gazetteer_style_t::copy_out(osmium::OSMObject const &o,
-                                 std::string const &geom, db_copy_mgr_t &buffer)
+                                 std::string const &geom, copy_mgr_t &buffer)
 {
     bool any = false;
     for (auto const &main : m_main) {
@@ -421,7 +421,7 @@ bool gazetteer_style_t::copy_out(osmium::OSMObject const &o,
 bool gazetteer_style_t::copy_out_maintag(pmaintag_t const &tag,
                                          osmium::OSMObject const &o,
                                          std::string const &geom,
-                                         db_copy_mgr_t &buffer)
+                                         copy_mgr_t &buffer)
 {
     std::vector<osmium::Tag const *> domain_name;
     if (std::get<2>(tag) & SF_MAIN_NAMED_KEY) {

--- a/src/gazetteer-style.cpp
+++ b/src/gazetteer-style.cpp
@@ -64,24 +64,20 @@ void gazetteer_style_t::clear()
 
 std::string gazetteer_style_t::class_list() const
 {
-    std::string l;
+    fmt::memory_buffer buf;
 
     for (auto const &m : m_main) {
-        bool do_include = true;
-        if (std::get<2>(m) & SF_MAIN_NAMED) {
-            do_include = !m_names.empty();
-        }
         // XXX should handle SF_MAIN_NAMED_KEY as well
-
-        if (do_include) {
-            l += "'{}',"_format(std::get<0>(m));
+        if (!(std::get<2>(m) & SF_MAIN_NAMED) || !m_names.empty()) {
+            fmt::format_to(buf, FMT_STRING("'{}',"), std::get<0>(m));
         }
     }
 
-    if (!l.empty())
-        l.resize(l.size() - 1);
+    if (buf.size() > 0) {
+        buf.resize(buf.size() - 1);
+    }
 
-    return l;
+    return fmt::to_string(buf);
 }
 
 void gazetteer_style_t::load_style(std::string const &filename)

--- a/src/gazetteer-style.hpp
+++ b/src/gazetteer-style.hpp
@@ -8,7 +8,7 @@
 
 #include <osmium/osm/metadata_options.hpp>
 
-#include "db-copy.hpp"
+#include "db-copy-mgr.hpp"
 
 class gazetteer_style_t
 {
@@ -57,10 +57,12 @@ class gazetteer_style_t
     using flag_list_t = std::vector<string_with_flag_t>;
 
 public:
+    using copy_mgr_t = db_copy_mgr_t<db_deleter_by_id_t>;
+
     void load_style(std::string const &filename);
     void process_tags(osmium::OSMObject const &o);
     bool copy_out(osmium::OSMObject const &o, std::string const &geom,
-                  db_copy_mgr_t &buffer);
+                  copy_mgr_t &buffer);
     bool has_place(std::string const &cls) const;
 
     bool has_data() const { return !m_main.empty(); }
@@ -73,7 +75,7 @@ private:
     flag_t find_flag(char const *k, char const *v) const;
 
     bool copy_out_maintag(pmaintag_t const &tag, osmium::OSMObject const &o,
-                          std::string const &geom, db_copy_mgr_t &buffer);
+                          std::string const &geom, copy_mgr_t &buffer);
     void clear();
 
     // Style data.

--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -396,7 +396,7 @@ void middle_pgsql_t::nodes_delete(osmid_t osm_id)
         persistent_cache->set(osm_id, osmium::Location());
     } else {
         m_db_copy.new_line(tables[NODE_TABLE].m_copy_target);
-        m_db_copy.delete_id(osm_id);
+        m_db_copy.delete_object(osm_id);
     }
 }
 
@@ -531,7 +531,7 @@ middle_query_pgsql_t::rel_way_members_get(osmium::Relation const &rel,
 void middle_pgsql_t::ways_delete(osmid_t osm_id)
 {
     m_db_copy.new_line(tables[WAY_TABLE].m_copy_target);
-    m_db_copy.delete_id(osm_id);
+    m_db_copy.delete_object(osm_id);
 }
 
 void middle_pgsql_t::iterate_ways(middle_t::pending_processor &pf)
@@ -636,7 +636,7 @@ void middle_pgsql_t::relations_delete(osmid_t osm_id)
     }
 
     m_db_copy.new_line(tables[REL_TABLE].m_copy_target);
-    m_db_copy.delete_id(osm_id);
+    m_db_copy.delete_object(osm_id);
 }
 
 void middle_pgsql_t::iterate_relations(pending_processor &pf)

--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -11,7 +11,7 @@
 
 #include <memory>
 
-#include "db-copy.hpp"
+#include "db-copy-mgr.hpp"
 #include "id-tracker.hpp"
 #include "middle.hpp"
 #include "node-persistent-cache.hpp"
@@ -128,7 +128,7 @@ private:
     std::unique_ptr<pg_conn_t> m_query_conn;
     // middle keeps its own thread for writing to the database.
     std::shared_ptr<db_copy_thread_t> m_copy_thread;
-    db_copy_mgr_t m_db_copy;
+    db_copy_mgr_t<db_deleter_by_id_t> m_db_copy;
 };
 
 #endif // OSM2PGSQL_MIDDLE_PGSQL_HPP

--- a/src/output-gazetteer.cpp
+++ b/src/output-gazetteer.cpp
@@ -19,6 +19,10 @@ static auto place_table =
 void output_gazetteer_t::delete_unused_classes(char const *osm_type,
                                                osmid_t osm_id)
 {
+    if (!m_options.append) {
+        return;
+    }
+
     if (m_style.has_data()) {
         std::string cls = m_style.class_list();
         m_copy.delete_object(osm_type[0], osm_id, cls);
@@ -80,10 +84,7 @@ int output_gazetteer_t::process_node(osmium::Node const &node)
 {
     m_copy.new_line(place_table);
     m_style.process_tags(node);
-
-    if (m_options.append) {
-        delete_unused_classes("N", node.id());
-    }
+    delete_unused_classes("N", node.id());
 
     /* Are we interested in this item? */
     if (m_style.has_data()) {
@@ -100,10 +101,7 @@ int output_gazetteer_t::process_way(osmium::Way *way)
 {
     m_copy.new_line(place_table);
     m_style.process_tags(*way);
-
-    if (m_options.append) {
-        delete_unused_classes("W", way->id());
-    }
+    delete_unused_classes("W", way->id());
 
     /* Are we interested in this item? */
     if (m_style.has_data()) {
@@ -154,10 +152,7 @@ int output_gazetteer_t::process_relation(osmium::Relation const &rel)
     }
 
     m_style.process_tags(rel);
-
-    if (m_options.append) {
-        delete_unused_classes("R", rel.id());
-    }
+    delete_unused_classes("R", rel.id());
 
     /* Are we interested in this item? */
     if (!m_style.has_data()) {

--- a/src/output-gazetteer.hpp
+++ b/src/output-gazetteer.hpp
@@ -106,16 +106,16 @@ private:
     };
 
     /// Delete all places that are not covered by the current style results.
-    void delete_unused_classes(char const *osm_type, osmid_t osm_id);
+    void delete_unused_classes(char osm_type, osmid_t osm_id);
     int process_node(osmium::Node const &node);
     int process_way(osmium::Way *way);
     int process_relation(osmium::Relation const &rel);
     void connect();
 
-    void delete_unused_full(char const *osm_type, osmid_t osm_id)
+    void delete_unused_full(char osm_type, osmid_t osm_id)
     {
         if (m_options.append) {
-            m_copy.delete_object(osm_type[0], osm_id);
+            m_copy.delete_object(osm_type, osm_id);
         }
     }
 

--- a/src/output-gazetteer.hpp
+++ b/src/output-gazetteer.hpp
@@ -6,7 +6,7 @@
 
 #include <osmium/memory/buffer.hpp>
 
-#include "db-copy.hpp"
+#include "db-copy-mgr.hpp"
 #include "gazetteer-style.hpp"
 #include "osmium-builder.hpp"
 #include "osmtypes.hpp"
@@ -124,7 +124,7 @@ private:
         }
     }
 
-    db_copy_mgr_t m_copy;
+    db_copy_mgr_t<db_deleter_by_id_t> m_copy;
     std::unique_ptr<pg_conn_t> m_conn;
     gazetteer_style_t m_style;
 

--- a/src/output-gazetteer.hpp
+++ b/src/output-gazetteer.hpp
@@ -24,7 +24,6 @@ class output_gazetteer_t : public output_t
       osmium_buffer(PLACE_BUFFER_SIZE, osmium::memory::Buffer::auto_grow::yes)
     {
         connect();
-        prepare_query_conn();
     }
 
 public:
@@ -84,19 +83,19 @@ public:
 
     int node_delete(osmid_t id) override
     {
-        delete_place("N", id);
+        m_copy.delete_object('N', id);
         return 0;
     }
 
     int way_delete(osmid_t id) override
     {
-        delete_place("W", id);
+        m_copy.delete_object('W', id);
         return 0;
     }
 
     int relation_delete(osmid_t id) override
     {
-        delete_place("R", id);
+        m_copy.delete_object('R', id);
         return 0;
     }
 
@@ -108,23 +107,19 @@ private:
 
     /// Delete all places that are not covered by the current style results.
     void delete_unused_classes(char const *osm_type, osmid_t osm_id);
-    /// Delete all places for the given OSM object.
-    void delete_place(char const *osm_type, osmid_t osm_id);
     int process_node(osmium::Node const &node);
     int process_way(osmium::Way *way);
     int process_relation(osmium::Relation const &rel);
     void connect();
 
-    void prepare_query_conn() const;
-
     void delete_unused_full(char const *osm_type, osmid_t osm_id)
     {
         if (m_options.append) {
-            delete_place(osm_type, osm_id);
+            m_copy.delete_object(osm_type[0], osm_id);
         }
     }
 
-    db_copy_mgr_t<db_deleter_by_id_t> m_copy;
+    db_copy_mgr_t<db_deleter_place_t> m_copy;
     std::unique_ptr<pg_conn_t> m_conn;
     gazetteer_style_t m_style;
 

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -288,7 +288,7 @@ void table_t::stop(bool updateable, bool enable_hstore_index,
 void table_t::delete_row(const osmid_t id)
 {
     m_copy.new_line(m_target);
-    m_copy.delete_id(id);
+    m_copy.delete_object(id);
 }
 
 void table_t::write_row(osmid_t id, taglist_t const &tags,

--- a/src/table.hpp
+++ b/src/table.hpp
@@ -1,7 +1,7 @@
 #ifndef OSM2PGSQL_TABLE_HPP
 #define OSM2PGSQL_TABLE_HPP
 
-#include "db-copy.hpp"
+#include "db-copy-mgr.hpp"
 #include "osmtypes.hpp"
 #include "pgsql.hpp"
 #include "taginfo.hpp"
@@ -95,7 +95,7 @@ protected:
     hstores_t hstore_columns;
     std::string m_table_space;
 
-    db_copy_mgr_t m_copy;
+    db_copy_mgr_t<db_deleter_by_id_t> m_copy;
 };
 
 #endif // OSM2PGSQL_TABLE_HPP

--- a/tests/test-db-copy-mgr.cpp
+++ b/tests/test-db-copy-mgr.cpp
@@ -5,9 +5,11 @@
 #include <catch.hpp>
 
 #include "common-pg.hpp"
-#include "db-copy.hpp"
+#include "db-copy-mgr.hpp"
 
 static pg::tempdb_t db;
+
+using copy_mgr_t = db_copy_mgr_t<db_deleter_by_id_t>;
 
 static std::shared_ptr<db_target_descr_t> setup_table(std::string const &cols)
 {
@@ -24,7 +26,7 @@ static std::shared_ptr<db_target_descr_t> setup_table(std::string const &cols)
 }
 
 template <typename... ARGS>
-void add_row(db_copy_mgr_t &mgr, std::shared_ptr<db_target_descr_t> t,
+void add_row(copy_mgr_t &mgr, std::shared_ptr<db_target_descr_t> t,
              ARGS &&... args)
 {
     mgr.new_line(t);
@@ -35,7 +37,7 @@ void add_row(db_copy_mgr_t &mgr, std::shared_ptr<db_target_descr_t> t,
 }
 
 template <typename T>
-void add_array(db_copy_mgr_t &mgr, std::shared_ptr<db_target_descr_t> t, int id,
+void add_array(copy_mgr_t &mgr, std::shared_ptr<db_target_descr_t> t, int id,
                std::vector<T> const &values)
 {
     mgr.new_line(t);
@@ -51,7 +53,7 @@ void add_array(db_copy_mgr_t &mgr, std::shared_ptr<db_target_descr_t> t, int id,
 }
 
 static void
-add_hash(db_copy_mgr_t &mgr, std::shared_ptr<db_target_descr_t> t, int id,
+add_hash(copy_mgr_t &mgr, std::shared_ptr<db_target_descr_t> t, int id,
          std::vector<std::pair<std::string, std::string>> const &values)
 {
     mgr.new_line(t);
@@ -77,9 +79,9 @@ static void check_row(std::vector<std::string> const &row)
     }
 }
 
-TEST_CASE("db_copy_mgr_t")
+TEST_CASE("copy_mgr_t")
 {
-    db_copy_mgr_t mgr(std::make_shared<db_copy_thread_t>(db.conninfo()));
+    copy_mgr_t mgr(std::make_shared<db_copy_thread_t>(db.conninfo()));
 
     SECTION("Insert null")
     {

--- a/tests/test-db-copy-thread.cpp
+++ b/tests/test-db-copy-thread.cpp
@@ -70,8 +70,8 @@ TEST_CASE("db_copy_thread_t")
 
         SECTION("simple delete of existing rows")
         {
-            cmd->deletables.push_back(223);
-            cmd->deletables.push_back(42);
+            cmd->deleter.add(223);
+            cmd->deleter.add(42);
 
             t.add_buffer(std::unique_ptr<db_cmd_t>(cmd.release()));
             t.sync_and_wait();
@@ -82,7 +82,7 @@ TEST_CASE("db_copy_thread_t")
 
         SECTION("delete one and add another")
         {
-            cmd->deletables.push_back(133);
+            cmd->deleter.add(133);
             cmd->buffer += "134\n";
 
             t.add_buffer(std::unique_ptr<db_cmd_t>(cmd.release()));
@@ -94,7 +94,7 @@ TEST_CASE("db_copy_thread_t")
 
         SECTION("delete one and add the same")
         {
-            cmd->deletables.push_back(133);
+            cmd->deleter.add(133);
             cmd->buffer += "133\n";
 
             t.add_buffer(std::unique_ptr<db_cmd_t>(cmd.release()));
@@ -126,7 +126,7 @@ TEST_CASE("db_copy_thread_t")
         t.add_buffer(std::unique_ptr<db_cmd_t>(cmd.release()));
 
         cmd = std::unique_ptr<db_cmd_copy_t>(new db_cmd_copy_t(table));
-        cmd->deletables.push_back(542);
+        cmd->deleter.add(542);
         cmd->buffer += "12\n";
         t.add_buffer(std::unique_ptr<db_cmd_t>(cmd.release()));
 


### PR DESCRIPTION
Objects so far have been deleted directly from the main thread in gazetteer. This may lead to deadlock as the updates in the copy thread trigger SQL triggers which may touch an object currently being deleted.

Gazetteer objects are now deleted in the copy thread in a batch just like we do for all other tables. For this we need a different kind of deleter as the primary key is different for gazetteer's place table. For this, delete lists become first class objects and the copy manager becomes responsible for adding the right deleter to the copy buffer object.

Fixes #964.