### PR TITLE
Make sure PostgreSQL connection is cleaned up properly.

### DIFF
--- a/src/pgsql.cpp
+++ b/src/pgsql.cpp
@@ -10,11 +10,12 @@ pg_conn_t::pg_conn_t(std::string const &connection)
     if (PQstatus(m_conn) != CONNECTION_OK) {
         fprintf(stderr, "Connection to database failed: %s\n",
                 PQerrorMessage(m_conn));
+        PQfinish(m_conn);
         throw std::runtime_error{"Connecting to database."};
     }
 }
 
-pg_conn_t::~pg_conn_t()
+pg_conn_t::~pg_conn_t() noexcept
 {
     if (m_conn) {
         PQfinish(m_conn);

--- a/src/pgsql.hpp
+++ b/src/pgsql.hpp
@@ -26,9 +26,9 @@ public:
     pg_conn_t(std::string const &connection);
 
     pg_conn_t(pg_conn_t const &) = delete;
-    pg_conn_t &operator=(const pg_conn_t &) = delete;
+    pg_conn_t &operator=(pg_conn_t const &) = delete;
 
-    ~pg_conn_t();
+    ~pg_conn_t() noexcept;
 
     pg_result_t exec_prepared(char const *stmt, int num_params,
                               const char *const *param_values,


### PR DESCRIPTION
PQfinish(m_conn) must also be called if the connection attempt fails.
(The destructor is not run unless the constructor succeeds.)

Also declares destructor noexcept.