### PR TITLE
Move declaration of static `db` into tests

### DIFF
--- a/tests/test-db-copy-thread.cpp
+++ b/tests/test-db-copy-thread.cpp
@@ -4,8 +4,6 @@
 #include "db-copy.hpp"
 #include "gazetteer-style.hpp"
 
-static pg::tempdb_t db;
-
 static int table_count(pg::conn_t const &conn, std::string const &where = "")
 {
     return conn.require_scalar<int>("SELECT count(*) FROM test_copy_thread " +
@@ -14,6 +12,8 @@ static int table_count(pg::conn_t const &conn, std::string const &where = "")
 
 TEST_CASE("db_copy_thread_t with db_deleter_by_id_t")
 {
+    pg::tempdb_t db;
+
     auto conn = db.connect();
     conn.exec("DROP TABLE IF EXISTS test_copy_thread");
     conn.exec("CREATE TABLE test_copy_thread (id int8)");
@@ -142,6 +142,8 @@ TEST_CASE("db_copy_thread_t with db_deleter_by_id_t")
 
 TEST_CASE("db_copy_thread_t with db_deleter_place_t")
 {
+    pg::tempdb_t db;
+
     auto conn = db.connect();
     conn.exec("DROP TABLE IF EXISTS test_copy_thread");
     conn.exec("CREATE TABLE test_copy_thread ("

--- a/tests/test-middle.cpp
+++ b/tests/test-middle.cpp
@@ -9,8 +9,6 @@
 #include "common-options.hpp"
 #include "common-pg.hpp"
 
-static pg::tempdb_t db;
-
 namespace {
 
 /// Simple osmium buffer to store object with some convenience.
@@ -93,6 +91,8 @@ TEMPLATE_TEST_CASE("middle import", "", options_slim_default,
                    options_slim_dense_cache, options_ram_optimized,
                    options_ram_flatnode)
 {
+    pg::tempdb_t db;
+
     options_t options = TestType::options(db);
 
     auto mid = options.slim

--- a/tests/test-options-projection.cpp
+++ b/tests/test-options-projection.cpp
@@ -4,10 +4,10 @@
 
 #include "common-import.hpp"
 
-static testing::db::import_t db;
-
 TEST_CASE("Projection setup")
 {
+    testing::db::import_t db;
+
     std::vector<char const *> option_params = {
         "osm2pgsql", "-S", OSM2PGSQLDATA_DIR "default.style",
         "--number-processes", "1"};
@@ -68,7 +68,7 @@ TEST_CASE("Projection setup")
 
     db.run_import(options, "n1 Tamenity=bar x0 y0");
 
-    auto conn = db.connect();
+    auto const conn = db.connect();
 
     CHECK(conn.require_scalar<std::string>(
               "select find_srid('public', 'planet_osm_roads', 'way')") == srid);

--- a/tests/test-output-gazetteer.cpp
+++ b/tests/test-output-gazetteer.cpp
@@ -3,8 +3,6 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 static options_t options() { return testing::opt_t().gazetteer(); }
 
 static pg::result_t require_place(pg::conn_t const &conn, char type, osmid_t id,
@@ -27,6 +25,8 @@ static void require_place_not(pg::conn_t const &conn, char type, osmid_t id,
 
 TEST_CASE("output_gazetteer_t import")
 {
+    testing::db::import_t db;
+
     SECTION("Main tags")
     {
         REQUIRE_NOTHROW(db.run_import(

--- a/tests/test-output-multi-line-storage.cpp
+++ b/tests/test-output-multi-line-storage.cpp
@@ -3,18 +3,19 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 TEST_CASE("multi backend line import")
 {
-    options_t options = testing::opt_t()
-                            .slim()
-                            .multi("test_output_multi_line_trivial.style.json")
-                            .srs(PROJ_LATLONG);
+    testing::db::import_t db;
+
+    options_t const options =
+        testing::opt_t()
+            .slim()
+            .multi("test_output_multi_line_trivial.style.json")
+            .srs(PROJ_LATLONG);
 
     REQUIRE_NOTHROW(db.run_file(options, "test_output_multi_line_storage.osm"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
     conn.require_has_table("test_line");
 
     REQUIRE(3 == conn.get_count("test_line"));

--- a/tests/test-output-multi-line.cpp
+++ b/tests/test-output-multi-line.cpp
@@ -10,19 +10,19 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 TEST_CASE("parse linestring")
 {
-    options_t options = testing::opt_t().slim();
+    testing::db::import_t db;
 
-    auto processor = geometry_processor::create("line", &options);
+    options_t const options = testing::opt_t().slim();
+
+    auto const processor = geometry_processor::create("line", &options);
 
     db.run_file_multi_output(testing::opt_t().slim(), processor,
                              "foobar_highways", osmium::item_type::way,
                              "highway", "liechtenstein-2013-08-03.osm.pbf");
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
     conn.require_has_table("foobar_highways");
 
     REQUIRE(2753 == conn.get_count("foobar_highways"));

--- a/tests/test-output-multi-point-multi-table.cpp
+++ b/tests/test-output-multi-point-multi-table.cpp
@@ -10,10 +10,10 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 TEST_CASE("parse point")
 {
+    testing::db::import_t db;
+
     options_t options = testing::opt_t().slim();
     options.database_options = db.db().db_options();
 
@@ -35,9 +35,9 @@ TEST_CASE("parse point")
     for (int i = 0; i < 10; ++i) {
         std::string const name{"foobar_{}"_format(i)};
 
-        auto processor = geometry_processor::create("point", &options);
+        auto const processor = geometry_processor::create("point", &options);
 
-        auto out_test = std::make_shared<output_multi_t>(
+        auto const out_test = std::make_shared<output_multi_t>(
             name, processor, columns, midq, options,
             std::make_shared<db_copy_thread_t>(
                 options.database_options.conninfo()));
@@ -48,7 +48,7 @@ TEST_CASE("parse point")
     testing::parse_file(options, mid_pgsql, outputs,
                         "liechtenstein-2013-08-03.osm.pbf");
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
 
     for (int i = 0; i < 10; ++i) {
         std::string const buf{"foobar_{}"_format(i)};

--- a/tests/test-output-multi-point.cpp
+++ b/tests/test-output-multi-point.cpp
@@ -10,19 +10,19 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 TEST_CASE("parse point")
 {
-    options_t options = testing::opt_t().slim();
+    testing::db::import_t db;
 
-    auto processor = geometry_processor::create("point", &options);
+    options_t const options = testing::opt_t().slim();
+
+    auto const processor = geometry_processor::create("point", &options);
 
     db.run_file_multi_output(testing::opt_t().slim(), processor,
                              "foobar_amenities", osmium::item_type::node,
                              "amenity", "liechtenstein-2013-08-03.osm.pbf");
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
     conn.require_has_table("foobar_amenities");
 
     REQUIRE(244 == conn.get_count("foobar_amenities"));

--- a/tests/test-output-multi-poly-trivial.cpp
+++ b/tests/test-output-multi-poly-trivial.cpp
@@ -3,10 +3,10 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 TEST_CASE("multi backend trivial polygon import")
 {
+    testing::db::import_t db;
+
     options_t options = testing::opt_t()
                             .slim()
                             .multi("test_output_multi_poly_trivial.style.json")
@@ -17,7 +17,7 @@ TEST_CASE("multi backend trivial polygon import")
         REQUIRE_NOTHROW(
             db.run_file(options, "test_output_multi_poly_trivial.osm"));
 
-        auto conn = db.db().connect();
+        auto const conn = db.db().connect();
         conn.require_has_table("test_poly");
 
         REQUIRE(2 == conn.get_count("test_poly"));
@@ -38,7 +38,7 @@ TEST_CASE("multi backend trivial polygon import")
         REQUIRE_NOTHROW(
             db.run_file(options, "test_output_multi_poly_trivial.osm"));
 
-        auto conn = db.db().connect();
+        auto const conn = db.db().connect();
         conn.require_has_table("test_poly");
 
         REQUIRE(1 == conn.get_count("test_poly"));

--- a/tests/test-output-multi-polygon.cpp
+++ b/tests/test-output-multi-polygon.cpp
@@ -10,19 +10,19 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 TEST_CASE("parse point")
 {
-    options_t options = testing::opt_t().slim();
+    testing::db::import_t db;
 
-    auto processor = geometry_processor::create("polygon", &options);
+    options_t const options = testing::opt_t().slim();
+
+    auto const processor = geometry_processor::create("polygon", &options);
 
     db.run_file_multi_output(testing::opt_t().slim(), processor,
                              "foobar_buildings", osmium::item_type::way,
                              "building", "liechtenstein-2013-08-03.osm.pbf");
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
     conn.require_has_table("foobar_buildings");
 
     REQUIRE(3723 == conn.get_count("foobar_buildings"));

--- a/tests/test-output-multi-tags.cpp
+++ b/tests/test-output-multi-tags.cpp
@@ -3,18 +3,18 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 TEST_CASE("multi backend tag import")
 {
-    options_t options = testing::opt_t()
-                            .slim()
-                            .multi("test_output_multi_tags.json")
-                            .srs(PROJ_LATLONG);
+    testing::db::import_t db;
+
+    options_t const options = testing::opt_t()
+                                  .slim()
+                                  .multi("test_output_multi_tags.json")
+                                  .srs(PROJ_LATLONG);
 
     REQUIRE_NOTHROW(db.run_file(options, "test_output_multi_tags.osm"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
 
     // Check we got the right tables
     conn.require_has_table("test_points_1");

--- a/tests/test-output-pgsql-area.cpp
+++ b/tests/test-output-pgsql-area.cpp
@@ -3,15 +3,15 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 TEST_CASE("default projection")
 {
-    options_t options = testing::opt_t().slim();
+    testing::db::import_t db;
+
+    options_t const options = testing::opt_t().slim();
 
     REQUIRE_NOTHROW(db.run_file(options, "test_output_pgsql_area.osm"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
 
     REQUIRE(2 == conn.get_count("osm2pgsql_test_polygon"));
     conn.assert_double(
@@ -24,11 +24,13 @@ TEST_CASE("default projection")
 
 TEST_CASE("latlon projection")
 {
-    options_t options = testing::opt_t().slim().srs(PROJ_LATLONG);
+    testing::db::import_t db;
+
+    options_t const options = testing::opt_t().slim().srs(PROJ_LATLONG);
 
     REQUIRE_NOTHROW(db.run_file(options, "test_output_pgsql_area.osm"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
 
     REQUIRE(2 == conn.get_count("osm2pgsql_test_polygon"));
     conn.assert_double(
@@ -39,12 +41,14 @@ TEST_CASE("latlon projection")
 
 TEST_CASE("latlon projection with way_area reprojection")
 {
+    testing::db::import_t db;
+
     options_t options = testing::opt_t().slim().srs(PROJ_LATLONG);
     options.reproject_area = true;
 
     REQUIRE_NOTHROW(db.run_file(options, "test_output_pgsql_area.osm"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
 
     REQUIRE(2 == conn.get_count("osm2pgsql_test_polygon"));
     conn.assert_double(

--- a/tests/test-output-pgsql-hstore-match-only.cpp
+++ b/tests/test-output-pgsql-hstore-match-only.cpp
@@ -3,10 +3,10 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 TEST_CASE("hstore match only import")
 {
+    testing::db::import_t db;
+
     options_t options =
         testing::opt_t().slim().style("hstore-match-only.style");
     options.hstore_match_only = true;
@@ -14,7 +14,7 @@ TEST_CASE("hstore match only import")
 
     REQUIRE_NOTHROW(db.run_file(options, "hstore-match-only.osm"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
 
     // tables should not contain any tag columns
     REQUIRE(4 == conn.get_count("information_schema.columns",

--- a/tests/test-output-pgsql-int4.cpp
+++ b/tests/test-output-pgsql-int4.cpp
@@ -5,8 +5,6 @@
 
 #include <string>
 
-static testing::db::import_t db;
-
 static std::string population(osmid_t id)
 {
     return "SELECT population FROM osm2pgsql_test_point WHERE osm_id = " +
@@ -15,12 +13,14 @@ static std::string population(osmid_t id)
 
 TEST_CASE("int4 conversion")
 {
+    testing::db::import_t db;
+
     options_t const options =
         testing::opt_t().slim().style("test_output_pgsql_int4.style");
 
     REQUIRE_NOTHROW(db.run_file(options, "test_output_pgsql_int4.osm"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
 
     // First three nodes have population values that are out of range for int4 columns
     conn.assert_null(population(1));

--- a/tests/test-output-pgsql-schema.cpp
+++ b/tests/test-output-pgsql-schema.cpp
@@ -3,10 +3,10 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 TEST_CASE("schema separation")
 {
+    testing::db::import_t db;
+
     {
         auto conn = db.db().connect();
         conn.exec("CREATE SCHEMA myschema;"
@@ -19,7 +19,7 @@ TEST_CASE("schema separation")
     REQUIRE_NOTHROW(
         db.run_file(testing::opt_t().slim(), "test_output_pgsql_z_order.osm"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
 
     conn.require_has_table("public.osm2pgsql_test_point");
     conn.require_has_table("public.osm2pgsql_test_line");

--- a/tests/test-output-pgsql-tablespace.cpp
+++ b/tests/test-output-pgsql-tablespace.cpp
@@ -3,8 +3,6 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 static void require_tables(pg::conn_t const &conn)
 {
     conn.require_has_table("osm2pgsql_test_point");
@@ -15,8 +13,10 @@ static void require_tables(pg::conn_t const &conn)
 
 TEST_CASE("simple import with tables spaces")
 {
+    testing::db::import_t db;
+
     {
-        auto conn = db.db().connect();
+        auto const conn = db.db().connect();
         REQUIRE(1 ==
                 conn.get_count("pg_tablespace", "spcname = 'tablespacetest'"));
     }
@@ -27,7 +27,7 @@ TEST_CASE("simple import with tables spaces")
 
     REQUIRE_NOTHROW(db.run_file(options, "liechtenstein-2013-08-03.osm.pbf"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
     require_tables(conn);
 
     REQUIRE(1342 == conn.get_count("osm2pgsql_test_point"));

--- a/tests/test-output-pgsql-validgeom.cpp
+++ b/tests/test-output-pgsql-validgeom.cpp
@@ -3,14 +3,14 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 TEST_CASE("no invalid geometries")
 {
+    testing::db::import_t db;
+
     REQUIRE_NOTHROW(db.run_file(testing::opt_t().slim(),
                                 "test_output_pgsql_validgeom.osm"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
 
     conn.require_has_table("osm2pgsql_test_point");
     conn.require_has_table("osm2pgsql_test_line");

--- a/tests/test-output-pgsql-z_order.cpp
+++ b/tests/test-output-pgsql-z_order.cpp
@@ -3,14 +3,14 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 TEST_CASE("compute Z order")
 {
+    testing::db::import_t db;
+
     REQUIRE_NOTHROW(
         db.run_file(testing::opt_t().slim(), "test_output_pgsql_z_order.osm"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
 
     char const *expected[] = {"motorway", "trunk", "primary", "secondary",
                               "tertiary"};

--- a/tests/test-output-pgsql.cpp
+++ b/tests/test-output-pgsql.cpp
@@ -3,8 +3,6 @@
 #include "common-import.hpp"
 #include "common-options.hpp"
 
-static testing::db::import_t db;
-
 static void require_tables(pg::conn_t const &conn)
 {
     conn.require_has_table("osm2pgsql_test_point");
@@ -15,10 +13,12 @@ static void require_tables(pg::conn_t const &conn)
 
 TEST_CASE("liechtenstein slim regression simple")
 {
+    testing::db::import_t db;
+
     REQUIRE_NOTHROW(db.run_file(testing::opt_t().slim(),
                                 "liechtenstein-2013-08-03.osm.pbf"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
     require_tables(conn);
 
     REQUIRE(1342 == conn.get_count("osm2pgsql_test_point"));
@@ -52,10 +52,12 @@ TEST_CASE("liechtenstein slim regression simple")
 
 TEST_CASE("liechtenstein slim latlon")
 {
+    testing::db::import_t db;
+
     REQUIRE_NOTHROW(db.run_file(testing::opt_t().slim().srs(PROJ_LATLONG),
                                 "liechtenstein-2013-08-03.osm.pbf"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
     require_tables(conn);
 
     REQUIRE(1342 == conn.get_count("osm2pgsql_test_point"));
@@ -89,10 +91,12 @@ TEST_CASE("liechtenstein slim latlon")
 
 TEST_CASE("way area slim flatnode")
 {
+    testing::db::import_t db;
+
     REQUIRE_NOTHROW(db.run_file(testing::opt_t().slim().flatnodes(),
                                 "test_output_pgsql_way_area.osm"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
     require_tables(conn);
 
     REQUIRE(0 == conn.get_count("osm2pgsql_test_point"));
@@ -103,10 +107,12 @@ TEST_CASE("way area slim flatnode")
 
 TEST_CASE("route relation slim flatnode")
 {
+    testing::db::import_t db;
+
     REQUIRE_NOTHROW(db.run_file(testing::opt_t().slim().flatnodes(),
                                 "test_output_pgsql_route_rel.osm"));
 
-    auto conn = db.db().connect();
+    auto const conn = db.db().connect();
     require_tables(conn);
 
     REQUIRE(0 == conn.get_count("osm2pgsql_test_point"));


### PR DESCRIPTION
`pg::tempdb_t db` or `testing::db::import_t db` is defined as static in many test files. This is problematic, because the class may throw errors which we can't catch and the testing framework can't report correctly then.

This is caught by clang-tidy with error messages like this:
"warning: initialization of 'db' with static storage duration may throw an exception that cannot be caught [cert-err58-cpp]"

This commit fixes all these cases.

This commit also adds a bunch of `const`s.