### PR TITLE
Gazetteer: move main tag filtering into processing function

### DIFF
--- a/src/gazetteer-style.hpp
+++ b/src/gazetteer-style.hpp
@@ -53,6 +53,11 @@ private:
     std::vector<item_t> m_deletables;
 };
 
+/**
+ * Copy manager for the gazetteer place table only.
+ *
+ * Implicitly contains the table description.
+ */
 class gazetteer_copy_mgr_t : public db_copy_mgr_t<db_deleter_place_t>
 {
 public:
@@ -61,9 +66,7 @@ public:
       m_table(std::make_shared<db_target_descr_t>("place", "place_id"))
     {}
 
-    using db_copy_mgr_t<db_deleter_place_t>::new_line;
-
-    void new_line() { new_line(m_table); }
+    void prepare() { new_line(m_table); }
 
 private:
     std::shared_ptr<db_target_descr_t> m_table;
@@ -120,8 +123,8 @@ public:
 
     void load_style(std::string const &filename);
     void process_tags(osmium::OSMObject const &o);
-    bool copy_out(osmium::OSMObject const &o, std::string const &geom,
-                  copy_mgr_t &buffer);
+    void copy_out(osmium::OSMObject const &o, std::string const &geom,
+                  copy_mgr_t &buffer) const;
     std::string class_list() const;
 
     bool has_data() const { return !m_main.empty(); }
@@ -134,8 +137,6 @@ private:
     flag_t find_flag(char const *k, char const *v) const;
     void filter_main_tags(bool is_named, osmium::TagList const &tags);
 
-    void copy_out_maintag(pmaintag_t const &tag, osmium::OSMObject const &o,
-                          std::string const &geom, copy_mgr_t &buffer);
     void clear();
 
     // Style data.

--- a/src/gazetteer-style.hpp
+++ b/src/gazetteer-style.hpp
@@ -53,6 +53,22 @@ private:
     std::vector<item_t> m_deletables;
 };
 
+class gazetteer_copy_mgr_t : public db_copy_mgr_t<db_deleter_place_t>
+{
+public:
+    gazetteer_copy_mgr_t(std::shared_ptr<db_copy_thread_t> const &processor)
+    : db_copy_mgr_t<db_deleter_place_t>(processor),
+      m_table(std::make_shared<db_target_descr_t>("place", "place_id"))
+    {}
+
+    using db_copy_mgr_t<db_deleter_place_t>::new_line;
+
+    void new_line() { new_line(m_table); }
+
+private:
+    std::shared_ptr<db_target_descr_t> m_table;
+};
+
 class gazetteer_style_t
 {
     using flag_t = uint16_t;
@@ -100,7 +116,7 @@ class gazetteer_style_t
     using flag_list_t = std::vector<string_with_flag_t>;
 
 public:
-    using copy_mgr_t = db_copy_mgr_t<db_deleter_place_t>;
+    using copy_mgr_t = gazetteer_copy_mgr_t;
 
     void load_style(std::string const &filename);
     void process_tags(osmium::OSMObject const &o);
@@ -116,8 +132,9 @@ private:
                          flag_t flags);
     flag_t parse_flags(std::string const &str);
     flag_t find_flag(char const *k, char const *v) const;
+    void filter_main_tags(bool is_named, osmium::TagList const &tags);
 
-    bool copy_out_maintag(pmaintag_t const &tag, osmium::OSMObject const &o,
+    void copy_out_maintag(pmaintag_t const &tag, osmium::OSMObject const &o,
                           std::string const &geom, copy_mgr_t &buffer);
     void clear();
 
@@ -140,8 +157,6 @@ private:
     char const *m_operator;
     /// admin level
     int m_admin_level;
-    /// True if there is an actual name to the object (not a ref).
-    bool m_is_named;
 
     /// which metadata fields of the OSM objects should be written to the output
     osmium::metadata_options m_metadata_fields{"none"};

--- a/src/output-gazetteer.cpp
+++ b/src/output-gazetteer.cpp
@@ -13,9 +13,6 @@
 #include <iostream>
 #include <memory>
 
-static auto place_table =
-    std::make_shared<db_target_descr_t>("place", "place_id");
-
 void output_gazetteer_t::delete_unused_classes(char osm_type, osmid_t osm_id)
 {
     if (!m_options.append) {
@@ -76,7 +73,7 @@ void output_gazetteer_t::commit() { m_copy.sync(); }
 
 int output_gazetteer_t::process_node(osmium::Node const &node)
 {
-    m_copy.new_line(place_table);
+    m_copy.new_line();
     m_style.process_tags(node);
     delete_unused_classes('N', node.id());
 
@@ -93,7 +90,7 @@ int output_gazetteer_t::process_node(osmium::Node const &node)
 
 int output_gazetteer_t::process_way(osmium::Way *way)
 {
-    m_copy.new_line(place_table);
+    m_copy.new_line();
     m_style.process_tags(*way);
     delete_unused_classes('W', way->id());
 
@@ -127,7 +124,7 @@ int output_gazetteer_t::process_way(osmium::Way *way)
 
 int output_gazetteer_t::process_relation(osmium::Relation const &rel)
 {
-    m_copy.new_line(place_table);
+    m_copy.new_line();
 
     auto const &tags = rel.tags();
     char const *type = tags["type"];

--- a/src/output-gazetteer.cpp
+++ b/src/output-gazetteer.cpp
@@ -73,16 +73,14 @@ void output_gazetteer_t::commit() { m_copy.sync(); }
 
 int output_gazetteer_t::process_node(osmium::Node const &node)
 {
-    m_copy.new_line();
+    m_copy.prepare();
     m_style.process_tags(node);
     delete_unused_classes('N', node.id());
 
     /* Are we interested in this item? */
     if (m_style.has_data()) {
         auto wkb = m_builder.get_wkb_node(node.location());
-        if (!m_style.copy_out(node, wkb, m_copy)) {
-            delete_unused_full('N', node.id());
-        }
+        m_style.copy_out(node, wkb, m_copy);
     }
 
     return 0;
@@ -90,7 +88,7 @@ int output_gazetteer_t::process_node(osmium::Node const &node)
 
 int output_gazetteer_t::process_way(osmium::Way *way)
 {
-    m_copy.new_line();
+    m_copy.prepare();
     m_style.process_tags(*way);
     delete_unused_classes('W', way->id());
 
@@ -114,9 +112,7 @@ int output_gazetteer_t::process_way(osmium::Way *way)
             geom = wkbs[0];
         }
 
-        if (!m_style.copy_out(*way, geom, m_copy)) {
-            delete_unused_full('W', way->id());
-        }
+        m_style.copy_out(*way, geom, m_copy);
     }
 
     return 0;
@@ -124,7 +120,7 @@ int output_gazetteer_t::process_way(osmium::Way *way)
 
 int output_gazetteer_t::process_relation(osmium::Relation const &rel)
 {
-    m_copy.new_line();
+    m_copy.prepare();
 
     auto const &tags = rel.tags();
     char const *type = tags["type"];
@@ -167,8 +163,10 @@ int output_gazetteer_t::process_relation(osmium::Relation const &rel)
                      ? m_builder.get_wkb_multiline(osmium_buffer, 0.0)
                      : m_builder.get_wkb_multipolygon(rel, osmium_buffer);
 
-    if (geoms.empty() || !m_style.copy_out(rel, geoms[0], m_copy)) {
+    if (geoms.empty()) {
         delete_unused_full('R', rel.id());
+    } else {
+        m_style.copy_out(rel, geoms[0], m_copy);
     }
 
     return 0;

--- a/src/output-gazetteer.hpp
+++ b/src/output-gazetteer.hpp
@@ -115,7 +115,7 @@ private:
         }
     }
 
-    db_copy_mgr_t<db_deleter_place_t> m_copy;
+    gazetteer_copy_mgr_t m_copy;
     gazetteer_style_t m_style;
 
     geom::osmium_builder_t m_builder;

--- a/tests/common-import.hpp
+++ b/tests/common-import.hpp
@@ -69,7 +69,14 @@ public:
         options.database_options = m_db.db_options();
 
         // setup the middle
-        auto middle = std::make_shared<middle_ram_t>(&options);
+        std::shared_ptr<middle_t> middle;
+
+        if (options.slim) {
+            // middle gets its own copy-in thread
+            middle = std::shared_ptr<middle_t>(new middle_pgsql_t(&options));
+        } else {
+            middle = std::shared_ptr<middle_t>(new middle_ram_t(&options));
+        }
         middle->start();
 
         // setup the output

--- a/tests/test-output-gazetteer.cpp
+++ b/tests/test-output-gazetteer.cpp
@@ -16,46 +16,15 @@ static void update(char const *opl)
     REQUIRE_NOTHROW(db.run_import(opt, opl));
 }
 
-static bool has_node(pg::conn_t const &conn, osmid_t id, char const *cls)
+static unsigned long node_count(pg::conn_t const &conn, osmid_t id,
+                                char const *cls)
 {
-    auto row_count =
-        conn.get_count("place", "osm_type = 'N' "
-                                "AND osm_id = {} "
-                                "AND class = '{}'"_format(id, cls));
-
-    CHECK(row_count <= 1);
-
-    return row_count == 1;
+    return conn.get_count("place", "osm_type = 'N' "
+                                   "AND osm_id = {} "
+                                   "AND class = '{}'"_format(id, cls));
 }
 
-TEST_CASE("Import: Main tags")
-{
-    import("n1 Tamenity=restaurant,name=Foobar x12.3 y3\n"
-           "n2 Thighway=bus_stop,railway=stop,name=X x56.4 y-4\n"
-           "n3 Tnatural=no x2 y5\n");
-
-    auto conn = db.connect();
-
-    CHECK(has_node(conn, 1, "amenity"));
-    CHECK(has_node(conn, 2, "highway"));
-    CHECK(has_node(conn, 2, "railway"));
-    CHECK_FALSE(has_node(conn, 3, "natural"));
-}
-
-TEST_CASE("Import: Main tags with name")
-{
-    import("n45 Tlanduse=cemetry x0 y0\n"
-           "n54 Tlanduse=cemetry,name=There x3 y5\n"
-           "n55 Tname:de=Da,landuse=cemetry x0.0 y6.5\n");
-
-    auto conn = db.connect();
-
-    CHECK_FALSE(has_node(conn, 45, "landuse"));
-    CHECK(has_node(conn, 54, "landuse"));
-    CHECK(has_node(conn, 55, "landuse"));
-}
-
-TEST_CASE("Import: Main tags as fallback")
+TEST_CASE("Import main tags as fallback")
 {
     import("n100 Tjunction=yes,highway=bus_stop x0 y0\n"
            "n101 Tjunction=yes,name=Bar x4 y6\n"
@@ -65,9 +34,185 @@ TEST_CASE("Import: Main tags as fallback")
 
     auto conn = db.connect();
 
-    CHECK_FALSE(has_node(conn, 100, "junction"));
-    CHECK(has_node(conn, 101, "junction"));
-    CHECK_FALSE(has_node(conn, 200, "building"));
-    CHECK(has_node(conn, 201, "building"));
-    CHECK_FALSE(has_node(conn, 202, "building"));
+    CHECK(0 == node_count(conn, 100, "junction"));
+    CHECK(1 == node_count(conn, 101, "junction"));
+    CHECK(0 == node_count(conn, 200, "building"));
+    CHECK(1 == node_count(conn, 201, "building"));
+    CHECK(0 == node_count(conn, 202, "building"));
+}
+
+TEST_CASE("Main tag deleted")
+{
+    import("n1 Tamenity=restaurant x12.3 y3\n"
+           "n2 Thighway=bus_stop,railway=stop,name=X x56.4 y-4\n");
+
+    auto conn = db.connect();
+
+    CHECK(1 == node_count(conn, 1, "amenity"));
+    CHECK(1 == node_count(conn, 2, "highway"));
+    CHECK(1 == node_count(conn, 2, "railway"));
+
+    update("n1 Tatiy=restaurant x12.3 y3\n"
+           "n2 Thighway=bus_stop,name=X x56.4 y-4\n");
+
+    CHECK(0 == node_count(conn, 1, "amenity"));
+    CHECK(2 == node_count(conn, 2, "highway"));
+    CHECK(0 == node_count(conn, 2, "railway"));
+}
+
+TEST_CASE("Main tag added")
+{
+    import("n1 Tatiy=restaurant x12.3 y3\n"
+           "n2 Thighway=bus_stop,name=X x56.4 y-4\n");
+
+    auto conn = db.connect();
+
+    CHECK(0 == node_count(conn, 1, "amenity"));
+    CHECK(1 == node_count(conn, 2, "highway"));
+    CHECK(0 == node_count(conn, 2, "railway"));
+
+    update("n1 Tamenity=restaurant x12.3 y3\n"
+           "n2 Thighway=bus_stop,railway=stop,name=X x56.4 y-4\n");
+
+    CHECK(1 == node_count(conn, 1, "amenity"));
+    CHECK(2 == node_count(conn, 2, "highway"));
+    CHECK(1 == node_count(conn, 2, "railway"));
+}
+
+TEST_CASE("Main tag modified")
+{
+    import("n10 Thighway=footway,name=X x10 y11\n"
+           "n11 Tamenity=atm x-10 y-11\n");
+
+    auto conn = db.connect();
+
+    CHECK(1 == node_count(conn, 10, "highway"));
+    CHECK(1 == node_count(conn, 11, "amenity"));
+
+    update("n10 Thighway=path,name=X x10 y11\n"
+           "n11 Thighway=primary x-10 y-11\n");
+
+    CHECK(2 == node_count(conn, 10, "highway"));
+    CHECK(0 == node_count(conn, 11, "amenity"));
+    CHECK(1 == node_count(conn, 11, "highway"));
+}
+
+TEST_CASE("Main tags with name, name added")
+{
+    import("n45 Tlanduse=cemetry x0 y0\n"
+           "n46 Tbuilding=yes x1 y1\n");
+
+    auto conn = db.connect();
+
+    CHECK(0 == node_count(conn, 45, "landuse"));
+    CHECK(0 == node_count(conn, 46, "building"));
+
+    update("n45 Tlanduse=cemetry,name=TODO x0 y0\n"
+           "n46 Tbuilding=yes,addr:housenumber=1 x1 y1\n");
+
+    CHECK(1 == node_count(conn, 45, "landuse"));
+    CHECK(1 == node_count(conn, 46, "building"));
+}
+
+TEST_CASE("Main tags with name, name removed")
+{
+    import("n45 Tlanduse=cemetry,name=TODO x0 y0\n"
+           "n46 Tbuilding=yes,addr:housenumber=1 x1 y1\n");
+
+    auto conn = db.connect();
+
+    CHECK(1 == node_count(conn, 45, "landuse"));
+    CHECK(1 == node_count(conn, 46, "building"));
+
+    update("n45 Tlanduse=cemetry x0 y0\n"
+           "n46 Tbuilding=yes x1 y1\n");
+
+    CHECK(0 == node_count(conn, 45, "landuse"));
+    CHECK(0 == node_count(conn, 46, "building"));
+}
+
+TEST_CASE("Main tags with name, name modified")
+{
+    import("n45 Tlanduse=cemetry,name=TODO x0 y0\n"
+           "n46 Tbuilding=yes,addr:housenumber=1 x1 y1\n");
+
+    auto conn = db.connect();
+
+    CHECK(1 == node_count(conn, 45, "landuse"));
+    CHECK(1 == node_count(conn, 46, "building"));
+
+    update("n45 Tlanduse=cemetry,name=DONE x0 y0\n"
+           "n46 Tbuilding=yes,addr:housenumber=10 x1 y1\n");
+
+    CHECK(2 == node_count(conn, 45, "landuse"));
+    CHECK(2 == node_count(conn, 46, "building"));
+}
+
+TEST_CASE("Main tag added to address only node")
+{
+    import("n1 Taddr:housenumber=345 x0 y0\n");
+
+    auto conn = db.connect();
+
+    CHECK(1 == node_count(conn, 1, "place"));
+    CHECK(0 == node_count(conn, 1, "building"));
+
+    update("n1 Taddr:housenumber=345,building=yes x0 y0\n");
+
+    CHECK(0 == node_count(conn, 1, "place"));
+    CHECK(1 == node_count(conn, 1, "building"));
+}
+
+TEST_CASE("Main tag removed from address only node")
+{
+    import("n1 Taddr:housenumber=345,building=yes x0 y0\n");
+
+    auto conn = db.connect();
+
+    CHECK(0 == node_count(conn, 1, "place"));
+    CHECK(1 == node_count(conn, 1, "building"));
+
+    update("n1 Taddr:housenumber=345 x0 y0\n");
+
+    CHECK(1 == node_count(conn, 1, "place"));
+    CHECK(0 == node_count(conn, 1, "building"));
+}
+
+TEST_CASE("Main tags with name key, adding key name")
+{
+    import("n22 Tbridge=yes x0 y0\n");
+
+    auto conn = db.connect();
+
+    CHECK(0 == node_count(conn, 22, "bridge"));
+
+    update("n22 Tbridge=yes,bridge:name=high x0 y0\n");
+
+    CHECK(1 == node_count(conn, 22, "bridge"));
+}
+
+TEST_CASE("Main tags with name key, deleting key name")
+{
+    import("n22 Tbridge=yes,bridge:name=high x0 y0\n");
+
+    auto conn = db.connect();
+
+    CHECK(1 == node_count(conn, 22, "bridge"));
+
+    update("n22 Tbridge=yes x0 y0\n");
+
+    CHECK(0 == node_count(conn, 22, "bridge"));
+}
+
+TEST_CASE("Main tags with name key, changing key name")
+{
+    import("n22 Tbridge=yes,bridge:name=high x0 y0\n");
+
+    auto conn = db.connect();
+
+    CHECK(1 == node_count(conn, 22, "bridge"));
+
+    update("n22 Tbridge=yes,bridge:name:en=high x0 y0\n");
+
+    CHECK(2 == node_count(conn, 22, "bridge"));
 }

--- a/tests/test-output-gazetteer.cpp
+++ b/tests/test-output-gazetteer.cpp
@@ -52,7 +52,7 @@ TEST_CASE("Main tag deleted")
     CHECK(1 == node_count(conn, 2, "highway"));
     CHECK(1 == node_count(conn, 2, "railway"));
 
-    update("n1 Tatiy=restaurant x12.3 y3\n"
+    update("n1 Tnot_a=restaurant x12.3 y3\n"
            "n2 Thighway=bus_stop,name=X x56.4 y-4\n");
 
     CHECK(0 == node_count(conn, 1, "amenity"));

--- a/tests/test-output-gazetteer.cpp
+++ b/tests/test-output-gazetteer.cpp
@@ -5,72 +5,69 @@
 
 static testing::db::import_t db;
 
-static options_t options() { return testing::opt_t().gazetteer(); }
-
-static pg::result_t require_place(pg::conn_t const &conn, char type, osmid_t id,
-                                  char const *cls, char const *typ)
+static void import(char const *opl)
 {
-    return conn.require_row(
-        "SELECT * FROM place"
-        " WHERE osm_type = '{}' AND osm_id = {}"
-        " AND class = '{}' AND type = '{}'"_format(type, id, cls, typ));
+    REQUIRE_NOTHROW(db.run_import(testing::opt_t().gazetteer().slim(), opl));
 }
 
-static void require_place_not(pg::conn_t const &conn, char type, osmid_t id,
-                              char const *cls)
+static void update(char const *opl)
 {
-    REQUIRE(
-        conn.get_count(
-            "place", "osm_type = '{}' AND osm_id = {} AND class = '{}'"_format(
-                         type, id, cls)) == 0);
+    auto opt = testing::opt_t().gazetteer().slim().append();
+    REQUIRE_NOTHROW(db.run_import(opt, opl));
 }
 
-TEST_CASE("output_gazetteer_t import")
+static bool has_node(pg::conn_t const &conn, osmid_t id, char const *cls)
 {
-    SECTION("Main tags")
-    {
-        REQUIRE_NOTHROW(db.run_import(
-            options(), "n1 Tamenity=restaurant,name=Foobar x12.3 y3\n"
-                       "n2 Thighway=bus_stop,railway=stop,name=X x56.4 y-4\n"
-                       "n3 Tnatural=no x2 y5\n"));
+    auto row_count =
+        conn.get_count("place", "osm_type = 'N' "
+                                "AND osm_id = {} "
+                                "AND class = '{}'"_format(id, cls));
 
-        auto conn = db.connect();
+    CHECK(row_count <= 1);
 
-        require_place(conn, 'N', 1, "amenity", "restaurant");
-        require_place(conn, 'N', 2, "highway", "bus_stop");
-        require_place(conn, 'N', 2, "railway", "stop");
-        require_place_not(conn, 'N', 3, "natural");
-    }
+    return row_count == 1;
+}
 
-    SECTION("Main tags with name")
-    {
-        REQUIRE_NOTHROW(db.run_import(
-            options(), "n45 Tlanduse=cemetry x0 y0\n"
-                       "n54 Tlanduse=cemetry,name=There x3 y5\n"
-                       "n55 Tname:de=Da,landuse=cemetry x0.0 y6.5\n"));
+TEST_CASE("Import: Main tags")
+{
+    import("n1 Tamenity=restaurant,name=Foobar x12.3 y3\n"
+           "n2 Thighway=bus_stop,railway=stop,name=X x56.4 y-4\n"
+           "n3 Tnatural=no x2 y5\n");
 
-        auto conn = db.connect();
+    auto conn = db.connect();
 
-        require_place_not(conn, 'N', 45, "landuse");
-        require_place(conn, 'N', 54, "landuse", "cemetry");
-        require_place(conn, 'N', 55, "landuse", "cemetry");
-    }
+    CHECK(has_node(conn, 1, "amenity"));
+    CHECK(has_node(conn, 2, "highway"));
+    CHECK(has_node(conn, 2, "railway"));
+    CHECK_FALSE(has_node(conn, 3, "natural"));
+}
 
-    SECTION("Main tags as fallback")
-    {
-        REQUIRE_NOTHROW(db.run_import(
-            options(), "n100 Tjunction=yes,highway=bus_stop x0 y0\n"
-                       "n101 Tjunction=yes,name=Bar x4 y6\n"
-                       "n200 Tbuilding=yes,amenity=cafe x3 y7\n"
-                       "n201 Tbuilding=yes,name=Intersting x4 y5\n"
-                       "n202 Tbuilding=yes x6 y9\n"));
+TEST_CASE("Import: Main tags with name")
+{
+    import("n45 Tlanduse=cemetry x0 y0\n"
+           "n54 Tlanduse=cemetry,name=There x3 y5\n"
+           "n55 Tname:de=Da,landuse=cemetry x0.0 y6.5\n");
 
-        auto conn = db.connect();
+    auto conn = db.connect();
 
-        require_place_not(conn, 'N', 100, "junction");
-        require_place(conn, 'N', 101, "junction", "yes");
-        require_place_not(conn, 'N', 200, "building");
-        require_place(conn, 'N', 201, "building", "yes");
-        require_place_not(conn, 'N', 202, "building");
-    }
+    CHECK_FALSE(has_node(conn, 45, "landuse"));
+    CHECK(has_node(conn, 54, "landuse"));
+    CHECK(has_node(conn, 55, "landuse"));
+}
+
+TEST_CASE("Import: Main tags as fallback")
+{
+    import("n100 Tjunction=yes,highway=bus_stop x0 y0\n"
+           "n101 Tjunction=yes,name=Bar x4 y6\n"
+           "n200 Tbuilding=yes,amenity=cafe x3 y7\n"
+           "n201 Tbuilding=yes,name=Intersting x4 y5\n"
+           "n202 Tbuilding=yes x6 y9\n");
+
+    auto conn = db.connect();
+
+    CHECK_FALSE(has_node(conn, 100, "junction"));
+    CHECK(has_node(conn, 101, "junction"));
+    CHECK_FALSE(has_node(conn, 200, "building"));
+    CHECK(has_node(conn, 201, "building"));
+    CHECK_FALSE(has_node(conn, 202, "building"));
 }


### PR DESCRIPTION
Filtering of main tags (i.e. handling of named-only tags or fallback tags) must happen before the actual output because the filtered list is already needed when computing the list of classes to keep. Currently the function that creates the  class list does its own filtering and is inconsistent with  what the output function does.

Also fixes use of new_line().