### PR TITLE
Change return type of osmdata member functions to void

### DIFF
--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -34,7 +34,7 @@ osmdata_t::osmdata_t(std::shared_ptr<middle_t> mid_,
     with_extra = outs[0]->get_options()->extra_attributes;
 }
 
-void osmdata_t::node_add(osmium::Node const &node)
+void osmdata_t::node_add(osmium::Node const &node) const
 {
     mid->nodes_set(node);
 
@@ -45,7 +45,7 @@ void osmdata_t::node_add(osmium::Node const &node)
     }
 }
 
-void osmdata_t::way_add(osmium::Way *way)
+void osmdata_t::way_add(osmium::Way *way) const
 {
     mid->ways_set(*way);
 
@@ -56,7 +56,7 @@ void osmdata_t::way_add(osmium::Way *way)
     }
 }
 
-void osmdata_t::relation_add(osmium::Relation const &rel)
+void osmdata_t::relation_add(osmium::Relation const &rel) const
 {
     mid->relations_set(rel);
 
@@ -67,7 +67,7 @@ void osmdata_t::relation_add(osmium::Relation const &rel)
     }
 }
 
-void osmdata_t::node_modify(osmium::Node const &node)
+void osmdata_t::node_modify(osmium::Node const &node) const
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
@@ -81,7 +81,7 @@ void osmdata_t::node_modify(osmium::Node const &node)
     slim->node_changed(node.id());
 }
 
-void osmdata_t::way_modify(osmium::Way *way)
+void osmdata_t::way_modify(osmium::Way *way) const
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
@@ -95,7 +95,7 @@ void osmdata_t::way_modify(osmium::Way *way)
     slim->way_changed(way->id());
 }
 
-void osmdata_t::relation_modify(osmium::Relation const &rel)
+void osmdata_t::relation_modify(osmium::Relation const &rel) const
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
@@ -109,7 +109,7 @@ void osmdata_t::relation_modify(osmium::Relation const &rel)
     slim->relation_changed(rel.id());
 }
 
-void osmdata_t::node_delete(osmid_t id)
+void osmdata_t::node_delete(osmid_t id) const
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
@@ -120,7 +120,7 @@ void osmdata_t::node_delete(osmid_t id)
     slim->nodes_delete(id);
 }
 
-void osmdata_t::way_delete(osmid_t id)
+void osmdata_t::way_delete(osmid_t id) const
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
@@ -131,7 +131,7 @@ void osmdata_t::way_delete(osmid_t id)
     slim->ways_delete(id);
 }
 
-void osmdata_t::relation_delete(osmid_t id)
+void osmdata_t::relation_delete(osmid_t id) const
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
@@ -142,14 +142,14 @@ void osmdata_t::relation_delete(osmid_t id)
     slim->relations_delete(id);
 }
 
-void osmdata_t::start()
+void osmdata_t::start() const
 {
     for (auto &out : outs) {
         out->start();
     }
 }
 
-void osmdata_t::type_changed(osmium::item_type new_type)
+void osmdata_t::type_changed(osmium::item_type new_type) const
 {
     mid->flush(new_type);
 }
@@ -397,7 +397,7 @@ private:
 
 } // anonymous namespace
 
-void osmdata_t::stop()
+void osmdata_t::stop() const
 {
     /* Commit the transactions, so that multiple processes can
      * access the data simultanious to process the rest in parallel
@@ -410,7 +410,7 @@ void osmdata_t::stop()
     }
 
     // should be the same for all outputs
-    auto *opts = outs[0]->get_options();
+    auto const *opts = outs[0]->get_options();
 
     // are there any objects left pending?
     bool has_pending = mid->pending_count() > 0;

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -34,141 +34,112 @@ osmdata_t::osmdata_t(std::shared_ptr<middle_t> mid_,
     with_extra = outs[0]->get_options()->extra_attributes;
 }
 
-int osmdata_t::node_add(osmium::Node const &node)
+void osmdata_t::node_add(osmium::Node const &node)
 {
     mid->nodes_set(node);
 
-    int status = 0;
-
     if (with_extra || !node.tags().empty()) {
         for (auto &out : outs) {
-            status |= out->node_add(node);
+            out->node_add(node);
         }
     }
-
-    return status;
 }
 
-int osmdata_t::way_add(osmium::Way *way)
+void osmdata_t::way_add(osmium::Way *way)
 {
     mid->ways_set(*way);
 
-    int status = 0;
-
     if (with_extra || !way->tags().empty()) {
         for (auto &out : outs) {
-            status |= out->way_add(way);
+            out->way_add(way);
         }
     }
-
-    return status;
 }
 
-int osmdata_t::relation_add(osmium::Relation const &rel)
+void osmdata_t::relation_add(osmium::Relation const &rel)
 {
     mid->relations_set(rel);
 
-    int status = 0;
     if (with_extra || !rel.tags().empty()) {
         for (auto &out : outs) {
-            status |= out->relation_add(rel);
+            out->relation_add(rel);
         }
     }
-
-    return status;
 }
 
-int osmdata_t::node_modify(osmium::Node const &node)
+void osmdata_t::node_modify(osmium::Node const &node)
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
     slim->nodes_delete(node.id());
     slim->nodes_set(node);
 
-    int status = 0;
     for (auto &out : outs) {
-        status |= out->node_modify(node);
+        out->node_modify(node);
     }
 
     slim->node_changed(node.id());
-
-    return status;
 }
 
-int osmdata_t::way_modify(osmium::Way *way)
+void osmdata_t::way_modify(osmium::Way *way)
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
     slim->ways_delete(way->id());
     slim->ways_set(*way);
 
-    int status = 0;
     for (auto &out : outs) {
-        status |= out->way_modify(way);
+        out->way_modify(way);
     }
 
     slim->way_changed(way->id());
-
-    return status;
 }
 
-int osmdata_t::relation_modify(osmium::Relation const &rel)
+void osmdata_t::relation_modify(osmium::Relation const &rel)
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
     slim->relations_delete(rel.id());
     slim->relations_set(rel);
 
-    int status = 0;
     for (auto &out : outs) {
-        status |= out->relation_modify(rel);
+        out->relation_modify(rel);
     }
 
     slim->relation_changed(rel.id());
-
-    return status;
 }
 
-int osmdata_t::node_delete(osmid_t id)
+void osmdata_t::node_delete(osmid_t id)
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
-    int status = 0;
     for (auto &out : outs) {
-        status |= out->node_delete(id);
+        out->node_delete(id);
     }
 
     slim->nodes_delete(id);
-
-    return status;
 }
 
-int osmdata_t::way_delete(osmid_t id)
+void osmdata_t::way_delete(osmid_t id)
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
-    int status = 0;
     for (auto &out : outs) {
-        status |= out->way_delete(id);
+        out->way_delete(id);
     }
 
     slim->ways_delete(id);
-
-    return status;
 }
 
-int osmdata_t::relation_delete(osmid_t id)
+void osmdata_t::relation_delete(osmid_t id)
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
 
-    int status = 0;
     for (auto &out : outs) {
-        status |= out->relation_delete(id);
+        out->relation_delete(id);
     }
 
     slim->relations_delete(id);
-
-    return status;
 }
 
 void osmdata_t::start()

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -26,17 +26,17 @@ public:
     void type_changed(osmium::item_type new_type);
     void stop();
 
-    int node_add(osmium::Node const &node);
-    int way_add(osmium::Way *way);
-    int relation_add(osmium::Relation const &rel);
+    void node_add(osmium::Node const &node);
+    void way_add(osmium::Way *way);
+    void relation_add(osmium::Relation const &rel);
 
-    int node_modify(osmium::Node const &node);
-    int way_modify(osmium::Way *way);
-    int relation_modify(osmium::Relation const &rel);
+    void node_modify(osmium::Node const &node);
+    void way_modify(osmium::Way *way);
+    void relation_modify(osmium::Relation const &rel);
 
-    int node_delete(osmid_t id);
-    int way_delete(osmid_t id);
-    int relation_delete(osmid_t id);
+    void node_delete(osmid_t id);
+    void way_delete(osmid_t id);
+    void relation_delete(osmid_t id);
 
 private:
     std::shared_ptr<middle_t> mid;

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -22,21 +22,21 @@ public:
     osmdata_t(std::shared_ptr<middle_t> mid_,
               std::vector<std::shared_ptr<output_t>> const &outs_);
 
-    void start();
-    void type_changed(osmium::item_type new_type);
-    void stop();
+    void start() const;
+    void type_changed(osmium::item_type new_type) const;
+    void stop() const;
 
-    void node_add(osmium::Node const &node);
-    void way_add(osmium::Way *way);
-    void relation_add(osmium::Relation const &rel);
+    void node_add(osmium::Node const &node) const;
+    void way_add(osmium::Way *way) const;
+    void relation_add(osmium::Relation const &rel) const;
 
-    void node_modify(osmium::Node const &node);
-    void way_modify(osmium::Way *way);
-    void relation_modify(osmium::Relation const &rel);
+    void node_modify(osmium::Node const &node) const;
+    void way_modify(osmium::Way *way) const;
+    void relation_modify(osmium::Relation const &rel) const;
 
-    void node_delete(osmid_t id);
-    void way_delete(osmid_t id);
-    void relation_delete(osmid_t id);
+    void node_delete(osmid_t id) const;
+    void way_delete(osmid_t id) const;
+    void relation_delete(osmid_t id) const;
 
 private:
     std::shared_ptr<middle_t> mid;


### PR DESCRIPTION
The result of these functions is not used, so they can be void. This is the first part of a refactoring, the same will be needed for the functions in the outputs called by the functions here.