### PR TITLE
Make some functions return void instead of int

### DIFF
--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <cstdio>
 #include <functional>
 #include <future>
@@ -10,7 +11,6 @@
 
 #include "db-copy.hpp"
 #include "middle.hpp"
-#include "node-ram-cache.hpp"
 #include "osmdata.hpp"
 #include "output.hpp"
 
@@ -400,7 +400,7 @@ private:
 void osmdata_t::stop() const
 {
     /* Commit the transactions, so that multiple processes can
-     * access the data simultanious to process the rest in parallel
+     * access the data simultaneously to process the rest in parallel
      * as well as see the newly created tables.
      */
     mid->commit();

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -8,7 +8,6 @@
 
 class output_t;
 struct middle_t;
-class reprojection;
 
 class osmdata_t
 {

--- a/src/output-gazetteer.cpp
+++ b/src/output-gazetteer.cpp
@@ -28,7 +28,7 @@ void output_gazetteer_t::delete_unused_classes(char osm_type, osmid_t osm_id)
     }
 }
 
-int output_gazetteer_t::start()
+void output_gazetteer_t::start()
 {
     int srid = m_options.projection->target_srs();
 
@@ -65,8 +65,6 @@ int output_gazetteer_t::start()
         }
         conn.exec(index_sql);
     }
-
-    return 0;
 }
 
 void output_gazetteer_t::commit() { m_copy.sync(); }

--- a/src/output-gazetteer.hpp
+++ b/src/output-gazetteer.hpp
@@ -42,7 +42,7 @@ public:
             new output_gazetteer_t(this, mid, copy_thread));
     }
 
-    int start() override;
+    void start() override;
     void stop(osmium::thread::Pool *) override {}
     void commit() override;
 

--- a/src/output-gazetteer.hpp
+++ b/src/output-gazetteer.hpp
@@ -54,47 +54,29 @@ public:
     {}
     int pending_relation(osmid_t, int) override { return 0; }
 
-    int node_add(osmium::Node const &node) override
+    void node_add(osmium::Node const &node) override { process_node(node); }
+
+    void way_add(osmium::Way *way) override { process_way(way); }
+
+    void relation_add(osmium::Relation const &rel) override
     {
-        return process_node(node);
+        process_relation(rel);
     }
 
-    int way_add(osmium::Way *way) override { return process_way(way); }
+    void node_modify(osmium::Node const &node) override { process_node(node); }
 
-    int relation_add(osmium::Relation const &rel) override
+    void way_modify(osmium::Way *way) override { process_way(way); }
+
+    void relation_modify(osmium::Relation const &rel) override
     {
-        return process_relation(rel);
+        process_relation(rel);
     }
 
-    int node_modify(osmium::Node const &node) override
-    {
-        return process_node(node);
-    }
+    void node_delete(osmid_t id) override { m_copy.delete_object('N', id); }
 
-    int way_modify(osmium::Way *way) override { return process_way(way); }
+    void way_delete(osmid_t id) override { m_copy.delete_object('W', id); }
 
-    int relation_modify(osmium::Relation const &rel) override
-    {
-        return process_relation(rel);
-    }
-
-    int node_delete(osmid_t id) override
-    {
-        m_copy.delete_object('N', id);
-        return 0;
-    }
-
-    int way_delete(osmid_t id) override
-    {
-        m_copy.delete_object('W', id);
-        return 0;
-    }
-
-    int relation_delete(osmid_t id) override
-    {
-        m_copy.delete_object('R', id);
-        return 0;
-    }
+    void relation_delete(osmid_t id) override { m_copy.delete_object('R', id); }
 
 private:
     enum

--- a/src/output-gazetteer.hpp
+++ b/src/output-gazetteer.hpp
@@ -86,9 +86,9 @@ private:
 
     /// Delete all places that are not covered by the current style results.
     void delete_unused_classes(char osm_type, osmid_t osm_id);
-    int process_node(osmium::Node const &node);
-    int process_way(osmium::Way *way);
-    int process_relation(osmium::Relation const &rel);
+    void process_node(osmium::Node const &node);
+    void process_way(osmium::Way *way);
+    void process_relation(osmium::Relation const &rel);
 
     void delete_unused_full(char osm_type, osmid_t osm_id)
     {

--- a/src/output-gazetteer.hpp
+++ b/src/output-gazetteer.hpp
@@ -47,12 +47,12 @@ public:
     void commit() override;
 
     void enqueue_ways(pending_queue_t &, osmid_t, size_t, size_t &) override {}
-    int pending_way(osmid_t, int) override { return 0; }
+    void pending_way(osmid_t, int) override {}
 
     void enqueue_relations(pending_queue_t &, osmid_t, size_t,
                            size_t &) override
     {}
-    int pending_relation(osmid_t, int) override { return 0; }
+    void pending_relation(osmid_t, int) override {}
 
     void node_add(osmium::Node const &node) override { process_node(node); }
 

--- a/src/output-multi.cpp
+++ b/src/output-multi.cpp
@@ -120,18 +120,14 @@ void output_multi_t::enqueue_ways(pending_queue_t &job_queue, osmid_t id,
     }
 }
 
-int output_multi_t::pending_way(osmid_t id, int exists)
+void output_multi_t::pending_way(osmid_t id, int exists)
 {
-    int ret = 0;
-
     // Try to fetch the way from the DB
     buffer.clear();
     if (m_mid->ways_get(id, buffer)) {
         // Output the way
-        ret = reprocess_way(&buffer.get<osmium::Way>(0), exists);
+        reprocess_way(&buffer.get<osmium::Way>(0), exists);
     }
-
-    return ret;
 }
 
 void output_multi_t::enqueue_relations(pending_queue_t &job_queue, osmid_t id,
@@ -174,18 +170,14 @@ void output_multi_t::enqueue_relations(pending_queue_t &job_queue, osmid_t id,
     }
 }
 
-int output_multi_t::pending_relation(osmid_t id, int exists)
+void output_multi_t::pending_relation(osmid_t id, int exists)
 {
-    int ret = 0;
-
     // Try to fetch the relation from the DB
     buffer.clear();
     if (m_mid->relations_get(id, buffer)) {
         auto const &rel = buffer.get<osmium::Relation>(0);
-        ret = process_relation(rel, exists);
+        process_relation(rel, exists);
     }
-
-    return ret;
 }
 
 void output_multi_t::stop(osmium::thread::Pool *pool)

--- a/src/output-multi.cpp
+++ b/src/output-multi.cpp
@@ -276,7 +276,7 @@ void output_multi_t::relation_delete(osmid_t id)
     }
 }
 
-int output_multi_t::process_node(osmium::Node const &node)
+void output_multi_t::process_node(osmium::Node const &node)
 {
     // check if we are keeping this node
     taglist_t outtags;
@@ -290,10 +290,9 @@ int output_multi_t::process_node(osmium::Node const &node)
             copy_node_to_table(node.id(), geom, outtags);
         }
     }
-    return 0;
 }
 
-int output_multi_t::reprocess_way(osmium::Way *way, bool exists)
+void output_multi_t::reprocess_way(osmium::Way *way, bool exists)
 {
     //if the way could exist already we have to make the relation pending and reprocess it later
     //but only if we actually care about relations
@@ -319,10 +318,9 @@ int output_multi_t::reprocess_way(osmium::Way *way, bool exists)
             copy_to_table(way->id(), geom, outtags);
         }
     }
-    return 0;
 }
 
-int output_multi_t::process_way(osmium::Way *way)
+void output_multi_t::process_way(osmium::Way *way)
 {
     //check if we are keeping this way
     taglist_t outtags;
@@ -331,7 +329,7 @@ int output_multi_t::process_way(osmium::Way *way)
     if (!filter) {
         //get the geom from the middle
         if (m_mid->nodes_get_list(&(way->nodes())) < 1) {
-            return 0;
+            return;
         }
         //grab its geom
         auto geom = m_processor->process_way(*way, &m_builder);
@@ -348,10 +346,9 @@ int output_multi_t::process_way(osmium::Way *way)
             }
         }
     }
-    return 0;
 }
 
-int output_multi_t::process_relation(osmium::Relation const &rel, bool exists)
+void output_multi_t::process_relation(osmium::Relation const &rel, bool exists)
 {
     //if it may exist already, delete it first
     if (exists) {
@@ -366,7 +363,7 @@ int output_multi_t::process_relation(osmium::Relation const &rel, bool exists)
         //TODO: move this into geometry processor, figure a way to come back for tag transform
         //grab ways/nodes of the members in the relation, bail if none were used
         if (m_relation_helper.set(rel, m_mid.get()) < 1) {
-            return 0;
+            return;
         }
 
         //NOTE: make_polygon is preset here this is to force the tag matching
@@ -390,7 +387,6 @@ int output_multi_t::process_relation(osmium::Relation const &rel, bool exists)
             }
         }
     }
-    return 0;
 }
 
 void output_multi_t::copy_node_to_table(osmid_t id, std::string const &geom,

--- a/src/output-multi.cpp
+++ b/src/output-multi.cpp
@@ -202,33 +202,30 @@ void output_multi_t::stop(osmium::thread::Pool *pool)
 
 void output_multi_t::commit() { m_table->commit(); }
 
-int output_multi_t::node_add(osmium::Node const &node)
+void output_multi_t::node_add(osmium::Node const &node)
 {
     if (m_processor->interests(geometry_processor::interest_node)) {
-        return process_node(node);
+        process_node(node);
     }
-    return 0;
 }
 
-int output_multi_t::way_add(osmium::Way *way)
+void output_multi_t::way_add(osmium::Way *way)
 {
     if (m_processor->interests(geometry_processor::interest_way) &&
         way->nodes().size() > 1) {
-        return process_way(way);
+        process_way(way);
     }
-    return 0;
 }
 
-int output_multi_t::relation_add(osmium::Relation const &rel)
+void output_multi_t::relation_add(osmium::Relation const &rel)
 {
     if (m_processor->interests(geometry_processor::interest_relation) &&
         !rel.members().empty()) {
-        return process_relation(rel, 0);
+        process_relation(rel, 0);
     }
-    return 0;
 }
 
-int output_multi_t::node_modify(osmium::Node const &node)
+void output_multi_t::node_modify(osmium::Node const &node)
 {
     if (m_processor->interests(geometry_processor::interest_node)) {
         // TODO - need to know it's a node?
@@ -236,13 +233,11 @@ int output_multi_t::node_modify(osmium::Node const &node)
 
         // TODO: need to mark any ways or relations using it - depends on what
         // type of output this is... delegate to the geometry processor??
-        return process_node(node);
+        process_node(node);
     }
-
-    return 0;
 }
 
-int output_multi_t::way_modify(osmium::Way *way)
+void output_multi_t::way_modify(osmium::Way *way)
 {
     if (m_processor->interests(geometry_processor::interest_way)) {
         // TODO - need to know it's a way?
@@ -250,13 +245,11 @@ int output_multi_t::way_modify(osmium::Way *way)
 
         // TODO: need to mark any relations using it - depends on what
         // type of output this is... delegate to the geometry processor??
-        return process_way(way);
+        process_way(way);
     }
-
-    return 0;
 }
 
-int output_multi_t::relation_modify(osmium::Relation const &rel)
+void output_multi_t::relation_modify(osmium::Relation const &rel)
 {
     if (m_processor->interests(geometry_processor::interest_relation)) {
         // TODO - need to know it's a relation?
@@ -264,37 +257,32 @@ int output_multi_t::relation_modify(osmium::Relation const &rel)
 
         // TODO: need to mark any other relations using it - depends on what
         // type of output this is... delegate to the geometry processor??
-        return process_relation(rel, false);
+        process_relation(rel, false);
     }
-
-    return 0;
 }
 
-int output_multi_t::node_delete(osmid_t id)
+void output_multi_t::node_delete(osmid_t id)
 {
     if (m_processor->interests(geometry_processor::interest_node)) {
         // TODO - need to know it's a node?
         delete_from_output(id);
     }
-    return 0;
 }
 
-int output_multi_t::way_delete(osmid_t id)
+void output_multi_t::way_delete(osmid_t id)
 {
     if (m_processor->interests(geometry_processor::interest_way)) {
         // TODO - need to know it's a way?
         delete_from_output(id);
     }
-    return 0;
 }
 
-int output_multi_t::relation_delete(osmid_t id)
+void output_multi_t::relation_delete(osmid_t id)
 {
     if (m_processor->interests(geometry_processor::interest_relation)) {
         // TODO - need to know it's a relation?
         delete_from_output(-id);
     }
-    return 0;
 }
 
 int output_multi_t::process_node(osmium::Node const &node)

--- a/src/output-multi.cpp
+++ b/src/output-multi.cpp
@@ -65,11 +65,10 @@ std::shared_ptr<output_t> output_multi_t::clone(
         new output_multi_t(this, mid, copy_thread));
 }
 
-int output_multi_t::start()
+void output_multi_t::start()
 {
     m_table->start(m_options.database_options.conninfo(),
                    m_options.tblsmain_data);
-    return 0;
 }
 
 size_t output_multi_t::pending_count() const

--- a/src/output-multi.hpp
+++ b/src/output-multi.hpp
@@ -54,17 +54,17 @@ public:
                            size_t output_id, size_t &added) override;
     int pending_relation(osmid_t id, int exists) override;
 
-    int node_add(osmium::Node const &node) override;
-    int way_add(osmium::Way *way) override;
-    int relation_add(osmium::Relation const &rel) override;
+    void node_add(osmium::Node const &node) override;
+    void way_add(osmium::Way *way) override;
+    void relation_add(osmium::Relation const &rel) override;
 
-    int node_modify(osmium::Node const &node) override;
-    int way_modify(osmium::Way *way) override;
-    int relation_modify(osmium::Relation const &rel) override;
+    void node_modify(osmium::Node const &node) override;
+    void way_modify(osmium::Way *way) override;
+    void relation_modify(osmium::Relation const &rel) override;
 
-    int node_delete(osmid_t id) override;
-    int way_delete(osmid_t id) override;
-    int relation_delete(osmid_t id) override;
+    void node_delete(osmid_t id) override;
+    void way_delete(osmid_t id) override;
+    void relation_delete(osmid_t id) override;
 
     size_t pending_count() const override;
 

--- a/src/output-multi.hpp
+++ b/src/output-multi.hpp
@@ -42,7 +42,7 @@ public:
     clone(std::shared_ptr<middle_query_t> const &mid,
           std::shared_ptr<db_copy_thread_t> const &copy_thread) const override;
 
-    int start() override;
+    void start() override;
     void stop(osmium::thread::Pool *pool) override;
     void commit() override;
 

--- a/src/output-multi.hpp
+++ b/src/output-multi.hpp
@@ -73,10 +73,10 @@ public:
 
 protected:
     void delete_from_output(osmid_t id);
-    int process_node(osmium::Node const &node);
-    int process_way(osmium::Way *way);
-    int reprocess_way(osmium::Way *way, bool exists);
-    int process_relation(osmium::Relation const &rel, bool exists);
+    void process_node(osmium::Node const &node);
+    void process_way(osmium::Way *way);
+    void reprocess_way(osmium::Way *way, bool exists);
+    void process_relation(osmium::Relation const &rel, bool exists);
     void copy_node_to_table(osmid_t id, const std::string &geom,
                             taglist_t &tags);
     void copy_to_table(const osmid_t id, geometry_processor::wkb_t const &geom,

--- a/src/output-multi.hpp
+++ b/src/output-multi.hpp
@@ -48,11 +48,11 @@ public:
 
     void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id,
                       size_t &added) override;
-    int pending_way(osmid_t id, int exists) override;
+    void pending_way(osmid_t id, int exists) override;
 
     void enqueue_relations(pending_queue_t &job_queue, osmid_t id,
                            size_t output_id, size_t &added) override;
-    int pending_relation(osmid_t id, int exists) override;
+    void pending_relation(osmid_t id, int exists) override;
 
     void node_add(osmium::Node const &node) override;
     void way_add(osmium::Way *way) override;

--- a/src/output-null.cpp
+++ b/src/output-null.cpp
@@ -12,13 +12,9 @@ void output_null_t::commit() {}
 void output_null_t::enqueue_ways(pending_queue_t &, osmid_t, size_t, size_t &)
 {}
 
-int output_null_t::pending_way(osmid_t, int) { return 0; }
-
 void output_null_t::enqueue_relations(pending_queue_t &, osmid_t, size_t,
                                       size_t &)
 {}
-
-int output_null_t::pending_relation(osmid_t, int) { return 0; }
 
 std::shared_ptr<output_t>
 output_null_t::clone(std::shared_ptr<middle_query_t> const &mid,

--- a/src/output-null.cpp
+++ b/src/output-null.cpp
@@ -20,24 +20,6 @@ void output_null_t::enqueue_relations(pending_queue_t &, osmid_t, size_t,
 
 int output_null_t::pending_relation(osmid_t, int) { return 0; }
 
-int output_null_t::node_add(osmium::Node const &) { return 0; }
-
-int output_null_t::way_add(osmium::Way *) { return 0; }
-
-int output_null_t::relation_add(osmium::Relation const &) { return 0; }
-
-int output_null_t::node_delete(osmid_t) { return 0; }
-
-int output_null_t::way_delete(osmid_t) { return 0; }
-
-int output_null_t::relation_delete(osmid_t) { return 0; }
-
-int output_null_t::node_modify(osmium::Node const &) { return 0; }
-
-int output_null_t::way_modify(osmium::Way *) { return 0; }
-
-int output_null_t::relation_modify(osmium::Relation const &) { return 0; }
-
 std::shared_ptr<output_t>
 output_null_t::clone(std::shared_ptr<middle_query_t> const &mid,
                      std::shared_ptr<db_copy_thread_t> const &) const

--- a/src/output-null.cpp
+++ b/src/output-null.cpp
@@ -1,21 +1,6 @@
 #include "output-null.hpp"
 #include "osmtypes.hpp"
 
-void output_null_t::cleanup() {}
-
-int output_null_t::start() { return 0; }
-
-void output_null_t::stop(osmium::thread::Pool *) {}
-
-void output_null_t::commit() {}
-
-void output_null_t::enqueue_ways(pending_queue_t &, osmid_t, size_t, size_t &)
-{}
-
-void output_null_t::enqueue_relations(pending_queue_t &, osmid_t, size_t,
-                                      size_t &)
-{}
-
 std::shared_ptr<output_t>
 output_null_t::clone(std::shared_ptr<middle_query_t> const &mid,
                      std::shared_ptr<db_copy_thread_t> const &) const

--- a/src/output-null.hpp
+++ b/src/output-null.hpp
@@ -24,11 +24,11 @@ public:
 
     void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id,
                       size_t &added) override;
-    int pending_way(osmid_t id, int exists) override;
+    void pending_way(osmid_t id, int exists) override {};
 
     void enqueue_relations(pending_queue_t &job_queue, osmid_t id,
                            size_t output_id, size_t &added) override;
-    int pending_relation(osmid_t id, int exists) override;
+    void pending_relation(osmid_t id, int exists) override {};
 
     void node_add(osmium::Node const &node) override {}
     void way_add(osmium::Way *way) override {}

--- a/src/output-null.hpp
+++ b/src/output-null.hpp
@@ -17,18 +17,22 @@ public:
     clone(std::shared_ptr<middle_query_t> const &mid,
           std::shared_ptr<db_copy_thread_t> const &copy_thread) const override;
 
-    int start() override;
-    void stop(osmium::thread::Pool *pool) override;
-    void commit() override;
-    void cleanup(void);
+    void start() override {}
+    void stop(osmium::thread::Pool *pool) override {}
+    void commit() override {}
+    void cleanup() {}
 
     void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id,
-                      size_t &added) override;
-    void pending_way(osmid_t id, int exists) override {};
+                      size_t &added) override
+    {}
+
+    void pending_way(osmid_t id, int exists) override {}
 
     void enqueue_relations(pending_queue_t &job_queue, osmid_t id,
-                           size_t output_id, size_t &added) override;
-    void pending_relation(osmid_t id, int exists) override {};
+                           size_t output_id, size_t &added) override
+    {}
+
+    void pending_relation(osmid_t id, int exists) override {}
 
     void node_add(osmium::Node const &node) override {}
     void way_add(osmium::Way *way) override {}

--- a/src/output-null.hpp
+++ b/src/output-null.hpp
@@ -30,17 +30,17 @@ public:
                            size_t output_id, size_t &added) override;
     int pending_relation(osmid_t id, int exists) override;
 
-    int node_add(osmium::Node const &node) override;
-    int way_add(osmium::Way *way) override;
-    int relation_add(osmium::Relation const &rel) override;
+    void node_add(osmium::Node const &node) override {}
+    void way_add(osmium::Way *way) override {}
+    void relation_add(osmium::Relation const &rel) override {}
 
-    int node_modify(osmium::Node const &node) override;
-    int way_modify(osmium::Way *way) override;
-    int relation_modify(osmium::Relation const &rel) override;
+    void node_modify(osmium::Node const &node) override {}
+    void way_modify(osmium::Way *way) override {}
+    void relation_modify(osmium::Relation const &rel) override {}
 
-    int node_delete(osmid_t id) override;
-    int way_delete(osmid_t id) override;
-    int relation_delete(osmid_t id) override;
+    void node_delete(osmid_t id) override {}
+    void way_delete(osmid_t id) override {}
+    void relation_delete(osmid_t id) override {}
 };
 
 #endif // OSM2PGSQL_OUTPUT_NULL_HPP

--- a/src/output-null.hpp
+++ b/src/output-null.hpp
@@ -18,33 +18,33 @@ public:
           std::shared_ptr<db_copy_thread_t> const &copy_thread) const override;
 
     void start() override {}
-    void stop(osmium::thread::Pool *pool) override {}
+    void stop(osmium::thread::Pool * /*pool*/) override {}
     void commit() override {}
     void cleanup() {}
 
-    void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id,
-                      size_t &added) override
+    void enqueue_ways(pending_queue_t & /*job_queue*/, osmid_t /*id*/, size_t /*output_id*/,
+                      size_t & /*added*/) override
     {}
 
-    void pending_way(osmid_t id, int exists) override {}
+    void pending_way(osmid_t /*id*/, int /*exists*/) override {}
 
-    void enqueue_relations(pending_queue_t &job_queue, osmid_t id,
-                           size_t output_id, size_t &added) override
+    void enqueue_relations(pending_queue_t & /*job_queue*/, osmid_t /*id*/,
+                           size_t /*output_id*/, size_t & /*added*/) override
     {}
 
-    void pending_relation(osmid_t id, int exists) override {}
+    void pending_relation(osmid_t /*id*/, int /*exists*/) override {}
 
-    void node_add(osmium::Node const &node) override {}
-    void way_add(osmium::Way *way) override {}
-    void relation_add(osmium::Relation const &rel) override {}
+    void node_add(osmium::Node const & /*node*/) override {}
+    void way_add(osmium::Way * /*way*/) override {}
+    void relation_add(osmium::Relation const & /*rel*/) override {}
 
-    void node_modify(osmium::Node const &node) override {}
-    void way_modify(osmium::Way *way) override {}
-    void relation_modify(osmium::Relation const &rel) override {}
+    void node_modify(osmium::Node const & /*node*/) override {}
+    void way_modify(osmium::Way * /*way*/) override {}
+    void relation_modify(osmium::Relation const & /*rel*/) override {}
 
-    void node_delete(osmid_t id) override {}
-    void way_delete(osmid_t id) override {}
-    void relation_delete(osmid_t id) override {}
+    void node_delete(osmid_t /*id*/) override {}
+    void way_delete(osmid_t /*id*/) override {}
+    void relation_delete(osmid_t /*id*/) override {}
 };
 
 #endif // OSM2PGSQL_OUTPUT_NULL_HPP

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -111,7 +111,7 @@ void output_pgsql_t::enqueue_ways(pending_queue_t &job_queue, osmid_t id,
     }
 }
 
-int output_pgsql_t::pending_way(osmid_t id, int exists)
+void output_pgsql_t::pending_way(osmid_t id, int exists)
 {
     // Try to fetch the way from the DB
     buffer.clear();
@@ -136,12 +136,10 @@ int output_pgsql_t::pending_way(osmid_t id, int exists)
             auto nnodes = m_mid->nodes_get_list(&(way.nodes()));
             if (nnodes > 1) {
                 pgsql_out_way(way, &outtags, polygon, roads);
-                return 1;
+                return;
             }
         }
     }
-
-    return 0;
 }
 
 void output_pgsql_t::enqueue_relations(pending_queue_t &job_queue, osmid_t id,
@@ -184,7 +182,7 @@ void output_pgsql_t::enqueue_relations(pending_queue_t &job_queue, osmid_t id,
     }
 }
 
-int output_pgsql_t::pending_relation(osmid_t id, int exists)
+void output_pgsql_t::pending_relation(osmid_t id, int exists)
 {
     // Try to fetch the relation from the DB
     // Note that we cannot use the global buffer here because
@@ -198,10 +196,9 @@ int output_pgsql_t::pending_relation(osmid_t id, int exists)
         }
 
         auto const &rel = rels_buffer.get<osmium::Relation>(0);
-        return pgsql_process_relation(rel);
+        pgsql_process_relation(rel);
+        return;
     }
-
-    return 0;
 }
 
 void output_pgsql_t::commit()

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -197,7 +197,6 @@ void output_pgsql_t::pending_relation(osmid_t id, int exists)
 
         auto const &rel = rels_buffer.get<osmium::Relation>(0);
         pgsql_process_relation(rel);
-        return;
     }
 }
 

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -454,15 +454,13 @@ void output_pgsql_t::relation_modify(osmium::Relation const &rel)
     relation_add(rel);
 }
 
-int output_pgsql_t::start()
+void output_pgsql_t::start()
 {
     for (auto &t : m_tables) {
         //setup the table in postgres
         t->start(m_options.database_options.conninfo(),
                  m_options.tblsmain_data);
     }
-
-    return 0;
 }
 
 std::shared_ptr<output_t> output_pgsql_t::clone(

--- a/src/output-pgsql.hpp
+++ b/src/output-pgsql.hpp
@@ -54,17 +54,17 @@ public:
                            size_t output_id, size_t &added) override;
     int pending_relation(osmid_t id, int exists) override;
 
-    int node_add(osmium::Node const &node) override;
-    int way_add(osmium::Way *way) override;
-    int relation_add(osmium::Relation const &rel) override;
+    void node_add(osmium::Node const &node) override;
+    void way_add(osmium::Way *way) override;
+    void relation_add(osmium::Relation const &rel) override;
 
-    int node_modify(osmium::Node const &node) override;
-    int way_modify(osmium::Way *way) override;
-    int relation_modify(osmium::Relation const &rel) override;
+    void node_modify(osmium::Node const &node) override;
+    void way_modify(osmium::Way *way) override;
+    void relation_modify(osmium::Relation const &rel) override;
 
-    int node_delete(osmid_t id) override;
-    int way_delete(osmid_t id) override;
-    int relation_delete(osmid_t id) override;
+    void node_delete(osmid_t id) override;
+    void way_delete(osmid_t id) override;
+    void relation_delete(osmid_t id) override;
 
     size_t pending_count() const override;
 

--- a/src/output-pgsql.hpp
+++ b/src/output-pgsql.hpp
@@ -74,9 +74,9 @@ public:
 protected:
     void pgsql_out_way(osmium::Way const &way, taglist_t *tags, bool polygon,
                        bool roads);
-    int pgsql_process_relation(osmium::Relation const &rel);
-    int pgsql_delete_way_from_output(osmid_t osm_id);
-    int pgsql_delete_relation_from_output(osmid_t osm_id);
+    void pgsql_process_relation(osmium::Relation const &rel);
+    void pgsql_delete_way_from_output(osmid_t osm_id);
+    void pgsql_delete_relation_from_output(osmid_t osm_id);
 
     std::unique_ptr<tagtransform_t> m_tagtransform;
 

--- a/src/output-pgsql.hpp
+++ b/src/output-pgsql.hpp
@@ -42,7 +42,7 @@ public:
     clone(std::shared_ptr<middle_query_t> const &mid,
           std::shared_ptr<db_copy_thread_t> const &copy_thread) const override;
 
-    int start() override;
+    void start() override;
     void stop(osmium::thread::Pool *pool) override;
     void commit() override;
 

--- a/src/output-pgsql.hpp
+++ b/src/output-pgsql.hpp
@@ -48,11 +48,11 @@ public:
 
     void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id,
                       size_t &added) override;
-    int pending_way(osmid_t id, int exists) override;
+    void pending_way(osmid_t id, int exists) override;
 
     void enqueue_relations(pending_queue_t &job_queue, osmid_t id,
                            size_t output_id, size_t &added) override;
-    int pending_relation(osmid_t id, int exists) override;
+    void pending_relation(osmid_t id, int exists) override;
 
     void node_add(osmium::Node const &node) override;
     void way_add(osmium::Way *way) override;

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -59,17 +59,17 @@ public:
                                    size_t output_id, size_t &added) = 0;
     virtual int pending_relation(osmid_t id, int exists) = 0;
 
-    virtual int node_add(osmium::Node const &node) = 0;
-    virtual int way_add(osmium::Way *way) = 0;
-    virtual int relation_add(osmium::Relation const &rel) = 0;
+    virtual void node_add(osmium::Node const &node) = 0;
+    virtual void way_add(osmium::Way *way) = 0;
+    virtual void relation_add(osmium::Relation const &rel) = 0;
 
-    virtual int node_modify(osmium::Node const &node) = 0;
-    virtual int way_modify(osmium::Way *way) = 0;
-    virtual int relation_modify(osmium::Relation const &rel) = 0;
+    virtual void node_modify(osmium::Node const &node) = 0;
+    virtual void way_modify(osmium::Way *way) = 0;
+    virtual void relation_modify(osmium::Relation const &rel) = 0;
 
-    virtual int node_delete(osmid_t id) = 0;
-    virtual int way_delete(osmid_t id) = 0;
-    virtual int relation_delete(osmid_t id) = 0;
+    virtual void node_delete(osmid_t id) = 0;
+    virtual void way_delete(osmid_t id) = 0;
+    virtual void relation_delete(osmid_t id) = 0;
 
     virtual size_t pending_count() const;
 

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -47,7 +47,7 @@ public:
     clone(std::shared_ptr<middle_query_t> const &mid,
           std::shared_ptr<db_copy_thread_t> const &copy_thread) const = 0;
 
-    virtual int start() = 0;
+    virtual void start() = 0;
     virtual void stop(osmium::thread::Pool *pool) = 0;
     virtual void commit() = 0;
 

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -53,11 +53,11 @@ public:
 
     virtual void enqueue_ways(pending_queue_t &job_queue, osmid_t id,
                               size_t output_id, size_t &added) = 0;
-    virtual int pending_way(osmid_t id, int exists) = 0;
+    virtual void pending_way(osmid_t id, int exists) = 0;
 
     virtual void enqueue_relations(pending_queue_t &job_queue, osmid_t id,
                                    size_t output_id, size_t &added) = 0;
-    virtual int pending_relation(osmid_t id, int exists) = 0;
+    virtual void pending_relation(osmid_t id, int exists) = 0;
 
     virtual void node_add(osmium::Node const &node) = 0;
     virtual void way_add(osmium::Way *way) = 0;

--- a/tests/test-parse-osmium.cpp
+++ b/tests/test-parse-osmium.cpp
@@ -65,63 +65,40 @@ struct counting_output_t : public output_null_t
         return std::shared_ptr<output_t>(new counting_output_t(m_options));
     }
 
-    int node_add(osmium::Node const &n) override
+    void node_add(osmium::Node const &n) override
     {
         ++node.added;
         sum_ids += n.id();
-        return 0;
     }
 
-    int way_add(osmium::Way *w) override
+    void way_add(osmium::Way *w) override
     {
         ++way.added;
         sum_ids += w->id();
         sum_nds += w->nodes().size();
-        return 0;
     }
 
-    int relation_add(osmium::Relation const &r) override
+    void relation_add(osmium::Relation const &r) override
     {
         ++relation.added;
         sum_ids += r.id();
         sum_members += r.members().size();
-        return 0;
     }
 
-    int node_modify(osmium::Node const &) override
-    {
-        ++node.modified;
-        return 0;
-    }
+    void node_modify(osmium::Node const &) override { ++node.modified; }
 
-    int way_modify(osmium::Way *) override
-    {
-        ++way.modified;
-        return 0;
-    }
-    int relation_modify(osmium::Relation const &) override
+    void way_modify(osmium::Way *) override { ++way.modified; }
+
+    void relation_modify(osmium::Relation const &) override
     {
         ++relation.modified;
-        return 0;
     }
 
-    int node_delete(osmid_t) override
-    {
-        ++node.deleted;
-        return 0;
-    }
+    void node_delete(osmid_t) override { ++node.deleted; }
 
-    int way_delete(osmid_t) override
-    {
-        ++way.deleted;
-        return 0;
-    }
+    void way_delete(osmid_t) override { ++way.deleted; }
 
-    int relation_delete(osmid_t) override
-    {
-        ++relation.deleted;
-        return 0;
-    }
+    void relation_delete(osmid_t) override { ++relation.deleted; }
 
     type_stats_t node, way, relation;
     long long sum_ids = 0;


### PR DESCRIPTION
This is the second batch of changes after #1020 switching the return type of some functions from int to void where the result is never used.