### PR TITLE
Limit the number of scheduled deletes

### DIFF
--- a/src/db-copy-mgr.hpp
+++ b/src/db-copy-mgr.hpp
@@ -53,7 +53,7 @@ public:
         assert(buf[sz - 1] == '\t');
         buf[sz - 1] = '\n';
 
-        if (sz > db_cmd_copy_t::Max_buf_size - 100) {
+        if (m_current->is_full()) {
             m_processor->add_buffer(std::move(m_current));
         }
     }

--- a/src/gazetteer-style.hpp
+++ b/src/gazetteer-style.hpp
@@ -19,6 +19,14 @@
  */
 class db_deleter_place_t
 {
+    enum
+    {
+        // Deletion in the place table is fairly complex because of the
+        // compound primary key. It is better to start earlier with the
+        // deletion, so it can run in parallel with the file import.
+        Max_entries = 100000
+    };
+
     struct item_t
     {
         std::string classes;
@@ -47,6 +55,8 @@ public:
 
     void delete_rows(std::string const &table, std::string const &column,
                      pg_conn_t *conn);
+
+    bool is_full() const noexcept { return m_deletables.size() > Max_entries; }
 
 private:
     /// Vector with object to delete before copying


### PR DESCRIPTION
As we have to issue a delete for each and every untagged node,
the number of scheduled deletes can become quite large even for
a small change file. It is better to send off the copy buffer
a bit earlier in this case to ensure that the deletes can already
run in parallel with the parsing of the file. The change also
ensures that the memory usage of the deleter is bound.