### PR TITLE
gazetteer: fix keys for domain-specific naming

### DIFF
--- a/src/gazetteer-style.cpp
+++ b/src/gazetteer-style.cpp
@@ -36,7 +36,7 @@ public:
         if (std::strncmp(t.key(), m_domain, m_len) == 0 &&
             std::strncmp(t.key() + m_len, ":name", 5) == 0 &&
             (t.key()[m_len + 5] == '\0' || t.key()[m_len + 5] == ':')) {
-            return t.key() + m_len + 6;
+            return t.key() + m_len + 1;
         }
 
         return nullptr;


### PR DESCRIPTION
In a domain-specific key like `bridge:name`, we'd only want to cut the tag prefix, i.e. `bridge:`.