### PR TITLE
Refactor tests pg code

### DIFF
--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -351,10 +351,10 @@ middle_query_pgsql_t::local_nodes_get_list(osmium::WayNodeList *nodes) const
     std::unordered_map<osmid_t, osmium::Location> locs;
     for (int i = 0; i < countPG; ++i) {
         locs.emplace(
-            strtoosmid(PQgetvalue(res.get(), i, 0), nullptr, 10),
+            strtoosmid(res.get_value(i, 0), nullptr, 10),
             osmium::Location(
-                (int)strtol(PQgetvalue(res.get(), i, 2), nullptr, 10),
-                (int)strtol(PQgetvalue(res.get(), i, 1), nullptr, 10)));
+                (int)strtol(res.get_value(i, 2), nullptr, 10),
+                (int)strtol(res.get_value(i, 1), nullptr, 10)));
     }
 
     for (auto &n : *nodes) {
@@ -410,7 +410,7 @@ void middle_pgsql_t::node_changed(osmid_t osm_id)
     auto res = exec_prepared("mark_ways_by_node", osm_id);
     for (int i = 0; i < res.num_tuples(); ++i) {
         char *end;
-        osmid_t marked = strtoosmid(PQgetvalue(res.get(), i, 0), &end, 10);
+        osmid_t marked = strtoosmid(res.get_value(i, 0), &end, 10);
         ways_pending_tracker->mark(marked);
     }
 
@@ -418,7 +418,7 @@ void middle_pgsql_t::node_changed(osmid_t osm_id)
     res = exec_prepared("mark_rels_by_node", osm_id);
     for (int i = 0; i < res.num_tuples(); ++i) {
         char *end;
-        osmid_t marked = strtoosmid(PQgetvalue(res.get(), i, 0), &end, 10);
+        osmid_t marked = strtoosmid(res.get_value(i, 0), &end, 10);
         rels_pending_tracker->mark(marked);
     }
 }
@@ -454,8 +454,8 @@ bool middle_query_pgsql_t::ways_get(osmid_t id,
         osmium::builder::WayBuilder builder(buffer);
         builder.set_id(id);
 
-        pgsql_parse_nodes(PQgetvalue(res.get(), 0, 0), buffer, builder);
-        pgsql_parse_tags(PQgetvalue(res.get(), 0, 1), buffer, builder);
+        pgsql_parse_nodes(res.get_value(0, 0), buffer, builder);
+        pgsql_parse_tags(res.get_value(0, 1), buffer, builder);
     }
 
     buffer.commit();
@@ -493,7 +493,7 @@ middle_query_pgsql_t::rel_way_members_get(osmium::Relation const &rel,
 
     for (int i = 0; i < countPG; i++) {
         wayidspg.push_back(
-            strtoosmid(PQgetvalue(res.get(), i, 0), nullptr, 10));
+            strtoosmid(res.get_value(i, 0), nullptr, 10));
     }
 
     // Match the list of ways coming from postgres in a different order
@@ -509,9 +509,9 @@ middle_query_pgsql_t::rel_way_members_get(osmium::Relation const &rel,
                     osmium::builder::WayBuilder builder(buffer);
                     builder.set_id(m.ref());
 
-                    pgsql_parse_nodes(PQgetvalue(res.get(), j, 1), buffer,
+                    pgsql_parse_nodes(res.get_value(j, 1), buffer,
                                       builder);
-                    pgsql_parse_tags(PQgetvalue(res.get(), j, 2), buffer,
+                    pgsql_parse_tags(res.get_value(j, 2), buffer,
                                      builder);
                 }
 
@@ -554,7 +554,7 @@ void middle_pgsql_t::way_changed(osmid_t osm_id)
     auto const res = exec_prepared("mark_rels_by_way", osm_id);
     for (int i = 0; i < res.num_tuples(); ++i) {
         char *end;
-        osmid_t marked = strtoosmid(PQgetvalue(res.get(), i, 0), &end, 10);
+        osmid_t marked = strtoosmid(res.get_value(i, 0), &end, 10);
         rels_pending_tracker->mark(marked);
     }
 }
@@ -616,8 +616,8 @@ bool middle_query_pgsql_t::relations_get(osmid_t id,
         osmium::builder::RelationBuilder builder(buffer);
         builder.set_id(id);
 
-        pgsql_parse_members(PQgetvalue(res.get(), 0, 0), buffer, builder);
-        pgsql_parse_tags(PQgetvalue(res.get(), 0, 1), buffer, builder);
+        pgsql_parse_members(res.get_value(0, 0), buffer, builder);
+        pgsql_parse_tags(res.get_value(0, 1), buffer, builder);
     }
 
     buffer.commit();
@@ -631,7 +631,7 @@ void middle_pgsql_t::relations_delete(osmid_t osm_id)
     auto const res = exec_prepared("mark_ways_by_rel", osm_id);
     for (int i = 0; i < res.num_tuples(); ++i) {
         char *end;
-        osmid_t marked = strtoosmid(PQgetvalue(res.get(), i, 0), &end, 10);
+        osmid_t marked = strtoosmid(res.get_value(i, 0), &end, 10);
         ways_pending_tracker->mark(marked);
     }
 
@@ -661,7 +661,7 @@ void middle_pgsql_t::relation_changed(osmid_t osm_id)
     auto const res = exec_prepared("mark_rels", osm_id);
     for (int i = 0; i < res.num_tuples(); ++i) {
         char *end;
-        osmid_t marked = strtoosmid(PQgetvalue(res.get(), i, 0), &end, 10);
+        osmid_t marked = strtoosmid(res.get_value(i, 0), &end, 10);
         rels_pending_tracker->mark(marked);
     }
 }
@@ -673,7 +673,7 @@ idlist_t middle_query_pgsql_t::relations_using_way(osmid_t way_id) const
     idlist_t rel_ids;
     rel_ids.resize((size_t)ntuples);
     for (int i = 0; i < ntuples; ++i) {
-        rel_ids[i] = strtoosmid(PQgetvalue(result.get(), i, 0), nullptr, 10);
+        rel_ids[i] = strtoosmid(result.get_value(i, 0), nullptr, 10);
     }
 
     return rel_ids;

--- a/src/pgsql.cpp
+++ b/src/pgsql.cpp
@@ -4,8 +4,8 @@
 #include <cstdarg>
 #include <cstdio>
 
-pg_conn_t::pg_conn_t(std::string const &connection)
-: m_conn(PQconnectdb(connection.c_str()))
+pg_conn_t::pg_conn_t(std::string const &conninfo)
+: m_conn(PQconnectdb(conninfo.c_str()))
 {
     if (PQstatus(m_conn.get()) != CONNECTION_OK) {
         fprintf(stderr, "Connection to database failed: %s\n", error_msg());

--- a/src/pgsql.hpp
+++ b/src/pgsql.hpp
@@ -13,7 +13,35 @@ struct pg_result_deleter_t
     void operator()(PGresult *p) const noexcept { PQclear(p); }
 };
 
-using pg_result_t = std::unique_ptr<PGresult, pg_result_deleter_t>;
+using pg_result_wrapper_t = std::unique_ptr<PGresult, pg_result_deleter_t>;
+
+class pg_result_t
+{
+public:
+    pg_result_t(PGresult *result) : m_result(result) {}
+
+    PGresult *get() const noexcept { return m_result.get(); }
+
+    ExecStatusType status() const noexcept
+    {
+        return PQresultStatus(m_result.get());
+    }
+
+    int num_tuples() const noexcept { return PQntuples(m_result.get()); }
+
+    std::string get_value(int row, int col) const noexcept
+    {
+        return PQgetvalue(m_result.get(), row, col);
+    }
+
+    bool is_null(int row, int col) const noexcept
+    {
+        return PQgetisnull(m_result.get(), row, col) != 0;
+    }
+
+private:
+    pg_result_wrapper_t m_result;
+};
 
 struct pg_conn_deleter_t
 {

--- a/src/pgsql.hpp
+++ b/src/pgsql.hpp
@@ -9,17 +9,15 @@
 #include <memory>
 #include <string>
 
-struct pg_result_deleter_t
-{
-    void operator()(PGresult *p) const noexcept { PQclear(p); }
-};
-
-using pg_result_wrapper_t = std::unique_ptr<PGresult, pg_result_deleter_t>;
-
+/**
+ * PostgreSQL query result.
+ *
+ * Wraps the PGresult object of the libpq library.
+ */
 class pg_result_t
 {
 public:
-    pg_result_t(PGresult *result) : m_result(result) {}
+    explicit pg_result_t(PGresult *result) noexcept : m_result(result) {}
 
     /// Get a pointer to the underlying PGresult object.
     PGresult *get() const noexcept { return m_result.get(); }
@@ -70,32 +68,29 @@ public:
     }
 
 private:
-    pg_result_wrapper_t m_result;
-};
+    struct pg_result_deleter_t
+    {
+        void operator()(PGresult *p) const noexcept { PQclear(p); }
+    };
 
-struct pg_conn_deleter_t
-{
-    void operator()(PGconn *p) const noexcept { PQfinish(p); }
+    std::unique_ptr<PGresult, pg_result_deleter_t> m_result;
 };
-
-using pg_conn_wrapper_t = std::unique_ptr<PGconn, pg_conn_deleter_t>;
 
 /**
- * Simple postgres connection.
+ * PostgreSQL connection.
+ *
+ * Wraps the PGconn object of the libpq library.
  *
  * The connection is automatically closed when the object is destroyed.
  */
 class pg_conn_t
 {
 public:
-    pg_conn_t(std::string const &connection);
+    explicit pg_conn_t(std::string const &conninfo);
 
     pg_result_t exec_prepared(char const *stmt, int num_params,
                               const char *const *param_values,
                               ExecStatusType expect = PGRES_TUPLES_OK) const;
-
-    void copy_data(std::string const &sql, std::string const &context) const;
-    void end_copy(std::string const &context) const;
 
     pg_result_t query(ExecStatusType expect, char const *sql) const;
 
@@ -105,10 +100,19 @@ public:
 
     void exec(std::string const &sql) const;
 
+    void copy_data(std::string const &sql, std::string const &context) const;
+
+    void end_copy(std::string const &context) const;
+
     char const *error_msg() const noexcept;
 
 private:
-    pg_conn_wrapper_t m_conn;
+    struct pg_conn_deleter_t
+    {
+        void operator()(PGconn *p) const noexcept { PQfinish(p); }
+    };
+
+    std::unique_ptr<PGconn, pg_conn_deleter_t> m_conn;
 };
 
 #endif // OSM2PGSQL_PGSQL_HPP

--- a/src/table.hpp
+++ b/src/table.hpp
@@ -51,12 +51,6 @@ public:
         }
 
         int get_count() const { return m_count; }
-        void reset()
-        {
-            //NOTE: PQgetvalue doc doesn't say if you can call it
-            //      multiple times with the same row col
-            m_current = 0;
-        }
 
     private:
         wkb_reader(pg_result_t &&result)

--- a/src/table.hpp
+++ b/src/table.hpp
@@ -45,7 +45,7 @@ public:
         const char *get_next()
         {
             if (m_current < m_count) {
-                return PQgetvalue(m_result.get(), m_current++, 0);
+                return m_result.get_value(m_current++, 0);
             }
             return nullptr;
         }
@@ -54,7 +54,7 @@ public:
 
     private:
         wkb_reader(pg_result_t &&result)
-        : m_result(std::move(result)), m_count(PQntuples(m_result.get())),
+        : m_result(std::move(result)), m_count(m_result.num_tuples()),
           m_current(0)
         {}
 

--- a/tests/common-pg.hpp
+++ b/tests/common-pg.hpp
@@ -32,7 +32,7 @@ public:
         pg_result_t const res = query(PGRES_TUPLES_OK, cmd);
         REQUIRE(res.num_tuples() == 1);
 
-        std::string const str = res.get_value(0, 0);
+        auto const str = res.get_value_as_string(0, 0);
         return boost::lexical_cast<T>(str);
     }
 

--- a/tests/common-pg.hpp
+++ b/tests/common-pg.hpp
@@ -140,7 +140,7 @@ private:
 class tempdb_t
 {
 public:
-    tempdb_t()
+    tempdb_t() noexcept
     {
         try {
             conn_t conn("dbname=postgres");
@@ -159,6 +159,12 @@ public:
             exit(1);
         }
     }
+
+    tempdb_t(tempdb_t const &) = delete;
+    tempdb_t &operator=(tempdb_t const &) = delete;
+
+    tempdb_t(tempdb_t &&) = delete;
+    tempdb_t &operator=(tempdb_t const &&) = delete;
 
     ~tempdb_t() noexcept
     {

--- a/tests/common-pg.hpp
+++ b/tests/common-pg.hpp
@@ -5,8 +5,6 @@
 #include <stdexcept>
 #include <string>
 
-#include <libpq-fe.h>
-
 #include <boost/lexical_cast.hpp>
 
 #include "format.hpp"
@@ -23,51 +21,18 @@
 /// Helper classes for postgres connections
 namespace pg {
 
-class conn_t
+class conn_t : public pg_conn_t
 {
 public:
-    conn_t(char const *conninfo)
-    {
-        m_conn = PQconnectdb(conninfo);
-
-        if (PQstatus(m_conn) != CONNECTION_OK) {
-            fprintf(stderr, "Could not connect to database '%s' because: %s\n",
-                    conninfo, PQerrorMessage(m_conn));
-            PQfinish(m_conn);
-            throw std::runtime_error("Database connection failed");
-        }
-    }
-
-    ~conn_t() noexcept
-    {
-        if (m_conn) {
-            PQfinish(m_conn);
-        }
-    }
-
-    void exec(std::string const &cmd, ExecStatusType expect = PGRES_COMMAND_OK)
-    {
-        pg_result_t res = query(cmd);
-        if (res.status() != expect) {
-            fprintf(stderr, "Query '%s' failed with: %s\n", cmd.c_str(),
-                    PQerrorMessage(m_conn));
-            throw std::runtime_error("DB exec failed.");
-        }
-    }
-
-    pg_result_t query(std::string const &cmd) const
-    {
-        return PQexec(m_conn, cmd.c_str());
-    }
+    conn_t(std::string const &conninfo) : pg_conn_t(conninfo) {}
 
     template <typename T>
     T require_scalar(std::string const &cmd) const
     {
-        pg_result_t res = query(cmd);
-        REQUIRE(res.status() == PGRES_TUPLES_OK);
+        pg_result_t const res = query(PGRES_TUPLES_OK, cmd);
         REQUIRE(res.num_tuples() == 1);
 
-        std::string str = res.get_value(0, 0);
+        std::string const str = res.get_value(0, 0);
         return boost::lexical_cast<T>(str);
     }
 
@@ -78,16 +43,14 @@ public:
 
     void assert_null(std::string const &cmd) const
     {
-        pg_result_t res = query(cmd);
-        REQUIRE(res.status() == PGRES_TUPLES_OK);
+        pg_result_t const res = query(PGRES_TUPLES_OK, cmd);
         REQUIRE(res.num_tuples() == 1);
         REQUIRE(res.is_null(0, 0));
     }
 
     pg_result_t require_row(std::string const &cmd) const
     {
-        pg_result_t res = query(cmd);
-        REQUIRE(res.status() == PGRES_TUPLES_OK);
+        pg_result_t res = query(PGRES_TUPLES_OK, cmd);
         REQUIRE(res.num_tuples() == 1);
 
         return res;
@@ -108,9 +71,6 @@ public:
 
         REQUIRE(get_count("pg_catalog.pg_class", where) == 1);
     }
-
-private:
-    PGconn *m_conn = nullptr;
 };
 
 class tempdb_t
@@ -146,15 +106,15 @@ public:
     {
         if (!m_db_name.empty()) {
             try {
-                conn_t conn("dbname=postgres");
-                conn.query("DROP DATABASE IF EXISTS \"{}\""_format(m_db_name));
+                conn_t conn{"dbname=postgres"};
+                conn.exec("DROP DATABASE IF EXISTS \"{}\""_format(m_db_name));
             } catch (...) {
                 fprintf(stderr, "DROP DATABASE failed. Ignored.\n");
             }
         }
     }
 
-    conn_t connect() const { return conn_t(conninfo().c_str()); }
+    conn_t connect() const { return conn_t{conninfo()}; }
 
     std::string conninfo() const { return "dbname=" + m_db_name; }
 


### PR DESCRIPTION
Refactor low-level PostgreSQL code in the tests to use the low-level PostgreSQL code used in the application. This gives us simpler and better tested code and we can use convenience functions originally only implemented in the test code.

This also marks the tempdb_t constructor noexcept.