### PR TITLE
gazetteer: exclude country and postcode from address tags

### DIFF
--- a/src/gazetteer-style.cpp
+++ b/src/gazetteer-style.cpp
@@ -343,12 +343,16 @@ void gazetteer_style_t::process_tags(osmium::OSMObject const &o)
                 addr_key = k;
             }
 
-            bool first = std::none_of(m_address.begin(), m_address.end(),
-                                      [&](ptag_t const &t) {
-                                          return strcmp(t.first, addr_key) == 0;
-                                      });
-            if (first) {
-                m_address.emplace_back(addr_key, v);
+            // country and postcode are handled specially, ignore them here
+            if (strcmp(addr_key, "country") != 0 &&
+                strcmp(addr_key, "postcode") != 0) {
+                bool first = std::none_of(
+                    m_address.begin(), m_address.end(), [&](ptag_t const &t) {
+                        return strcmp(t.first, addr_key) == 0;
+                    });
+                if (first) {
+                    m_address.emplace_back(addr_key, v);
+                }
             }
         }
 


### PR DESCRIPTION
Country and postcodes have their own flag in the style file and
need special treatment. They are, however, eventually added to
the hstore of address tags. So we need to make sure that they
are not overwritten by ordinary address tags.

See also https://github.com/openstreetmap/Nominatim/issues/1606