### PR TITLE
Bugfix: Threading problem in db_copy_thread_t

### DIFF
--- a/src/db-copy.cpp
+++ b/src/db-copy.cpp
@@ -1,122 +1,8 @@
 #include <cassert>
-#include <cstdio>
-#include <future>
-#include <thread>
 
 #include "db-copy.hpp"
 #include "format.hpp"
 #include "pgsql.hpp"
-
-db_copy_thread_t::db_copy_thread_t(std::string const &conninfo)
-: m_conninfo(conninfo)
-{
-    m_worker = std::thread([this]() {
-        try {
-            worker_thread();
-        } catch (std::runtime_error const &e) {
-            fprintf(stderr, "DB writer thread failed due to ERROR: %s\n",
-                    e.what());
-            exit(2);
-        }
-    });
-}
-
-db_copy_thread_t::~db_copy_thread_t() { finish(); }
-
-void db_copy_thread_t::add_buffer(std::unique_ptr<db_cmd_t> &&buffer)
-{
-    assert(m_worker.joinable()); // thread must not have been finished
-
-    std::unique_lock<std::mutex> lock(m_queue_mutex);
-    m_queue_full_cond.wait(lock, [&] {
-        return m_worker_queue.size() < db_cmd_copy_t::Max_buffers;
-    });
-
-    m_worker_queue.push_back(std::move(buffer));
-    m_queue_cond.notify_one();
-}
-
-void db_copy_thread_t::sync_and_wait()
-{
-    std::promise<void> barrier;
-    std::future<void> sync = barrier.get_future();
-    add_buffer(
-        std::unique_ptr<db_cmd_t>(new db_cmd_sync_t(std::move(barrier))));
-    sync.wait();
-}
-
-void db_copy_thread_t::finish()
-{
-    if (m_worker.joinable()) {
-        finish_copy();
-
-        add_buffer(std::unique_ptr<db_cmd_t>(new db_cmd_finish_t()));
-        m_worker.join();
-    }
-}
-
-void db_copy_thread_t::worker_thread()
-{
-    connect();
-
-    bool done = false;
-    while (!done) {
-        std::unique_ptr<db_cmd_t> item;
-        {
-            std::unique_lock<std::mutex> lock(m_queue_mutex);
-            m_queue_cond.wait(lock, [&] { return !m_worker_queue.empty(); });
-
-            item = std::move(m_worker_queue.front());
-            m_worker_queue.pop_front();
-            m_queue_full_cond.notify_one();
-        }
-
-        switch (item->type) {
-        case db_cmd_t::Cmd_copy:
-            write_to_db(static_cast<db_cmd_copy_t *>(item.get()));
-            break;
-        case db_cmd_t::Cmd_sync:
-            finish_copy();
-            static_cast<db_cmd_sync_t *>(item.get())->barrier.set_value();
-            break;
-        case db_cmd_t::Cmd_finish:
-            done = true;
-            break;
-        }
-    }
-
-    finish_copy();
-
-    disconnect();
-}
-
-void db_copy_thread_t::connect()
-{
-    assert(!m_conn);
-
-    m_conn.reset(new pg_conn_t{m_conninfo});
-
-    // Let commits happen faster by delaying when they actually occur.
-    m_conn->exec("SET synchronous_commit TO off");
-}
-
-void db_copy_thread_t::disconnect() { m_conn.reset(); }
-
-void db_copy_thread_t::write_to_db(db_cmd_copy_t *buffer)
-{
-    if (buffer->has_deletables() ||
-        (m_inflight && !buffer->target->same_copy_target(*m_inflight.get()))) {
-        finish_copy();
-    }
-
-    buffer->delete_data(m_conn.get());
-
-    if (!m_inflight) {
-        start_copy(buffer->target);
-    }
-
-    m_conn->copy_data(buffer->buffer, buffer->target->name);
-}
 
 void db_deleter_by_id_t::delete_rows(std::string const &table,
                                      std::string const &column, pg_conn_t *conn)
@@ -138,10 +24,113 @@ void db_deleter_by_id_t::delete_rows(std::string const &table,
     conn->exec(fmt::to_string(sql));
 }
 
-void db_copy_thread_t::start_copy(
+db_copy_thread_t::db_copy_thread_t(std::string const &conninfo)
+{
+    // conninfo is captured by copy here, because we don't know wether the
+    // reference will still be valid once we get around to running the thread
+    m_worker = std::thread(thread_t{conninfo, m_shared});
+}
+
+db_copy_thread_t::~db_copy_thread_t() { finish(); }
+
+void db_copy_thread_t::add_buffer(std::unique_ptr<db_cmd_t> &&buffer)
+{
+    assert(m_worker.joinable()); // thread must not have been finished
+
+    std::unique_lock<std::mutex> lock{m_shared.queue_mutex};
+    m_shared.queue_full_cond.wait(lock, [&] {
+        return m_shared.worker_queue.size() < db_cmd_copy_t::Max_buffers;
+    });
+
+    m_shared.worker_queue.push_back(std::move(buffer));
+    m_shared.queue_cond.notify_one();
+}
+
+void db_copy_thread_t::sync_and_wait()
+{
+    std::promise<void> barrier;
+    std::future<void> sync = barrier.get_future();
+    add_buffer(
+        std::unique_ptr<db_cmd_t>(new db_cmd_sync_t(std::move(barrier))));
+    sync.wait();
+}
+
+void db_copy_thread_t::finish()
+{
+    if (m_worker.joinable()) {
+        add_buffer(std::unique_ptr<db_cmd_t>(new db_cmd_finish_t()));
+        m_worker.join();
+    }
+}
+
+db_copy_thread_t::thread_t::thread_t(std::string conninfo, shared &shared)
+: m_conninfo(std::move(conninfo)), m_shared(shared)
+{}
+
+void db_copy_thread_t::thread_t::operator()()
+{
+    try {
+        m_conn.reset(new pg_conn_t{m_conninfo});
+
+        // Let commits happen faster by delaying when they actually occur.
+        m_conn->exec("SET synchronous_commit TO off");
+
+        bool done = false;
+        while (!done) {
+            std::unique_ptr<db_cmd_t> item;
+            {
+                std::unique_lock<std::mutex> lock{m_shared.queue_mutex};
+                m_shared.queue_cond.wait(
+                    lock, [&] { return !m_shared.worker_queue.empty(); });
+
+                item = std::move(m_shared.worker_queue.front());
+                m_shared.worker_queue.pop_front();
+                m_shared.queue_full_cond.notify_one();
+            }
+
+            switch (item->type) {
+            case db_cmd_t::Cmd_copy:
+                write_to_db(static_cast<db_cmd_copy_t *>(item.get()));
+                break;
+            case db_cmd_t::Cmd_sync:
+                finish_copy();
+                static_cast<db_cmd_sync_t *>(item.get())->barrier.set_value();
+                break;
+            case db_cmd_t::Cmd_finish:
+                done = true;
+                break;
+            }
+        }
+
+        finish_copy();
+
+        m_conn.reset();
+    } catch (std::runtime_error const &e) {
+        fmt::print(stderr, "DB copy thread failed: {}\n", e.what());
+        exit(2);
+    }
+}
+
+void db_copy_thread_t::thread_t::write_to_db(db_cmd_copy_t *buffer)
+{
+    if (buffer->has_deletables() ||
+        (m_inflight && !buffer->target->same_copy_target(*m_inflight.get()))) {
+        finish_copy();
+    }
+
+    buffer->delete_data(m_conn.get());
+
+    if (!m_inflight) {
+        start_copy(buffer->target);
+    }
+
+    m_conn->copy_data(buffer->buffer, buffer->target->name);
+}
+
+void db_copy_thread_t::thread_t::start_copy(
     std::shared_ptr<db_target_descr_t> const &target)
 {
-    m_inflight = target;
+    assert(!m_inflight);
 
     std::string copystr = "COPY ";
     copystr.reserve(target->name.size() + target->rows.size() + 14);
@@ -157,7 +146,7 @@ void db_copy_thread_t::start_copy(
     m_inflight = target;
 }
 
-void db_copy_thread_t::finish_copy()
+void db_copy_thread_t::thread_t::finish_copy()
 {
     if (m_inflight) {
         m_conn->end_copy(m_inflight->name);


### PR DESCRIPTION
The finish_copy() method was called from the main program and from the
copy thread leading to a race condition.

I have fixed not only this but clearly separated out everything
happening in the main thread from everything in the copy thread by
putting the code for the latter into its own class. This way a
problem like this can not happen again.