### PR TITLE
travis: disable build on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,16 +88,16 @@ matrix:
       addons: *bionic_clang7_pg96
 
   # ---- OSX + CLANG ---------------------------
-    - os: osx
-      compiler: clang
-      env: T="osx_clang_NoDB"
-           BUILD_TYPE="Debug" LUAJIT_OPTION="OFF" TEST_NODB=1
-           CXXFLAGS="-pedantic -Wextra -Werror" CPPVERSION=11
-      before_install:
-        - brew install lua; brew install lua
-      before_script:
-        - proj | head -n1
-        - lua -v
+  #  - os: osx
+  #    compiler: clang
+  #    env: T="osx_clang_NoDB"
+  #         BUILD_TYPE="Debug" LUAJIT_OPTION="OFF" TEST_NODB=1
+  #         CXXFLAGS="-pedantic -Wextra -Werror" CPPVERSION=11
+  #    before_install:
+  #      - brew install lua; brew install lua
+  #    before_script:
+  #      - proj | head -n1
+  #      - lua -v
 
   # ---- Linux + GCC ---------------------------
     - os: linux


### PR DESCRIPTION
The osx build has been broken for unknown reasons for the last two weeks and is a blocking point for pending PRs. See also #1035.