### PR TITLE
Travis fix for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,16 +88,36 @@ matrix:
       addons: *bionic_clang7_pg96
 
   # ---- OSX + CLANG ---------------------------
-  #  - os: osx
-  #    compiler: clang
-  #    env: T="osx_clang_NoDB"
-  #         BUILD_TYPE="Debug" LUAJIT_OPTION="OFF" TEST_NODB=1
-  #         CXXFLAGS="-pedantic -Wextra -Werror" CPPVERSION=11
-  #    before_install:
-  #      - brew install lua; brew install lua
-  #    before_script:
-  #      - proj | head -n1
-  #      - lua -v
+    - os: osx
+      osx_image: xcode10.3
+      compiler: gcc
+      env: T="osx_gcc_NoDB"
+           BUILD_TYPE="Debug" LUAJIT_OPTION="OFF" TEST_NODB=1
+           CXXFLAGS="-pedantic -Wextra -Werror" CPPVERSION=11
+      before_script:
+        - proj | head -n1
+        - lua -v
+      addons:
+        homebrew:
+          packages:
+          - cmake
+          - gcc@9
+          - llvm@9
+          - lua
+          update: true
+      before_install:
+          # override default before_install
+      install:
+      # Homebrew packages aren't linked by default,
+      # need to be prepended to the path explicitly
+      - export PATH="$(brew --prefix llvm)/bin:$PATH"
+      # /usr/bin/gcc points to an older compiler on both Linux and macOS
+      - export CXX="g++-9"
+      - export CC="gcc-9"
+      - echo ${CC}
+      - echo ${CXX}
+      - ${CXX} --version
+      - cmake --version
 
   # ---- Linux + GCC ---------------------------
     - os: linux


### PR DESCRIPTION
This is pretty much the only configuration I got working on travis for OSX.

Unfortunately, I won't work with newer xcode releases due to some Apple bug (https://github.com/Homebrew/homebrew-core/issues/44579, see error message below). Also, it uses gcc-9 instead of clang. If someone happens to have lots of time and patience, we might get clang working at some point in the future again.

Changes were heavily inspired by https://github.com/google/crc32c/blob/master/.travis.yml

Fixes #1035

--- 

```
/Applications/Xcode-11.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/resource.h:443:34: error: expected initializer before '__OSX_AVAILABLE_STARTING'

  443 | int     getiopolicy_np(int, int) __OSX_AVAILABLE_STARTING(__MAC_10_5, __IPHONE_2_0);
```