### PR TITLE
Extend gazetteer tests to ways and relations

### DIFF
--- a/tests/test-output-gazetteer.cpp
+++ b/tests/test-output-gazetteer.cpp
@@ -7,8 +7,10 @@
 
 static testing::db::import_t db;
 
-static std::random_device dev;
-static std::mt19937 rng(dev());
+// Use a random device with a fixed seed. We don't really care about
+// the quality of random numbers here, we just need to generate valid
+// OSM test data. The fixed seed ensures that the results are reproducible.
+static std::mt19937_64 rng(47382);
 
 class node_opl_t
 {
@@ -72,7 +74,7 @@ private:
         unsigned const num_nodes = intdist(rng);
 
         // compute the start point, all points afterwards are relative
-        std::uniform_real_distribution<double> dist{-90, 89.99};
+        std::uniform_real_distribution<double> dist{-89.9, 89.9};
         double x = 2 * dist(rng);
         double y = dist(rng);
 
@@ -138,7 +140,7 @@ private:
     osmid_t make_nodes()
     {
         // compute a centre points and compute four corners from this
-        std::uniform_real_distribution<double> dist{-90, 89.99};
+        std::uniform_real_distribution<double> dist{-89.9, 89.9};
         double const x = 2 * dist(rng);
         double const y = dist(rng);
 

--- a/tests/test-output-gazetteer.cpp
+++ b/tests/test-output-gazetteer.cpp
@@ -15,7 +15,7 @@ class node_opl_t
 public:
     void add(osmid_t id, char const *tags)
     {
-        std::uniform_real_distribution<double> dist(-90, 89.99);
+        std::uniform_real_distribution<double> dist{-90, 89.99};
 
         fmt::format_to(m_opl, "n{} T{} x{} y{}\n", id, tags, 2 * dist(rng),
                        dist(rng));
@@ -41,8 +41,8 @@ class way_opl_t
 public:
     void add(osmid_t id, char const *tags)
     {
-        osmid_t first_node = m_current_node_id;
-        osmid_t last_node = make_nodes();
+        osmid_t const first_node = m_current_node_id;
+        osmid_t const last_node = make_nodes();
 
         fmt::format_to(m_way_opl, "w{} T{} N", id, tags);
         for (osmid_t i = first_node; i <= last_node; ++i) {
@@ -68,18 +68,20 @@ public:
 private:
     osmid_t make_nodes()
     {
-        unsigned num_nodes = std::uniform_int_distribution<unsigned>(2, 8)(rng);
+        std::uniform_int_distribution<unsigned> intdist{2, 8};
+        unsigned const num_nodes = intdist(rng);
 
         // compute the start point, all points afterwards are relative
-        std::uniform_real_distribution<double> dist(-90, 89.99);
+        std::uniform_real_distribution<double> dist{-90, 89.99};
         double x = 2 * dist(rng);
         double y = dist(rng);
 
-        std::uniform_real_distribution<double> diff_dist(-0.01, 0.01);
+        std::uniform_real_distribution<double> diff_dist{-0.01, 0.01};
         for (unsigned i = 0; i < num_nodes; ++i) {
             fmt::format_to(m_node_opl, "n{} x{} y{}\n", m_current_node_id++, x,
                            y);
-            double diffx = 0.0, diffy = 0.0;
+            double diffx = 0.0;
+            double diffy = 0.0;
             do {
                 diffx = diff_dist(rng);
                 diffy = diff_dist(rng);
@@ -101,8 +103,8 @@ class relation_opl_t
 public:
     void add(osmid_t id, char const *tags)
     {
-        osmid_t first_node = m_current_node_id;
-        osmid_t last_node = make_nodes();
+        osmid_t const first_node = m_current_node_id;
+        osmid_t const last_node = make_nodes();
 
         // create a very simple multipolygon with one closed way
         fmt::format_to(m_way_opl, "w{} N", id, tags);
@@ -136,11 +138,11 @@ private:
     osmid_t make_nodes()
     {
         // compute a centre points and compute four corners from this
-        std::uniform_real_distribution<double> dist(-90, 89.99);
-        double x = 2 * dist(rng);
-        double y = dist(rng);
+        std::uniform_real_distribution<double> dist{-90, 89.99};
+        double const x = 2 * dist(rng);
+        double const y = dist(rng);
 
-        std::uniform_real_distribution<double> diff_dist(0.0000001, 0.01);
+        std::uniform_real_distribution<double> diff_dist{0.0000001, 0.01};
 
         fmt::format_to(m_node_opl, "n{} x{} y{}\n", m_current_node_id++,
                        x - diff_dist(rng), y - diff_dist(rng));
@@ -170,7 +172,7 @@ public:
 
     void import()
     {
-        std::string opl = m_opl_factory.get_and_clear_opl();
+        std::string const opl = m_opl_factory.get_and_clear_opl();
         REQUIRE_NOTHROW(
             db.run_import(testing::opt_t().gazetteer().slim(), opl.c_str()));
     }
@@ -178,13 +180,13 @@ public:
     void update()
     {
         auto opt = testing::opt_t().gazetteer().slim().append();
-        std::string opl = m_opl_factory.get_and_clear_opl();
+        std::string const opl = m_opl_factory.get_and_clear_opl();
         REQUIRE_NOTHROW(db.run_import(opt, opl.c_str()));
     }
 
     unsigned long obj_count(pg::conn_t const &conn, osmid_t id, char const *cls)
     {
-        char tchar = m_opl_factory.type();
+        char const tchar = m_opl_factory.type();
         return conn.get_count("place",
                               "osm_type = '{}' "
                               "AND osm_id = {} "

--- a/tests/test-output-gazetteer.cpp
+++ b/tests/test-output-gazetteer.cpp
@@ -10,7 +10,7 @@ static testing::db::import_t db;
 static std::random_device dev;
 static std::mt19937 rng(dev());
 
-class node_importer_t
+class node_opl_t
 {
 public:
     void add(osmid_t id, char const *tags)
@@ -36,7 +36,7 @@ private:
     fmt::memory_buffer m_opl;
 };
 
-class way_importer_t
+class way_opl_t
 {
 public:
     void add(osmid_t id, char const *tags)
@@ -96,7 +96,7 @@ private:
     fmt::memory_buffer m_way_opl;
 };
 
-class relation_importer_t
+class relation_opl_t
 {
 public:
     void add(osmid_t id, char const *tags)
@@ -161,30 +161,43 @@ private:
 };
 
 template <typename T>
-static void import(T *importer)
+class gazetteer_fixture_t
 {
-    std::string opl = importer->get_and_clear_opl();
-    REQUIRE_NOTHROW(
-        db.run_import(testing::opt_t().gazetteer().slim(), opl.c_str()));
-}
+public:
+    void add(osmid_t id, char const *tags) { m_opl_factory.add(id, tags); }
 
-template <typename T>
-void update(T *importer)
-{
-    auto opt = testing::opt_t().gazetteer().slim().append();
-    std::string opl = importer->get_and_clear_opl();
-    REQUIRE_NOTHROW(db.run_import(opt, opl.c_str()));
-}
+    void del(osmid_t id) { m_opl_factory.del(id); }
 
-template <typename T>
-unsigned long obj_count(T *importer, pg::conn_t const &conn, osmid_t id,
-                        char const *cls)
-{
-    return conn.get_count("place",
-                          "osm_type = '{}' "
-                          "AND osm_id = {} "
-                          "AND class = '{}'"_format(importer->type(), id, cls));
-}
+    void import()
+    {
+        std::string opl = m_opl_factory.get_and_clear_opl();
+        REQUIRE_NOTHROW(
+            db.run_import(testing::opt_t().gazetteer().slim(), opl.c_str()));
+    }
+
+    void update()
+    {
+        auto opt = testing::opt_t().gazetteer().slim().append();
+        std::string opl = m_opl_factory.get_and_clear_opl();
+        REQUIRE_NOTHROW(db.run_import(opt, opl.c_str()));
+    }
+
+    unsigned long obj_count(pg::conn_t const &conn, osmid_t id, char const *cls)
+    {
+        char tchar = m_opl_factory.type();
+        return conn.get_count("place",
+                              "osm_type = '{}' "
+                              "AND osm_id = {} "
+                              "AND class = '{}'"_format(tchar, id, cls));
+    }
+
+private:
+    T m_opl_factory;
+};
+
+using node_importer_t = gazetteer_fixture_t<node_opl_t>;
+using way_importer_t = gazetteer_fixture_t<way_opl_t>;
+using relation_importer_t = gazetteer_fixture_t<relation_opl_t>;
 
 TEMPLATE_TEST_CASE("Main tags", "", node_importer_t, way_importer_t,
                    relation_importer_t)
@@ -199,15 +212,15 @@ TEMPLATE_TEST_CASE("Main tags", "", node_importer_t, way_importer_t,
         t.add(201, "building=yes,name=Intersting");
         t.add(202, "building=yes");
 
-        import(&t);
+        t.import();
 
         auto conn = db.connect();
 
-        CHECK(0 == obj_count(&t, conn, 100, "junction"));
-        CHECK(1 == obj_count(&t, conn, 101, "junction"));
-        CHECK(0 == obj_count(&t, conn, 200, "building"));
-        CHECK(1 == obj_count(&t, conn, 201, "building"));
-        CHECK(0 == obj_count(&t, conn, 202, "building"));
+        CHECK(0 == t.obj_count(conn, 100, "junction"));
+        CHECK(1 == t.obj_count(conn, 101, "junction"));
+        CHECK(0 == t.obj_count(conn, 200, "building"));
+        CHECK(1 == t.obj_count(conn, 201, "building"));
+        CHECK(0 == t.obj_count(conn, 202, "building"));
     }
 
     SECTION("Main tag deleted")
@@ -216,25 +229,25 @@ TEMPLATE_TEST_CASE("Main tags", "", node_importer_t, way_importer_t,
         t.add(2, "highway=bus_stop,railway=stop,name=X");
         t.add(3, "amenity=prison");
 
-        import(&t);
+        t.import();
 
         auto conn = db.connect();
 
-        CHECK(1 == obj_count(&t, conn, 1, "amenity"));
-        CHECK(1 == obj_count(&t, conn, 2, "highway"));
-        CHECK(1 == obj_count(&t, conn, 2, "railway"));
-        CHECK(1 == obj_count(&t, conn, 3, "amenity"));
+        CHECK(1 == t.obj_count(conn, 1, "amenity"));
+        CHECK(1 == t.obj_count(conn, 2, "highway"));
+        CHECK(1 == t.obj_count(conn, 2, "railway"));
+        CHECK(1 == t.obj_count(conn, 3, "amenity"));
 
         t.del(3);
         t.add(1, "not_a=restaurant");
         t.add(2, "highway=bus_stop,name=X");
 
-        update(&t);
+        t.update();
 
-        CHECK(0 == obj_count(&t, conn, 1, "amenity"));
-        CHECK(2 == obj_count(&t, conn, 2, "highway"));
-        CHECK(0 == obj_count(&t, conn, 2, "railway"));
-        CHECK(0 == obj_count(&t, conn, 3, "amenity"));
+        CHECK(0 == t.obj_count(conn, 1, "amenity"));
+        CHECK(2 == t.obj_count(conn, 2, "highway"));
+        CHECK(0 == t.obj_count(conn, 2, "railway"));
+        CHECK(0 == t.obj_count(conn, 3, "amenity"));
     }
 
     SECTION("Main tag added")
@@ -242,25 +255,25 @@ TEMPLATE_TEST_CASE("Main tags", "", node_importer_t, way_importer_t,
         t.add(1, "atiy=restaurant");
         t.add(2, "highway=bus_stop,name=X");
 
-        import(&t);
+        t.import();
 
         auto conn = db.connect();
 
-        CHECK(0 == obj_count(&t, conn, 1, "amenity"));
-        CHECK(1 == obj_count(&t, conn, 2, "highway"));
-        CHECK(0 == obj_count(&t, conn, 2, "railway"));
-        CHECK(0 == obj_count(&t, conn, 3, "amenity"));
+        CHECK(0 == t.obj_count(conn, 1, "amenity"));
+        CHECK(1 == t.obj_count(conn, 2, "highway"));
+        CHECK(0 == t.obj_count(conn, 2, "railway"));
+        CHECK(0 == t.obj_count(conn, 3, "amenity"));
 
         t.add(1, "amenity=restaurant");
         t.add(2, "highway=bus_stop,railway=stop,name=X");
         t.add(3, "amenity=prison");
 
-        update(&t);
+        t.update();
 
-        CHECK(1 == obj_count(&t, conn, 1, "amenity"));
-        CHECK(2 == obj_count(&t, conn, 2, "highway"));
-        CHECK(1 == obj_count(&t, conn, 2, "railway"));
-        CHECK(1 == obj_count(&t, conn, 3, "amenity"));
+        CHECK(1 == t.obj_count(conn, 1, "amenity"));
+        CHECK(2 == t.obj_count(conn, 2, "highway"));
+        CHECK(1 == t.obj_count(conn, 2, "railway"));
+        CHECK(1 == t.obj_count(conn, 3, "amenity"));
     }
 
     SECTION("Main tag modified")
@@ -268,21 +281,21 @@ TEMPLATE_TEST_CASE("Main tags", "", node_importer_t, way_importer_t,
         t.add(10, "highway=footway,name=X");
         t.add(11, "amenity=atm");
 
-        import(&t);
+        t.import();
 
         auto conn = db.connect();
 
-        CHECK(1 == obj_count(&t, conn, 10, "highway"));
-        CHECK(1 == obj_count(&t, conn, 11, "amenity"));
+        CHECK(1 == t.obj_count(conn, 10, "highway"));
+        CHECK(1 == t.obj_count(conn, 11, "amenity"));
 
         t.add(10, "highway=path,name=X");
         t.add(11, "highway=primary");
 
-        update(&t);
+        t.update();
 
-        CHECK(2 == obj_count(&t, conn, 10, "highway"));
-        CHECK(0 == obj_count(&t, conn, 11, "amenity"));
-        CHECK(1 == obj_count(&t, conn, 11, "highway"));
+        CHECK(2 == t.obj_count(conn, 10, "highway"));
+        CHECK(0 == t.obj_count(conn, 11, "amenity"));
+        CHECK(1 == t.obj_count(conn, 11, "highway"));
     }
 
     SECTION("Main tags with name, name added")
@@ -290,20 +303,20 @@ TEMPLATE_TEST_CASE("Main tags", "", node_importer_t, way_importer_t,
         t.add(45, "landuse=cemetry");
         t.add(46, "building=yes");
 
-        import(&t);
+        t.import();
 
         auto conn = db.connect();
 
-        CHECK(0 == obj_count(&t, conn, 45, "landuse"));
-        CHECK(0 == obj_count(&t, conn, 46, "building"));
+        CHECK(0 == t.obj_count(conn, 45, "landuse"));
+        CHECK(0 == t.obj_count(conn, 46, "building"));
 
         t.add(45, "landuse=cemetry,name=TODO");
         t.add(46, "building=yes,addr:housenumber=1");
 
-        update(&t);
+        t.update();
 
-        CHECK(1 == obj_count(&t, conn, 45, "landuse"));
-        CHECK(1 == obj_count(&t, conn, 46, "building"));
+        CHECK(1 == t.obj_count(conn, 45, "landuse"));
+        CHECK(1 == t.obj_count(conn, 46, "building"));
     }
 
     SECTION("Main tags with name, name removed")
@@ -311,20 +324,20 @@ TEMPLATE_TEST_CASE("Main tags", "", node_importer_t, way_importer_t,
         t.add(45, "landuse=cemetry,name=TODO");
         t.add(46, "building=yes,addr:housenumber=1");
 
-        import(&t);
+        t.import();
 
         auto conn = db.connect();
 
-        CHECK(1 == obj_count(&t, conn, 45, "landuse"));
-        CHECK(1 == obj_count(&t, conn, 46, "building"));
+        CHECK(1 == t.obj_count(conn, 45, "landuse"));
+        CHECK(1 == t.obj_count(conn, 46, "building"));
 
         t.add(45, "landuse=cemetry");
         t.add(46, "building=yes");
 
-        update(&t);
+        t.update();
 
-        CHECK(0 == obj_count(&t, conn, 45, "landuse"));
-        CHECK(0 == obj_count(&t, conn, 46, "building"));
+        CHECK(0 == t.obj_count(conn, 45, "landuse"));
+        CHECK(0 == t.obj_count(conn, 46, "building"));
     }
 
     SECTION("Main tags with name, name modified")
@@ -332,108 +345,108 @@ TEMPLATE_TEST_CASE("Main tags", "", node_importer_t, way_importer_t,
         t.add(45, "landuse=cemetry,name=TODO");
         t.add(46, "building=yes,addr:housenumber=1");
 
-        import(&t);
+        t.import();
 
         auto conn = db.connect();
 
-        CHECK(1 == obj_count(&t, conn, 45, "landuse"));
-        CHECK(1 == obj_count(&t, conn, 46, "building"));
+        CHECK(1 == t.obj_count(conn, 45, "landuse"));
+        CHECK(1 == t.obj_count(conn, 46, "building"));
 
         t.add(45, "landuse=cemetry,name=DONE");
         t.add(46, "building=yes,addr:housenumber=10");
 
-        update(&t);
+        t.update();
 
-        CHECK(2 == obj_count(&t, conn, 45, "landuse"));
-        CHECK(2 == obj_count(&t, conn, 46, "building"));
+        CHECK(2 == t.obj_count(conn, 45, "landuse"));
+        CHECK(2 == t.obj_count(conn, 46, "building"));
     }
 
     SECTION("Main tag added to address only node")
     {
         t.add(1, "addr:housenumber=345");
 
-        import(&t);
+        t.import();
 
         auto conn = db.connect();
 
-        CHECK(1 == obj_count(&t, conn, 1, "place"));
-        CHECK(0 == obj_count(&t, conn, 1, "building"));
+        CHECK(1 == t.obj_count(conn, 1, "place"));
+        CHECK(0 == t.obj_count(conn, 1, "building"));
 
         t.add(1, "addr:housenumber=345,building=yes");
 
-        update(&t);
+        t.update();
 
-        CHECK(0 == obj_count(&t, conn, 1, "place"));
-        CHECK(1 == obj_count(&t, conn, 1, "building"));
+        CHECK(0 == t.obj_count(conn, 1, "place"));
+        CHECK(1 == t.obj_count(conn, 1, "building"));
     }
 
     SECTION("Main tag removed from address only node")
     {
         t.add(1, "addr:housenumber=345,building=yes");
 
-        import(&t);
+        t.import();
 
         auto conn = db.connect();
 
-        CHECK(0 == obj_count(&t, conn, 1, "place"));
-        CHECK(1 == obj_count(&t, conn, 1, "building"));
+        CHECK(0 == t.obj_count(conn, 1, "place"));
+        CHECK(1 == t.obj_count(conn, 1, "building"));
 
         t.add(1, "addr:housenumber=345");
 
-        update(&t);
+        t.update();
 
-        CHECK(1 == obj_count(&t, conn, 1, "place"));
-        CHECK(0 == obj_count(&t, conn, 1, "building"));
+        CHECK(1 == t.obj_count(conn, 1, "place"));
+        CHECK(0 == t.obj_count(conn, 1, "building"));
     }
 
     SECTION("Main tags with name key, adding key name")
     {
         t.add(22, "bridge=yes");
 
-        import(&t);
+        t.import();
 
         auto conn = db.connect();
 
-        CHECK(0 == obj_count(&t, conn, 22, "bridge"));
+        CHECK(0 == t.obj_count(conn, 22, "bridge"));
 
         t.add(22, "bridge=yes,bridge:name=high");
 
-        update(&t);
+        t.update();
 
-        CHECK(1 == obj_count(&t, conn, 22, "bridge"));
+        CHECK(1 == t.obj_count(conn, 22, "bridge"));
     }
 
     SECTION("Main tags with name key, deleting key name")
     {
         t.add(22, "bridge=yes,bridge:name=high");
 
-        import(&t);
+        t.import();
 
         auto conn = db.connect();
 
-        CHECK(1 == obj_count(&t, conn, 22, "bridge"));
+        CHECK(1 == t.obj_count(conn, 22, "bridge"));
 
         t.add(22, "bridge=yes");
 
-        update(&t);
+        t.update();
 
-        CHECK(0 == obj_count(&t, conn, 22, "bridge"));
+        CHECK(0 == t.obj_count(conn, 22, "bridge"));
     }
 
     SECTION("Main tags with name key, changing key name")
     {
         t.add(22, "bridge=yes,bridge:name=high");
 
-        import(&t);
+        t.import();
 
         auto conn = db.connect();
 
-        CHECK(1 == obj_count(&t, conn, 22, "bridge"));
+        CHECK(1 == t.obj_count(conn, 22, "bridge"));
 
         t.add(22, "bridge=yes,bridge:name:en=high");
 
-        update(&t);
+        t.update();
 
-        CHECK(2 == obj_count(&t, conn, 22, "bridge"));
+        CHECK(2 == t.obj_count(conn, 22, "bridge"));
     }
 }

--- a/tests/test-output-gazetteer.cpp
+++ b/tests/test-output-gazetteer.cpp
@@ -1,225 +1,300 @@
 #include <catch.hpp>
 
+#include <random>
+
 #include "common-import.hpp"
 #include "common-options.hpp"
 
 static testing::db::import_t db;
 
-static void import(char const *opl)
+static std::random_device dev;
+static std::mt19937 rng(dev());
+
+class node_importer_t
 {
-    REQUIRE_NOTHROW(db.run_import(testing::opt_t().gazetteer().slim(), opl));
-}
+public:
+    void add(osmid_t id, char const *tags)
+    {
+        std::uniform_real_distribution<double> dist(-90, 89.99);
 
-static void update(char const *opl)
+        fmt::format_to(m_opl, "n{} T{} x{} y{}\n", id, tags, 2 * dist(rng),
+                       dist(rng));
+    }
+
+    void del(osmid_t id) { fmt::format_to(m_opl, "n{} v2 dD\n", id); }
+
+    void import()
+    {
+        REQUIRE_NOTHROW(db.run_import(testing::opt_t().gazetteer().slim(),
+                                      fmt::to_string(m_opl).c_str()));
+        m_opl.clear();
+    }
+
+    void update()
+    {
+        auto opt = testing::opt_t().gazetteer().slim().append();
+        REQUIRE_NOTHROW(db.run_import(opt, fmt::to_string(m_opl).c_str()));
+        m_opl.clear();
+    }
+
+    unsigned long obj_count(pg::conn_t const &conn, osmid_t id, char const *cls)
+    {
+        return conn.get_count("place", "osm_type = 'N' "
+                                       "AND osm_id = {} "
+                                       "AND class = '{}'"_format(id, cls));
+    }
+
+private:
+    fmt::memory_buffer m_opl;
+};
+
+TEMPLATE_TEST_CASE("Main tags", "", node_importer_t)
 {
-    auto opt = testing::opt_t().gazetteer().slim().append();
-    REQUIRE_NOTHROW(db.run_import(opt, opl));
-}
+    TestType t;
 
-static unsigned long node_count(pg::conn_t const &conn, osmid_t id,
-                                char const *cls)
-{
-    return conn.get_count("place", "osm_type = 'N' "
-                                   "AND osm_id = {} "
-                                   "AND class = '{}'"_format(id, cls));
-}
+    SECTION("Import main tags as fallback")
+    {
+        t.add(100, "junction=yes,highway=bus_stop");
+        t.add(101, "junction=yes,name=Bar");
+        t.add(200, "building=yes,amenity=cafe");
+        t.add(201, "building=yes,name=Intersting");
+        t.add(202, "building=yes");
 
-TEST_CASE("Import main tags as fallback")
-{
-    import("n100 Tjunction=yes,highway=bus_stop x0 y0\n"
-           "n101 Tjunction=yes,name=Bar x4 y6\n"
-           "n200 Tbuilding=yes,amenity=cafe x3 y7\n"
-           "n201 Tbuilding=yes,name=Intersting x4 y5\n"
-           "n202 Tbuilding=yes x6 y9\n");
+        t.import();
 
-    auto conn = db.connect();
+        auto conn = db.connect();
 
-    CHECK(0 == node_count(conn, 100, "junction"));
-    CHECK(1 == node_count(conn, 101, "junction"));
-    CHECK(0 == node_count(conn, 200, "building"));
-    CHECK(1 == node_count(conn, 201, "building"));
-    CHECK(0 == node_count(conn, 202, "building"));
-}
+        CHECK(0 == t.obj_count(conn, 100, "junction"));
+        CHECK(1 == t.obj_count(conn, 101, "junction"));
+        CHECK(0 == t.obj_count(conn, 200, "building"));
+        CHECK(1 == t.obj_count(conn, 201, "building"));
+        CHECK(0 == t.obj_count(conn, 202, "building"));
+    }
 
-TEST_CASE("Main tag deleted")
-{
-    import("n1 Tamenity=restaurant x12.3 y3\n"
-           "n2 Thighway=bus_stop,railway=stop,name=X x56.4 y-4\n"
-           "n3 Tamenity=prison x3 y5\n");
+    SECTION("Main tag deleted")
+    {
+        t.add(1, "amenity=restaurant");
+        t.add(2, "highway=bus_stop,railway=stop,name=X");
+        t.add(3, "amenity=prison");
 
-    auto conn = db.connect();
+        t.import();
 
-    CHECK(1 == node_count(conn, 1, "amenity"));
-    CHECK(1 == node_count(conn, 2, "highway"));
-    CHECK(1 == node_count(conn, 2, "railway"));
-    CHECK(1 == node_count(conn, 3, "amenity"));
+        auto conn = db.connect();
 
-    update("n3 v2 dD\n"
-           "n1 Tnot_a=restaurant x12.3 y3\n"
-           "n2 Thighway=bus_stop,name=X x56.4 y-4\n");
+        CHECK(1 == t.obj_count(conn, 1, "amenity"));
+        CHECK(1 == t.obj_count(conn, 2, "highway"));
+        CHECK(1 == t.obj_count(conn, 2, "railway"));
+        CHECK(1 == t.obj_count(conn, 3, "amenity"));
 
-    CHECK(0 == node_count(conn, 1, "amenity"));
-    CHECK(2 == node_count(conn, 2, "highway"));
-    CHECK(0 == node_count(conn, 2, "railway"));
-    CHECK(0 == node_count(conn, 3, "amenity"));
-}
+        t.del(3);
+        t.add(1, "not_a=restaurant");
+        t.add(2, "highway=bus_stop,name=X");
 
-TEST_CASE("Main tag added")
-{
-    import("n1 Tatiy=restaurant x12.3 y3\n"
-           "n2 Thighway=bus_stop,name=X x56.4 y-4\n");
+        t.update();
 
-    auto conn = db.connect();
+        CHECK(0 == t.obj_count(conn, 1, "amenity"));
+        CHECK(2 == t.obj_count(conn, 2, "highway"));
+        CHECK(0 == t.obj_count(conn, 2, "railway"));
+        CHECK(0 == t.obj_count(conn, 3, "amenity"));
+    }
 
-    CHECK(0 == node_count(conn, 1, "amenity"));
-    CHECK(1 == node_count(conn, 2, "highway"));
-    CHECK(0 == node_count(conn, 2, "railway"));
-    CHECK(0 == node_count(conn, 3, "amenity"));
+    SECTION("Main tag added")
+    {
+        t.add(1, "atiy=restaurant");
+        t.add(2, "highway=bus_stop,name=X");
 
-    update("n1 Tamenity=restaurant x12.3 y3\n"
-           "n2 Thighway=bus_stop,railway=stop,name=X x56.4 y-4\n"
-           "n3 Tamenity=prison x3 y5\n");
+        t.import();
 
-    CHECK(1 == node_count(conn, 1, "amenity"));
-    CHECK(2 == node_count(conn, 2, "highway"));
-    CHECK(1 == node_count(conn, 2, "railway"));
-    CHECK(1 == node_count(conn, 3, "amenity"));
-}
+        auto conn = db.connect();
 
-TEST_CASE("Main tag modified")
-{
-    import("n10 Thighway=footway,name=X x10 y11\n"
-           "n11 Tamenity=atm x-10 y-11\n");
+        CHECK(0 == t.obj_count(conn, 1, "amenity"));
+        CHECK(1 == t.obj_count(conn, 2, "highway"));
+        CHECK(0 == t.obj_count(conn, 2, "railway"));
+        CHECK(0 == t.obj_count(conn, 3, "amenity"));
 
-    auto conn = db.connect();
+        t.add(1, "amenity=restaurant");
+        t.add(2, "highway=bus_stop,railway=stop,name=X");
+        t.add(3, "amenity=prison");
 
-    CHECK(1 == node_count(conn, 10, "highway"));
-    CHECK(1 == node_count(conn, 11, "amenity"));
+        t.update();
 
-    update("n10 Thighway=path,name=X x10 y11\n"
-           "n11 Thighway=primary x-10 y-11\n");
+        CHECK(1 == t.obj_count(conn, 1, "amenity"));
+        CHECK(2 == t.obj_count(conn, 2, "highway"));
+        CHECK(1 == t.obj_count(conn, 2, "railway"));
+        CHECK(1 == t.obj_count(conn, 3, "amenity"));
+    }
 
-    CHECK(2 == node_count(conn, 10, "highway"));
-    CHECK(0 == node_count(conn, 11, "amenity"));
-    CHECK(1 == node_count(conn, 11, "highway"));
-}
+    SECTION("Main tag modified")
+    {
+        t.add(10, "highway=footway,name=X");
+        t.add(11, "amenity=atm");
 
-TEST_CASE("Main tags with name, name added")
-{
-    import("n45 Tlanduse=cemetry x0 y0\n"
-           "n46 Tbuilding=yes x1 y1\n");
+        t.import();
 
-    auto conn = db.connect();
+        auto conn = db.connect();
 
-    CHECK(0 == node_count(conn, 45, "landuse"));
-    CHECK(0 == node_count(conn, 46, "building"));
+        CHECK(1 == t.obj_count(conn, 10, "highway"));
+        CHECK(1 == t.obj_count(conn, 11, "amenity"));
 
-    update("n45 Tlanduse=cemetry,name=TODO x0 y0\n"
-           "n46 Tbuilding=yes,addr:housenumber=1 x1 y1\n");
+        t.add(10, "highway=path,name=X");
+        t.add(11, "highway=primary");
 
-    CHECK(1 == node_count(conn, 45, "landuse"));
-    CHECK(1 == node_count(conn, 46, "building"));
-}
+        t.update();
 
-TEST_CASE("Main tags with name, name removed")
-{
-    import("n45 Tlanduse=cemetry,name=TODO x0 y0\n"
-           "n46 Tbuilding=yes,addr:housenumber=1 x1 y1\n");
+        CHECK(2 == t.obj_count(conn, 10, "highway"));
+        CHECK(0 == t.obj_count(conn, 11, "amenity"));
+        CHECK(1 == t.obj_count(conn, 11, "highway"));
+    }
 
-    auto conn = db.connect();
+    SECTION("Main tags with name, name added")
+    {
+        t.add(45, "landuse=cemetry");
+        t.add(46, "building=yes");
 
-    CHECK(1 == node_count(conn, 45, "landuse"));
-    CHECK(1 == node_count(conn, 46, "building"));
+        t.import();
 
-    update("n45 Tlanduse=cemetry x0 y0\n"
-           "n46 Tbuilding=yes x1 y1\n");
+        auto conn = db.connect();
 
-    CHECK(0 == node_count(conn, 45, "landuse"));
-    CHECK(0 == node_count(conn, 46, "building"));
-}
+        CHECK(0 == t.obj_count(conn, 45, "landuse"));
+        CHECK(0 == t.obj_count(conn, 46, "building"));
 
-TEST_CASE("Main tags with name, name modified")
-{
-    import("n45 Tlanduse=cemetry,name=TODO x0 y0\n"
-           "n46 Tbuilding=yes,addr:housenumber=1 x1 y1\n");
+        t.add(45, "landuse=cemetry,name=TODO");
+        t.add(46, "building=yes,addr:housenumber=1");
 
-    auto conn = db.connect();
+        t.update();
 
-    CHECK(1 == node_count(conn, 45, "landuse"));
-    CHECK(1 == node_count(conn, 46, "building"));
+        CHECK(1 == t.obj_count(conn, 45, "landuse"));
+        CHECK(1 == t.obj_count(conn, 46, "building"));
+    }
 
-    update("n45 Tlanduse=cemetry,name=DONE x0 y0\n"
-           "n46 Tbuilding=yes,addr:housenumber=10 x1 y1\n");
+    SECTION("Main tags with name, name removed")
+    {
+        t.add(45, "landuse=cemetry,name=TODO");
+        t.add(46, "building=yes,addr:housenumber=1");
 
-    CHECK(2 == node_count(conn, 45, "landuse"));
-    CHECK(2 == node_count(conn, 46, "building"));
-}
+        t.import();
 
-TEST_CASE("Main tag added to address only node")
-{
-    import("n1 Taddr:housenumber=345 x0 y0\n");
+        auto conn = db.connect();
 
-    auto conn = db.connect();
+        CHECK(1 == t.obj_count(conn, 45, "landuse"));
+        CHECK(1 == t.obj_count(conn, 46, "building"));
 
-    CHECK(1 == node_count(conn, 1, "place"));
-    CHECK(0 == node_count(conn, 1, "building"));
+        t.add(45, "landuse=cemetry");
+        t.add(46, "building=yes");
 
-    update("n1 Taddr:housenumber=345,building=yes x0 y0\n");
+        t.update();
 
-    CHECK(0 == node_count(conn, 1, "place"));
-    CHECK(1 == node_count(conn, 1, "building"));
-}
+        CHECK(0 == t.obj_count(conn, 45, "landuse"));
+        CHECK(0 == t.obj_count(conn, 46, "building"));
+    }
 
-TEST_CASE("Main tag removed from address only node")
-{
-    import("n1 Taddr:housenumber=345,building=yes x0 y0\n");
+    SECTION("Main tags with name, name modified")
+    {
+        t.add(45, "landuse=cemetry,name=TODO");
+        t.add(46, "building=yes,addr:housenumber=1");
 
-    auto conn = db.connect();
+        t.import();
 
-    CHECK(0 == node_count(conn, 1, "place"));
-    CHECK(1 == node_count(conn, 1, "building"));
+        auto conn = db.connect();
 
-    update("n1 Taddr:housenumber=345 x0 y0\n");
+        CHECK(1 == t.obj_count(conn, 45, "landuse"));
+        CHECK(1 == t.obj_count(conn, 46, "building"));
 
-    CHECK(1 == node_count(conn, 1, "place"));
-    CHECK(0 == node_count(conn, 1, "building"));
-}
+        t.add(45, "landuse=cemetry,name=DONE");
+        t.add(46, "building=yes,addr:housenumber=10");
 
-TEST_CASE("Main tags with name key, adding key name")
-{
-    import("n22 Tbridge=yes x0 y0\n");
+        t.update();
 
-    auto conn = db.connect();
+        CHECK(2 == t.obj_count(conn, 45, "landuse"));
+        CHECK(2 == t.obj_count(conn, 46, "building"));
+    }
 
-    CHECK(0 == node_count(conn, 22, "bridge"));
+    SECTION("Main tag added to address only node")
+    {
+        t.add(1, "addr:housenumber=345");
 
-    update("n22 Tbridge=yes,bridge:name=high x0 y0\n");
+        t.import();
 
-    CHECK(1 == node_count(conn, 22, "bridge"));
-}
+        auto conn = db.connect();
 
-TEST_CASE("Main tags with name key, deleting key name")
-{
-    import("n22 Tbridge=yes,bridge:name=high x0 y0\n");
+        CHECK(1 == t.obj_count(conn, 1, "place"));
+        CHECK(0 == t.obj_count(conn, 1, "building"));
 
-    auto conn = db.connect();
+        t.add(1, "addr:housenumber=345,building=yes");
 
-    CHECK(1 == node_count(conn, 22, "bridge"));
+        t.update();
 
-    update("n22 Tbridge=yes x0 y0\n");
+        CHECK(0 == t.obj_count(conn, 1, "place"));
+        CHECK(1 == t.obj_count(conn, 1, "building"));
+    }
 
-    CHECK(0 == node_count(conn, 22, "bridge"));
-}
+    SECTION("Main tag removed from address only node")
+    {
+        t.add(1, "addr:housenumber=345,building=yes");
 
-TEST_CASE("Main tags with name key, changing key name")
-{
-    import("n22 Tbridge=yes,bridge:name=high x0 y0\n");
+        t.import();
 
-    auto conn = db.connect();
+        auto conn = db.connect();
 
-    CHECK(1 == node_count(conn, 22, "bridge"));
+        CHECK(0 == t.obj_count(conn, 1, "place"));
+        CHECK(1 == t.obj_count(conn, 1, "building"));
 
-    update("n22 Tbridge=yes,bridge:name:en=high x0 y0\n");
+        t.add(1, "addr:housenumber=345");
 
-    CHECK(2 == node_count(conn, 22, "bridge"));
+        t.update();
+
+        CHECK(1 == t.obj_count(conn, 1, "place"));
+        CHECK(0 == t.obj_count(conn, 1, "building"));
+    }
+
+    SECTION("Main tags with name key, adding key name")
+    {
+        t.add(22, "bridge=yes");
+
+        t.import();
+
+        auto conn = db.connect();
+
+        CHECK(0 == t.obj_count(conn, 22, "bridge"));
+
+        t.add(22, "bridge=yes,bridge:name=high");
+
+        t.update();
+
+        CHECK(1 == t.obj_count(conn, 22, "bridge"));
+    }
+
+    SECTION("Main tags with name key, deleting key name")
+    {
+        t.add(22, "bridge=yes,bridge:name=high");
+
+        t.import();
+
+        auto conn = db.connect();
+
+        CHECK(1 == t.obj_count(conn, 22, "bridge"));
+
+        t.add(22, "bridge=yes");
+
+        t.update();
+
+        CHECK(0 == t.obj_count(conn, 22, "bridge"));
+    }
+
+    SECTION("Main tags with name key, changing key name")
+    {
+        t.add(22, "bridge=yes,bridge:name=high");
+
+        t.import();
+
+        auto conn = db.connect();
+
+        CHECK(1 == t.obj_count(conn, 22, "bridge"));
+
+        t.add(22, "bridge=yes,bridge:name:en=high");
+
+        t.update();
+
+        CHECK(2 == t.obj_count(conn, 22, "bridge"));
+    }
 }


### PR DESCRIPTION
Parametrize gazetteer tests so that not only nodes are imported but also ways and relations. Geometries are created at random. For relations a simple tetragon from a single way is used.