### PR TITLE
Refactor constructor of db_target_descr_t

### DIFF
--- a/src/db-copy.hpp
+++ b/src/db-copy.hpp
@@ -35,7 +35,8 @@ struct db_target_descr_t
     }
 
     db_target_descr_t() = default;
-    db_target_descr_t(char const *n, char const *i, char const *r = "")
+
+    db_target_descr_t(std::string const &n, std::string const &i, std::string const &r = "")
     : name(n), rows(r), id(i)
     {}
 };

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -18,7 +18,7 @@ table_t::table_t(std::string const &name, std::string const &type,
                  columns_t const &columns, hstores_t const &hstore_columns,
                  int const srid, bool const append, int const hstore_mode,
                  std::shared_ptr<db_copy_thread_t> const &copy_thread)
-: m_target(std::make_shared<db_target_descr_t>(name.c_str(), "osm_id")),
+: m_target(std::make_shared<db_target_descr_t>(name, "osm_id")),
   type(type), srid(fmt::to_string(srid)), append(append),
   hstore_mode(hstore_mode), columns(columns), hstore_columns(hstore_columns),
   m_copy(copy_thread)


### PR DESCRIPTION
Takes `std::string const &` now instead of `char const *` to avoid
conversions from string to char* back to string.