### PR TITLE
Add more tests for the gazetteer configuration options

### DIFF
--- a/tests/data/gazetteer-test.style
+++ b/tests/data/gazetteer-test.style
@@ -156,7 +156,7 @@
 {
     "keys" : ["bridge", "tunnel"],
     "values" : {
-        "" : "main,with_name_key"
+        "" : "main,with_name_key,extra"
     }
 },
 {
@@ -182,11 +182,11 @@
     "keys" : ["postal_code", "postcode", "addr:postcode",
               "tiger:zip_left", "tiger:zip_right"],
     "values" : {
-        "" : "postcode"
+        "" : "postcode,fallback"
     }
 },
 {
-    "keys" : ["country_code", "ISO3166-1", "is_in:country_code", "is_in_country",
+    "keys" : ["country_code", "ISO3166-1", "is_in:country_code",
               "addr:country", "addr:country", "addr:country_code"],
     "values" : {
         "" : "country"
@@ -196,6 +196,12 @@
     "keys" : ["addr:housenumber", "addr:conscriptionnumber", "addr:streetnumber"],
     "values" : {
         "" : "address,house"
+    }
+},
+{
+    "keys" : ["addr:interpolation"],
+    "values" : {
+        "" : "interpolation,address"
     }
 },
 {
@@ -212,20 +218,18 @@
     }
 },
 {
-    "keys" : ["tracktype", "traffic_calming", "service", "cuisine", "capital",
-              "dispensing", "religion", "denomination", "sport",
-              "internet_access", "lanes", "surface", "smoothness", "width",
-              "est_width", "incline", "opening_hours", "collection_times",
-              "service_times", "disused", "wheelchair", "sac_scale",
-              "trail_visibility", "mtb:scale", "mtb:description", "wood",
-              "drive_through", "drive_in", "access", "vehicle", "bicyle",
-              "foot", "goods", "hgv", "motor_vehicle", "motor_car", "oneway",
-              "date_on", "date_off", "day_on", "day_off", "hour_on", "hour_off",
-              "maxweight", "maxheight", "maxspeed", "fee", "toll", "charge",
-              "population", "description", "image", "attribution", "fax",
-              "email", "url", "website", "phone", "real_ale", "smoking",
-              "food", "camera", "brewery", "locality", "wikipedia",
-              "wikipedia:*", "access:*", "contact:*", "drink:*", "toll:*"],
+    "keys" : ["note", "note:*", "source", "source*", "attribution",
+              "comment", "fixme", "FIXME", "created_by", "tiger:*", "NHD:*",
+              "nhd:*", "gnis:*", "geobase:*", "KSJ2:*", "yh:*",
+              "osak:*", "naptan:*", "CLC:*", "import", "it:fvg:*",
+              "type", "lacounty:*", "ref:ruian:*", "building:ruian:type",
+              "ref:linz:*"],
+    "values" : {
+        "" : "skip"
+    }
+},
+{
+    "keys" : [""],
     "values" : {
         "" : "extra"
     }

--- a/tests/regression.py
+++ b/tests/regression.py
@@ -328,14 +328,14 @@ class GazetteerTests(object):
     """ Tests for gazetteer output using Liechtenstein file.
     """
     def test_place_count(self):
-        self.assert_count(2867 if self.update else 2826, 'place')
+        self.assert_count(2877 if self.update else 2836, 'place')
 
     def test_place_node_count(self):
         self.assert_count(764 if self.update else 759, 'place',
                           where="osm_type = 'N'")
 
     def test_place_way_count(self):
-        self.assert_count(2085 if self.update else 2049, 'place',
+        self.assert_count(2095 if self.update else 2059, 'place',
                           where="osm_type = 'W'")
 
     def test_place_rel_count(self):
@@ -346,7 +346,7 @@ class GazetteerTests(object):
         self.assert_count(199, 'place', where="address ? 'housenumber'")
 
     def test_place_address_count(self):
-        self.assert_count(309, 'place', where='address is not null')
+        self.assert_count(319, 'place', where='address is not null')
 
 
 class MultipolygonTests(object):

--- a/tests/test-output-gazetteer.cpp
+++ b/tests/test-output-gazetteer.cpp
@@ -1,8 +1,8 @@
 #include <catch.hpp>
 
 #include <random>
-#include <tuple>
 #include <vector>
+#include <utility>
 
 #include "common-import.hpp"
 #include "common-options.hpp"
@@ -166,7 +166,7 @@ private:
     fmt::memory_buffer m_rel_opl;
 };
 
-using hstore_item = std::tuple<std::string, std::string>;
+using hstore_item = std::pair<std::string, std::string>;
 using hstore_list = std::vector<hstore_item>;
 
 template <typename T>

--- a/tests/test-output-gazetteer.cpp
+++ b/tests/test-output-gazetteer.cpp
@@ -1,6 +1,8 @@
 #include <catch.hpp>
 
 #include <random>
+#include <tuple>
+#include <vector>
 
 #include "common-import.hpp"
 #include "common-options.hpp"
@@ -164,6 +166,9 @@ private:
     fmt::memory_buffer m_rel_opl;
 };
 
+using hstore_item = std::tuple<std::string, std::string>;
+using hstore_list = std::vector<hstore_item>;
+
 template <typename T>
 class gazetteer_fixture_t
 {
@@ -195,9 +200,65 @@ public:
                               "AND class = '{}'"_format(tchar, id, cls));
     }
 
+    void obj_names(pg::conn_t const &conn, osmid_t id, char const *cls,
+                   hstore_list const &names)
+    {
+        hstore_compare(conn, id, cls, "name", names);
+    }
+
+    void obj_address(pg::conn_t const &conn, osmid_t id, char const *cls,
+                     hstore_list const &names)
+    {
+        hstore_compare(conn, id, cls, "address", names);
+    }
+
+    void obj_extratags(pg::conn_t const &conn, osmid_t id, char const *cls,
+                       hstore_list const &names)
+    {
+        hstore_compare(conn, id, cls, "extratags", names);
+    }
+
+    std::string obj_field(pg::conn_t const &conn, osmid_t id, char const *cls,
+                          char const *column)
+    {
+        char const tchar = m_opl_factory.type();
+        return conn.require_scalar<std::string>(
+            "SELECT {} FROM place WHERE osm_type = '{}' AND osm_id = {}"
+            " AND class = '{}'"_format(column, tchar, id, cls));
+    }
+
 private:
+    void hstore_compare(pg::conn_t const &conn, osmid_t id, char const *cls,
+                        char const *column, hstore_list const &names)
+    {
+        char const tchar = m_opl_factory.type();
+        auto const sql =
+            "SELECT skeys({}), svals({}) FROM place"
+            " WHERE osm_type = '{}' AND osm_id = {}"
+            " AND class = '{}'"_format(column, column, tchar, id, cls);
+        auto const res = conn.query(PGRES_TUPLES_OK, sql);
+
+        hstore_list actual;
+        for (int i = 0; i < res.num_tuples(); ++i) {
+            actual.emplace_back(res.get_value(i, 0), res.get_value(i, 1));
+        }
+
+        CHECK_THAT(actual, Catch::Matchers::UnorderedEquals(names));
+    }
+
     T m_opl_factory;
 };
+
+namespace Catch {
+template <>
+struct StringMaker<hstore_item>
+{
+    static std::string convert(hstore_item const &value)
+    {
+        return "({}, {})"_format(std::get<0>(value), std::get<1>(value));
+    }
+};
+} // namespace Catch
 
 using node_importer_t = gazetteer_fixture_t<node_opl_t>;
 using way_importer_t = gazetteer_fixture_t<way_opl_t>;
@@ -453,4 +514,253 @@ TEMPLATE_TEST_CASE("Main tags", "", node_importer_t, way_importer_t,
 
         CHECK(2 == t.obj_count(conn, 22, "bridge"));
     }
+}
+
+TEST_CASE("Operator tag")
+{
+    node_importer_t t;
+
+    t.add(1001, "amenity=restaurant,operator=McDo");
+    t.add(1002, "amenity=prison,operator=police");
+
+    t.import();
+
+    auto conn = db.connect();
+
+    t.obj_names(conn, 1001, "amenity", {{"operator", "McDo"}});
+    t.obj_names(conn, 1002, "amenity", {});
+}
+
+TEST_CASE("Name and reg tags")
+{
+    node_importer_t t;
+
+    t.add(2001, "highway=road,name=Foo,alt_name:de=Bar,ref=45");
+    t.add(2002, "highway=road,name:prefix=Pre,name:suffix=Post,ref:de=55");
+    t.add(2003, "highway=yes,name:%20%de=Foo,name=real1");
+    t.add(2004, "highway=yes,name:%a%de=Foo,name=real2");
+    t.add(2005, "highway=yes,name:%9%de=Foo,name:\\\\=real3");
+    t.add(2006, "highway=yes,name:%9%de=Foo,name=rea\\l3");
+
+    t.import();
+
+    auto conn = db.connect();
+
+    t.obj_names(conn, 2001, "highway",
+                {{"name", "Foo"}, {"alt_name:de", "Bar"}, {"ref", "45"}});
+    t.obj_names(conn, 2002, "highway", {});
+    t.obj_extratags(
+        conn, 2002, "highway",
+        {{"name:prefix", "Pre"}, {"name:suffix", "Post"}, {"ref:de", "55"}});
+    t.obj_names(conn, 2003, "highway",
+                {{"name: de", "Foo"}, {"name", "real1"}});
+    t.obj_names(conn, 2004, "highway",
+                {{"name:\nde", "Foo"}, {"name", "real2"}});
+    t.obj_names(conn, 2005, "highway",
+                {{"name:\tde", "Foo"}, {"name:\\\\", "real3"}});
+    t.obj_names(conn, 2006, "highway",
+                {{"name:\tde", "Foo"}, {"name", "rea\\l3"}});
+}
+
+TEST_CASE("Name when using with_name flag")
+{
+    node_importer_t t;
+
+    t.add(3001, "bridge=yes,bridge:name=GoldenGate");
+    t.add(3002, "bridge=yes,bridge:name:en=Rainbow");
+
+    t.import();
+
+    auto conn = db.connect();
+
+    t.obj_names(conn, 3001, "bridge", {{"name", "GoldenGate"}});
+    t.obj_names(conn, 3002, "bridge", {{"name:en", "Rainbow"}});
+}
+
+TEST_CASE("Address tags")
+{
+    node_importer_t t;
+
+    t.add(4001, "addr:housenumber=34,addr:city=Esmarald,addr:county=Land");
+    t.add(4002, "addr:streetnumber=10,is_in:city=Rootoo,is_in=Gold");
+
+    t.import();
+
+    auto conn = db.connect();
+
+    t.obj_address(
+        conn, 4001, "place",
+        {{"housenumber", "34"}, {"city", "Esmarald"}, {"county", "Land"}});
+    t.obj_address(
+        conn, 4002, "place",
+        {{"streetnumber", "10"}, {"city", "Rootoo"}, {"is_in", "Gold"}});
+}
+
+TEST_CASE("Country codes")
+{
+    node_importer_t t;
+
+    t.add(5001, "shop=yes,country_code=DE");
+    t.add(5002, "shop=yes,country_code=toolong");
+    t.add(5003, "shop=yes,country_code=x");
+    t.add(5004, "shop=yes,addr:country=us");
+    t.add(5005, "shop=yes,is_in:country=be");
+
+    t.import();
+
+    auto conn = db.connect();
+
+    t.obj_address(conn, 5001, "shop", {{"country", "DE"}});
+    t.obj_address(conn, 5002, "shop", {});
+    t.obj_address(conn, 5003, "shop", {});
+    t.obj_address(conn, 5004, "shop", {{"country", "us"}});
+    t.obj_address(conn, 5005, "shop", {});
+}
+
+TEST_CASE("Postcodes")
+{
+    node_importer_t t;
+
+    t.add(6001, "shop=bank,addr:postcode=12345");
+    t.add(6002, "shop=bank,tiger:zip_left=34343");
+    t.add(6003, "shop=bank,is_in:postcode=9009");
+
+    t.import();
+
+    auto conn = db.connect();
+
+    t.obj_address(conn, 6001, "shop", {{"postcode", "12345"}});
+    t.obj_address(conn, 6002, "shop", {{"postcode", "34343"}});
+    t.obj_address(conn, 6003, "shop", {});
+}
+
+TEST_CASE("Main with extra")
+{
+    way_importer_t t;
+
+    t.add(7001, "highway=primary,bridge=yes,name=1");
+
+    t.import();
+
+    auto conn = db.connect();
+
+    t.obj_extratags(conn, 7001, "highway", {{"bridge", "yes"}});
+}
+
+TEST_CASE("Global fallback and skipping")
+{
+    node_importer_t t;
+
+    t.add(8001, "shop=shoes,note:de=Nein,xx=yy");
+    t.add(8002, "shop=shoes,building=no,ele=234");
+    t.add(8003, "shop=shoes,name:source=survey");
+
+    t.import();
+
+    auto conn = db.connect();
+
+    t.obj_extratags(conn, 8001, "shop", {{"xx", "yy"}});
+    t.obj_extratags(conn, 8002, "shop", {{"ele", "234"}});
+    t.obj_extratags(conn, 8003, "shop", {});
+}
+
+TEST_CASE("Admin levels")
+{
+    node_importer_t t;
+
+    t.add(9001, "place=city");
+    t.add(9002, "place=city,admin_level=16");
+    t.add(9003, "place=city,admin_level=x");
+    t.add(9004, "place=city,admin_level=1");
+    t.add(9005, "place=city,admin_level=0");
+
+    t.import();
+
+    auto conn = db.connect();
+
+    CHECK("15" == t.obj_field(conn, 9001, "place", "admin_level"));
+    CHECK("15" == t.obj_field(conn, 9002, "place", "admin_level"));
+    CHECK("15" == t.obj_field(conn, 9003, "place", "admin_level"));
+    CHECK("1" == t.obj_field(conn, 9004, "place", "admin_level"));
+    CHECK("15" == t.obj_field(conn, 9005, "place", "admin_level"));
+}
+
+TEST_CASE("Administrative boundaries with place tags")
+{
+    relation_importer_t t;
+
+    t.add(10001, "boundary=administrative,place=city,name=A");
+    t.add(10002, "boundary=natural,place=city,name=B");
+    t.add(10003, "boundary=administrative,place=island,name=C");
+
+    t.import();
+
+    auto conn = db.connect();
+
+    CHECK(1 == t.obj_count(conn, 10001, "boundary"));
+    CHECK(0 == t.obj_count(conn, 10001, "place"));
+    t.obj_extratags(conn, 10001, "boundary", {{"place", "city"}});
+    CHECK(1 == t.obj_count(conn, 10002, "boundary"));
+    CHECK(1 == t.obj_count(conn, 10002, "place"));
+    t.obj_extratags(conn, 10002, "boundary", {});
+    CHECK(1 == t.obj_count(conn, 10003, "boundary"));
+    CHECK(1 == t.obj_count(conn, 10003, "place"));
+    t.obj_extratags(conn, 10003, "boundary", {});
+}
+
+TEST_CASE("Shorten tiger:county tags")
+{
+    node_importer_t t;
+
+    t.add(11001, "place=village,tiger:county=Feebourgh%2c%%20%AL");
+    t.add(11002,
+          "place=village,addr:state=Alabama,tiger:county=Feebourgh%2c%%20%AL");
+    t.add(11003, "place=village,tiger:county=Feebourgh");
+
+    t.import();
+
+    auto conn = db.connect();
+
+    t.obj_address(conn, 11001, "place", {{"tiger:county", "Feebourgh county"}});
+    t.obj_address(conn, 11002, "place",
+                  {{"tiger:county", "Feebourgh county"}, {"state", "Alabama"}});
+    t.obj_address(conn, 11003, "place", {{"tiger:county", "Feebourgh county"}});
+}
+
+TEST_CASE("Building fallbacks")
+{
+    node_importer_t t;
+
+    t.add(12001, "tourism=hotel,building=yes");
+    t.add(12002, "building=house");
+    t.add(12003, "building=shed,addr:housenumber=1");
+    t.add(12004, "building=yes,name=Das-Haus");
+    t.add(12005, "building=yes,addr:postcode=12345");
+
+    t.import();
+
+    auto conn = db.connect();
+
+    CHECK("hotel" == t.obj_field(conn, 12001, "tourism", "type"));
+    CHECK(0 == t.obj_count(conn, 12001, "building"));
+    CHECK(0 == t.obj_count(conn, 12002, "building"));
+    CHECK("shed" == t.obj_field(conn, 12003, "building", "type"));
+    CHECK("yes" == t.obj_field(conn, 12004, "building", "type"));
+    CHECK("postcode" == t.obj_field(conn, 12005, "place", "type"));
+}
+
+TEST_CASE("Address interpolations")
+{
+    way_importer_t t;
+
+    t.add(13001, "addr:interpolation=odd");
+    t.add(13002, "addr:interpolation=even,place=city");
+
+    t.import();
+
+    auto conn = db.connect();
+
+    CHECK("houses" == t.obj_field(conn, 13001, "place", "type"));
+    CHECK("houses" == t.obj_field(conn, 13002, "place", "type"));
+    t.obj_extratags(conn, 13002, "place", {{"place", "city"}});
 }


### PR DESCRIPTION
These test check that tags are processed according to the import style configuration options. Most of the tests already existed in a very similar form as part of the [Nominatim test suite](https://github.com/openstreetmap/Nominatim/blob/master/test/bdd/osm2pgsql/import/tags.feature). The goal is to remove the osm2pgsql-only tests there and have them here instead.

Requires a small adaption to the regression test numbers as the gazetteer test style has changed a bit to be able to accommodate all test cases.