### PR TITLE
Remove superfluous checks for append mode.

### DIFF
--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -70,6 +70,7 @@ void osmdata_t::relation_add(osmium::Relation const &rel) const
 void osmdata_t::node_modify(osmium::Node const &node) const
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
+    assert(slim);
 
     slim->nodes_delete(node.id());
     slim->nodes_set(node);
@@ -84,6 +85,7 @@ void osmdata_t::node_modify(osmium::Node const &node) const
 void osmdata_t::way_modify(osmium::Way *way) const
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
+    assert(slim);
 
     slim->ways_delete(way->id());
     slim->ways_set(*way);
@@ -98,6 +100,7 @@ void osmdata_t::way_modify(osmium::Way *way) const
 void osmdata_t::relation_modify(osmium::Relation const &rel) const
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
+    assert(slim);
 
     slim->relations_delete(rel.id());
     slim->relations_set(rel);
@@ -112,6 +115,7 @@ void osmdata_t::relation_modify(osmium::Relation const &rel) const
 void osmdata_t::node_delete(osmid_t id) const
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
+    assert(slim);
 
     for (auto &out : outs) {
         out->node_delete(id);
@@ -123,6 +127,7 @@ void osmdata_t::node_delete(osmid_t id) const
 void osmdata_t::way_delete(osmid_t id) const
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
+    assert(slim);
 
     for (auto &out : outs) {
         out->way_delete(id);
@@ -134,6 +139,7 @@ void osmdata_t::way_delete(osmid_t id) const
 void osmdata_t::relation_delete(osmid_t id) const
 {
     slim_middle_t *slim = dynamic_cast<slim_middle_t *>(mid.get());
+    assert(slim);
 
     for (auto &out : outs) {
         out->relation_delete(id);

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -355,11 +355,6 @@ void output_pgsql_t::relation_add(osmium::Relation const &rel)
  * contain the change for that also. */
 void output_pgsql_t::node_delete(osmid_t osm_id)
 {
-    if (!m_options.slim) {
-        fprintf(stderr, "Cannot apply diffs unless in slim mode\n");
-        util::exit_nicely();
-    }
-
     if (expire.from_db(m_tables[t_point].get(), osm_id) != 0) {
         m_tables[t_point]->delete_row(osm_id);
     }
@@ -388,10 +383,6 @@ void output_pgsql_t::pgsql_delete_way_from_output(osmid_t osm_id)
 
 void output_pgsql_t::way_delete(osmid_t osm_id)
 {
-    if (!m_options.slim) {
-        fprintf(stderr, "Cannot apply diffs unless in slim mode\n");
-        util::exit_nicely();
-    }
     pgsql_delete_way_from_output(osm_id);
 }
 
@@ -409,10 +400,6 @@ void output_pgsql_t::pgsql_delete_relation_from_output(osmid_t osm_id)
 
 void output_pgsql_t::relation_delete(osmid_t osm_id)
 {
-    if (!m_options.slim) {
-        fprintf(stderr, "Cannot apply diffs unless in slim mode\n");
-        util::exit_nicely();
-    }
     pgsql_delete_relation_from_output(osm_id);
 }
 
@@ -421,30 +408,18 @@ void output_pgsql_t::relation_delete(osmid_t osm_id)
  * objects that depend on this one */
 void output_pgsql_t::node_modify(osmium::Node const &node)
 {
-    if (!m_options.slim) {
-        fprintf(stderr, "Cannot apply diffs unless in slim mode\n");
-        util::exit_nicely();
-    }
     node_delete(node.id());
     node_add(node);
 }
 
 void output_pgsql_t::way_modify(osmium::Way *way)
 {
-    if (!m_options.slim) {
-        fprintf(stderr, "Cannot apply diffs unless in slim mode\n");
-        util::exit_nicely();
-    }
     way_delete(way->id());
     way_add(way);
 }
 
 void output_pgsql_t::relation_modify(osmium::Relation const &rel)
 {
-    if (!m_options.slim) {
-        fprintf(stderr, "Cannot apply diffs unless in slim mode\n");
-        util::exit_nicely();
-    }
     relation_delete(rel.id());
     relation_add(rel);
 }

--- a/tests/test-options-parse.cpp
+++ b/tests/test-options-parse.cpp
@@ -37,6 +37,8 @@ TEST_CASE("Incompatible arguments", "[NoDB]")
     bad_opt({"--drop"}, "drop only makes sense with");
 
     bad_opt({"-j", "-k"}, "You can not specify both");
+
+    bad_opt({"-a"}, "--append can only be used with slim mode");
 }
 
 TEST_CASE("Middle selection", "[NoDB]")


### PR DESCRIPTION
Inside the pgsql output (and only in that output) we checked whether we
are in append mode in (the node|way|relation)_(modify|delete) functions.
This is not needed because oms2pgsql checks early on that option -a
isn't used without -s.

This can also be seen because at the callsite of those functions we are
doing an unchecked dynamic_cast that would have failed and returned a
nullptr if we are not in slim mode. So we would have never reached those
checkes. I have added assert()s to make clear we are relying on those
dynamic_casts to work.