### PR TITLE
Disable test db cleanup by setting OSM2PGSQL_KEEP_TEST_DB env var

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,13 @@ FAILs). If you find something which seems to be a bug, please check to see if
 it is a known issue at https://github.com/openstreetmap/osm2pgsql/issues and,
 if it's not already known, report it there.
 
+If you have failing tests and want to look at the test database to figure out
+what's happening, you can set the environment variable `OSM2PGSQL_KEEP_TEST_DB`
+to anything. This will disable the database cleanup at the end of the test.
+This will often be used together with the `-s` option of `pg_virtualenv` which
+drops you into a shell after a failed test where you can still access the
+database created by `pg_virtualenv`.
+
 ### Performance Testing
 
 If performance testing with a full planet import is required, indicate what

--- a/tests/common-pg.hpp
+++ b/tests/common-pg.hpp
@@ -2,6 +2,7 @@
 #define OSM2PGSQL_TEST_COMMON_PG_HPP
 
 #include <cstdio>
+#include <cstdlib>
 #include <stdexcept>
 #include <string>
 
@@ -105,6 +106,13 @@ public:
     ~tempdb_t() noexcept
     {
         if (!m_db_name.empty()) {
+            // Disable removal of the test database by setting the environment
+            // variable OSM2PGSQL_KEEP_TEST_DB to anything. This can be useful
+            // when debugging tests.
+            const char *const keep_db = std::getenv("OSM2PGSQL_KEEP_TEST_DB");
+            if (keep_db != nullptr) {
+                return;
+            }
             try {
                 conn_t conn{"dbname=postgres"};
                 conn.exec("DROP DATABASE IF EXISTS \"{}\""_format(m_db_name));


### PR DESCRIPTION
If you have failing tests and want to look at the test database to
figure out what's happening, you can now set the environment variable
`OSM2PGSQL_KEEP_TEST_DB` to anything. This will disable the database
cleanup at the end of the test.