### PR TITLE
travis: fail everything when ctest fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,10 @@ script:
   - if [[ $TEST_NODB ]]; then
       ctest -VV -L NoDB;
     else
-      for PG_VERSION in $PG_VERSIONS; do pg_virtualenv -v $PG_VERSION ctest -VV; done
+      for PG_VERSION in $PG_VERSIONS; do
+        pg_virtualenv -v $PG_VERSION ctest -VV;
+        if [[ $? -ne "0" ]]; then exit 2; fi
+      done
     fi
 
 after_failure:


### PR DESCRIPTION
Executing ctest multiple times against different postgres versions in a for loop means that travis only sees the result of the final run. Change the code to exit with an error immediately when a ctest run fails.

Note that this also means that the 'after_failure' trigger is not executed on such a failure. Given that it only tries to recompile, we don't care much about it anyway.