### PR TITLE
Allow decision on single/multi geometry for each geometry

### DIFF
--- a/src/geometry-processor.cpp
+++ b/src/geometry-processor.cpp
@@ -20,7 +20,8 @@ geometry_processor::create(const std::string &type, const options_t *options)
     } else if (type == "line") {
         ptr = std::make_shared<processor_line>(options->projection);
     } else if (type == "polygon") {
-        ptr = std::make_shared<processor_polygon>(options->projection);
+        ptr = std::make_shared<processor_polygon>(options->projection,
+                                                  options->enable_multi);
     } else {
         throw std::runtime_error{
             "Unable to construct geometry processor "

--- a/src/osmium-builder.cpp
+++ b/src/osmium-builder.cpp
@@ -150,7 +150,8 @@ osmium_builder_t::get_wkb_polygon(osmium::Way const &way)
 
 osmium_builder_t::wkbs_t
 osmium_builder_t::get_wkb_multipolygon(osmium::Relation const &rel,
-                                       osmium::memory::Buffer const &ways)
+                                       osmium::memory::Buffer const &ways,
+                                       bool build_multigeoms)
 {
     wkbs_t ret;
     osmium::area::AssemblerConfig area_config;
@@ -159,7 +160,7 @@ osmium_builder_t::get_wkb_multipolygon(osmium::Relation const &rel,
 
     m_buffer.clear();
     if (assembler(rel, ways, m_buffer)) {
-        if (m_build_multigeoms) {
+        if (build_multigeoms) {
             ret.push_back(create_multipolygon(m_buffer.get<osmium::Area>(0)));
         } else {
             ret = create_polygons(m_buffer.get<osmium::Area>(0));

--- a/src/osmium-builder.hpp
+++ b/src/osmium-builder.hpp
@@ -19,10 +19,9 @@ public:
     typedef std::string wkb_t;
     typedef std::vector<std::string> wkbs_t;
 
-    explicit osmium_builder_t(std::shared_ptr<reprojection> const &proj,
-                              bool build_multigeoms)
+    explicit osmium_builder_t(std::shared_ptr<reprojection> const &proj)
     : m_proj(proj), m_buffer(1024, osmium::memory::Buffer::auto_grow::yes),
-      m_writer(m_proj->target_srs()), m_build_multigeoms(build_multigeoms)
+      m_writer(m_proj->target_srs())
     {}
 
     wkb_t get_wkb_node(osmium::Location const &loc) const;
@@ -30,7 +29,9 @@ public:
     wkb_t get_wkb_polygon(osmium::Way const &way);
 
     wkbs_t get_wkb_multipolygon(osmium::Relation const &rel,
-                                osmium::memory::Buffer const &ways);
+                                osmium::memory::Buffer const &ways,
+                                bool build_multigeoms);
+
     wkbs_t get_wkb_multiline(osmium::memory::Buffer const &ways,
                              double split_at);
 
@@ -43,7 +44,6 @@ private:
     // internal buffer for creating areas
     osmium::memory::Buffer m_buffer;
     ewkb::writer_t m_writer;
-    bool m_build_multigeoms;
 };
 
 } // namespace geom

--- a/src/output-gazetteer.cpp
+++ b/src/output-gazetteer.cpp
@@ -200,7 +200,7 @@ bool output_gazetteer_t::process_relation(osmium::Relation const &rel)
 
     auto geoms = is_waterway
                      ? m_builder.get_wkb_multiline(osmium_buffer, 0.0)
-                     : m_builder.get_wkb_multipolygon(rel, osmium_buffer);
+                     : m_builder.get_wkb_multipolygon(rel, osmium_buffer, true);
 
     if (geoms.empty()) {
         return false;

--- a/src/output-gazetteer.hpp
+++ b/src/output-gazetteer.hpp
@@ -19,7 +19,7 @@ class output_gazetteer_t : public output_t
                        std::shared_ptr<middle_query_t> const &cloned_mid,
                        std::shared_ptr<db_copy_thread_t> const &copy_thread)
     : output_t(cloned_mid, other->m_options), m_copy(copy_thread),
-      m_builder(other->m_options.projection, true),
+      m_builder(other->m_options.projection),
       osmium_buffer(PLACE_BUFFER_SIZE, osmium::memory::Buffer::auto_grow::yes)
     {}
 
@@ -28,7 +28,7 @@ public:
                        options_t const &options,
                        std::shared_ptr<db_copy_thread_t> const &copy_thread)
     : output_t(mid, options), m_copy(copy_thread),
-      m_builder(options.projection, true),
+      m_builder(options.projection),
       osmium_buffer(PLACE_BUFFER_SIZE, osmium::memory::Buffer::auto_grow::yes)
     {
         m_style.load_style(options.style);

--- a/src/output-multi.cpp
+++ b/src/output-multi.cpp
@@ -32,7 +32,7 @@ output_multi_t::output_multi_t(
   m_expire(m_options.expire_tiles_zoom, m_options.expire_tiles_max_bbox,
            m_options.projection),
   buffer(1024, osmium::memory::Buffer::auto_grow::yes),
-  m_builder(m_options.projection, m_options.enable_multi),
+  m_builder(m_options.projection),
   m_way_area(export_list.has_column(m_osm_type, "way_area"))
 {}
 
@@ -51,7 +51,7 @@ output_multi_t::output_multi_t(
   m_expire(m_options.expire_tiles_zoom, m_options.expire_tiles_max_bbox,
            m_options.projection),
   buffer(1024, osmium::memory::Buffer::auto_grow::yes),
-  m_builder(m_options.projection, m_options.enable_multi),
+  m_builder(m_options.projection),
   m_way_area(other->m_way_area)
 {}
 

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -304,7 +304,7 @@ void output_pgsql_t::pgsql_process_relation(osmium::Relation const &rel)
 
     // multipolygons and boundaries
     if (make_boundary || make_polygon) {
-        auto wkbs = m_builder.get_wkb_multipolygon(rel, buffer);
+        auto wkbs = m_builder.get_wkb_multipolygon(rel, buffer, m_options.enable_multi);
 
         char tmp[32];
         for (auto const &wkb : wkbs) {
@@ -436,7 +436,7 @@ std::shared_ptr<output_t> output_pgsql_t::clone(
 output_pgsql_t::output_pgsql_t(
     std::shared_ptr<middle_query_t> const &mid, options_t const &o,
     std::shared_ptr<db_copy_thread_t> const &copy_thread)
-: output_t(mid, o), m_builder(o.projection, o.enable_multi),
+: output_t(mid, o), m_builder(o.projection),
   expire(o.expire_tiles_zoom, o.expire_tiles_max_bbox, o.projection),
   ways_done_tracker(new id_tracker()),
   buffer(32768, osmium::memory::Buffer::auto_grow::yes),
@@ -494,7 +494,7 @@ output_pgsql_t::output_pgsql_t(
 : output_t(mid, other->m_options),
   m_tagtransform(other->m_tagtransform->clone()),
   m_enable_way_area(other->m_enable_way_area),
-  m_builder(m_options.projection, other->m_options.enable_multi),
+  m_builder(m_options.projection),
   expire(m_options.expire_tiles_zoom, m_options.expire_tiles_max_bbox,
          m_options.projection),
   //NOTE: we need to know which ways were used by relations so each thread

--- a/src/processor-polygon.cpp
+++ b/src/processor-polygon.cpp
@@ -1,8 +1,10 @@
 #include "processor-polygon.hpp"
 
-processor_polygon::processor_polygon(std::shared_ptr<reprojection> const &proj)
+processor_polygon::processor_polygon(std::shared_ptr<reprojection> const &proj,
+                                     bool build_multigeoms)
 : geometry_processor(proj->target_srs(), "GEOMETRY",
-                     interest_way | interest_relation)
+                     interest_way | interest_relation),
+  m_build_multigeoms(build_multigeoms)
 {}
 
 geometry_processor::wkb_t
@@ -17,5 +19,5 @@ processor_polygon::process_relation(osmium::Relation const &rel,
                                     osmium::memory::Buffer const &ways,
                                     geom::osmium_builder_t *builder)
 {
-    return builder->get_wkb_multipolygon(rel, ways);
+    return builder->get_wkb_multipolygon(rel, ways, m_build_multigeoms);
 }

--- a/src/processor-polygon.hpp
+++ b/src/processor-polygon.hpp
@@ -6,13 +6,16 @@
 class processor_polygon : public geometry_processor
 {
 public:
-    processor_polygon(std::shared_ptr<reprojection> const &proj);
+    processor_polygon(std::shared_ptr<reprojection> const &proj,
+                      bool build_multigeoms);
 
     wkb_t process_way(osmium::Way const &nodes,
                       geom::osmium_builder_t *builder) override;
     wkbs_t process_relation(osmium::Relation const &rel,
                             osmium::memory::Buffer const &ways,
                             geom::osmium_builder_t *builder) override;
+private:
+    bool m_build_multigeoms;
 };
 
 #endif // OSM2PGSQL_PROCESSOR_POLYGON_HPP


### PR DESCRIPTION
With the old code the decision whether to generate many single polygons
or one multipolygon is done when creating the osmium_builder_t object
(based on a command line argument). This change optionally allows this
to be set when each (multi)polgyon is build. This flexibility will be
used later to allow setting this on a table-by-table basis.