### PR TITLE
make PROJ library optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_BINARY_DIR})
 
-find_package(Osmium 2.14 REQUIRED COMPONENTS io proj)
+find_package(Osmium 2.14 REQUIRED COMPONENTS io)
 include_directories(SYSTEM ${OSMIUM_INCLUDE_DIRS} ${PROTOZERO_INCLUDE_DIR} ${FMT_INCLUDE_DIR})
 
 if (WITH_LUA)
@@ -135,6 +135,19 @@ find_package(Threads)
 ############### Libraries are found now ########################
 
 set(LIBS ${Boost_LIBRARIES} ${PostgreSQL_LIBRARY} ${OSMIUM_LIBRARIES})
+
+find_path(PROJ4_INCLUDE_DIR proj_api.h)
+find_library(PROJ_LIBRARY NAMES proj)
+if(PROJ4_INCLUDE_DIR AND PROJ_LIBRARY)
+    message(STATUS "Found Proj4 ${PROJ_LIBRARY}")
+    set(HAVE_GENERIC_PROJ 1)
+    set(HAVE_PROJ4 1)
+    list(APPEND LIBS ${PROJ_LIBRARY})
+    include_directories(SYSTEM ${PROJ_INCLUDE_DIR})
+else()
+    message(STATUS "Proj library not found.")
+    message(STATUS "    Only Mercartor and WGS84 projections will be available.")
+endif()
 
 if (LUAJIT_FOUND)
     list(APPEND LIBS ${LUAJIT_LIBRARIES})

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -1,3 +1,4 @@
 #cmakedefine HAVE_LUA 1
 #cmakedefine HAVE_LUAJIT 1
 #cmakedefine HAVE_TERMIOS_H 1
+#cmakedefine HAVE_GENERIC_PROJ 1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,12 @@ endif()
 
 list(APPEND osm2pgsql_lib_SOURCES ${PROJECT_BINARY_DIR}/src/version.cpp)
 
+if (HAVE_PROJ4)
+    list(APPEND osm2pgsql_lib_SOURCES reprojection-generic-proj4.cpp)
+else()
+    list(APPEND osm2pgsql_lib_SOURCES reprojection-generic-none.cpp)
+endif()
+
 add_library(osm2pgsql_lib STATIC ${osm2pgsql_lib_SOURCES})
 set_target_properties(osm2pgsql_lib PROPERTIES OUTPUT_NAME osm2pgsql)
 target_link_libraries(osm2pgsql_lib ${LIBS})

--- a/src/reprojection-generic-none.cpp
+++ b/src/reprojection-generic-none.cpp
@@ -1,0 +1,8 @@
+#include <stdexcept>
+
+#include "reprojection.hpp"
+
+std::shared_ptr<reprojection> reprojection::make_generic_projection(int srs)
+{
+    throw std::runtime_error("No generic projection library available.");
+}

--- a/src/reprojection-generic-proj4.cpp
+++ b/src/reprojection-generic-proj4.cpp
@@ -1,0 +1,62 @@
+#include "reprojection.hpp"
+
+#include <osmium/geom/projection.hpp>
+
+namespace {
+
+/**
+ * Generic projection based using proj library.
+ */
+class generic_reprojection_t : public reprojection
+{
+public:
+    generic_reprojection_t(int srs)
+    : m_target_srs(srs), pj_target(srs), pj_source(PROJ_LATLONG),
+      pj_tile(
+          "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 "
+          "+y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs")
+    {}
+
+    osmium::geom::Coordinates reproject(osmium::Location loc) const override
+    {
+        using namespace osmium::geom;
+        return transform(pj_source, pj_target,
+                         Coordinates(deg_to_rad(loc.lon_without_check()),
+                                     deg_to_rad(loc.lat_without_check())));
+    }
+
+    void target_to_tile(double *lat, double *lon) const override
+    {
+        auto c = transform(pj_target, pj_tile,
+                           osmium::geom::Coordinates(*lon, *lat));
+
+        *lon = c.x;
+        *lat = c.y;
+    }
+
+    int target_srs() const override { return m_target_srs; }
+    const char *target_desc() const override
+    {
+        return pj_get_def(pj_target.get(), 0);
+    }
+
+private:
+    int m_target_srs;
+    osmium::geom::CRS pj_target;
+    /** The projection of the source data. Always lat/lon (EPSG:4326). */
+    osmium::geom::CRS pj_source;
+
+    /** The projection used for tiles. Currently this is fixed to be Spherical
+     *  Mercator. You will usually have tiles in the same projection as used
+     *  for PostGIS, but it is theoretically possible to have your PostGIS data
+     *  in, say, lat/lon but still create tiles in Spherical Mercator.
+     */
+    osmium::geom::CRS pj_tile;
+};
+
+} // anonymous namespace
+
+std::shared_ptr<reprojection> reprojection::make_generic_projection(int srs)
+{
+    return std::shared_ptr<reprojection>(new generic_reprojection_t(srs));
+}

--- a/src/reprojection.cpp
+++ b/src/reprojection.cpp
@@ -71,65 +71,18 @@ public:
     const char *target_desc() const override { return "Spherical Mercator"; }
 };
 
-class generic_reprojection_t : public reprojection
-{
-public:
-    generic_reprojection_t(int srs)
-    : m_target_srs(srs), pj_target(srs), pj_source(PROJ_LATLONG),
-      pj_tile(
-          "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 "
-          "+y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs")
-    {}
-
-    osmium::geom::Coordinates reproject(osmium::Location loc) const override
-    {
-        using namespace osmium::geom;
-        return transform(pj_source, pj_target,
-                         Coordinates(deg_to_rad(loc.lon_without_check()),
-                                     deg_to_rad(loc.lat_without_check())));
-    }
-
-    void target_to_tile(double *lat, double *lon) const override
-    {
-        auto c = transform(pj_target, pj_tile,
-                           osmium::geom::Coordinates(*lon, *lat));
-
-        *lon = c.x;
-        *lat = c.y;
-    }
-
-    int target_srs() const override { return m_target_srs; }
-    const char *target_desc() const override
-    {
-        return pj_get_def(pj_target.get(), 0);
-    }
-
-private:
-    int m_target_srs;
-    osmium::geom::CRS pj_target;
-    /** The projection of the source data. Always lat/lon (EPSG:4326). */
-    osmium::geom::CRS pj_source;
-
-    /** The projection used for tiles. Currently this is fixed to be Spherical
-     *  Mercator. You will usually have tiles in the same projection as used
-     *  for PostGIS, but it is theoretically possible to have your PostGIS data
-     *  in, say, lat/lon but still create tiles in Spherical Mercator.
-     */
-    osmium::geom::CRS pj_tile;
-};
-
 } // anonymous namespace
 
-reprojection *reprojection::create_projection(int srs)
+std::shared_ptr<reprojection> reprojection::create_projection(int srs)
 {
     switch (srs) {
     case PROJ_LATLONG:
-        return new latlon_reprojection_t();
+        return std::shared_ptr<reprojection>(new latlon_reprojection_t());
     case PROJ_SPHERE_MERC:
-        return new merc_reprojection_t();
+        return std::shared_ptr<reprojection>(new merc_reprojection_t());
     }
 
-    return new generic_reprojection_t(srs);
+    return make_generic_projection(srs);
 }
 
 void reprojection::coords_to_tile(double *tilex, double *tiley, double lon,

--- a/src/reprojection.hpp
+++ b/src/reprojection.hpp
@@ -2,12 +2,14 @@
 #define OSM2PGSQL_REPROJECTION_HPP
 
 /*
- * Convert OSM lattitude / longitude from degrees to mercator
+ * Convert OSM latitude / longitude from degrees to mercator
  * so that Mapnik does not have to project the data again
  *
  */
 
-#include <osmium/geom/projection.hpp>
+#include <memory>
+
+#include <osmium/geom/coordinates.hpp>
 #include <osmium/osm/location.hpp>
 
 enum Projection
@@ -62,7 +64,10 @@ public:
      * The target projection (used in the PostGIS tables).
      * Controlled by the -l/-m/-E options.
      */
-    static reprojection *create_projection(int srs);
+    static std::shared_ptr<reprojection> create_projection(int srs);
+
+private:
+    static std::shared_ptr<reprojection> make_generic_projection(int srs);
 };
 
 #endif // OSM2PGSQL_REPROJECTION_HPP

--- a/tests/common-options.hpp
+++ b/tests/common-options.hpp
@@ -17,6 +17,7 @@ public:
         m_opt.num_procs = 1;
         m_opt.cache = 2;
         m_opt.append = false;
+        m_opt.projection = reprojection::create_projection(PROJ_SPHERE_MERC);
     }
 
     operator options_t() const { return m_opt; }
@@ -72,7 +73,7 @@ public:
 
     opt_t &srs(int srs)
     {
-        m_opt.projection.reset(reprojection::create_projection(srs));
+        m_opt.projection = reprojection::create_projection(srs);
         return *this;
     }
 

--- a/tests/test-options-projection.cpp
+++ b/tests/test-options-projection.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "common-import.hpp"
+#include "config.h"
 
 static testing::db::import_t db;
 
@@ -35,6 +36,7 @@ TEST_CASE("Projection setup")
         srid = "3857";
     }
 
+#ifdef HAVE_GENERIC_PROJ
     SECTION("Latlong with -E option")
     {
         proj_name = "Latlong";
@@ -57,6 +59,7 @@ TEST_CASE("Projection setup")
         option_params.push_back("-E");
         option_params.push_back(srid);
     }
+#endif
 
     option_params.push_back("foo");
 


### PR DESCRIPTION
If the proj library cannot be found by cmake, do not offer
the option to use arbitrary projections.

Also changes reprojection interface to return managed pointers
for the projection.

Fixes #1065.