### PR TITLE
Fix relative path link to main flex documentation

### DIFF
--- a/flex-config/README.md
+++ b/flex-config/README.md
@@ -3,7 +3,7 @@
 
 **The Flex Backend is experimental. Everything in here is subject to change.**
 
-See the [Flex Backend Documentation](docs/flex.md) for all the details.
+See the [Flex Backend Documentation](../docs/flex.md) for all the details.
 
 ## Example config files
 


### PR DESCRIPTION
This fixes the link in the documentation to have the correct target path.