### PR TITLE
Always write processing stats after all parsing is done

### DIFF
--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -80,27 +80,22 @@ int main(int argc, char *argv[])
         util::timer_t timer_overall;
         osmdata.start();
 
-        /* Processing
-         * In this phase the input file(s) are read and parsed, populating some of the
-         * tables. Not all ways can be handled before relations are processed, so they're
-         * set as pending, to be handled in the next stage.
-         */
+        // Processing: In this phase the input file(s) are read and parsed,
+        // populating some of the tables.
         parse_stats_t stats;
-        //read in the input files one by one
         for (auto const &filename : options.input_files) {
-            //read the actual input
             fmt::print(stderr, "\nReading in file: {}\n", filename);
             util::timer_t timer_parse;
 
-            parse_osmium_t parser(options.bbox, options.append, &osmdata);
+            parse_osmium_t parser{options.bbox, options.append, &osmdata};
             parser.stream_file(filename, options.input_reader);
 
             stats.update(parser.stats());
 
+            stats.print_status(std::time(nullptr));
             fmt::print(stderr, "  parse time: {}s\n", timer_parse.stop());
         }
 
-        //show stats
         stats.print_summary();
 
         //Process pending ways, relations, cluster, and create indexes

--- a/src/parse-osmium.cpp
+++ b/src/parse-osmium.cpp
@@ -49,7 +49,18 @@ void parse_stats_t::print_summary() const
                m_rel.count, m_rel.max, rels_time(now));
 }
 
-void parse_stats_t::print_status()
+void parse_stats_t::print_status(time_t now) const
+{
+    fmt::print(
+        stderr,
+        "\rProcessing: Node({}k {:.1f}k/s) Way({}k {:.2f}k/s)"
+        " Relation({} {:.1f}/s)",
+        m_node.count_k(), count_per_second(m_node.count_k(), nodes_time(now)),
+        m_way.count_k(), count_per_second(m_way.count_k(), ways_time(now)),
+        m_rel.count, count_per_second(m_rel.count, rels_time(now)));
+}
+
+void parse_stats_t::possibly_print_status()
 {
     std::time_t const now = std::time(nullptr);
 
@@ -58,13 +69,7 @@ void parse_stats_t::print_status()
     }
     m_last_print_time = now;
 
-    fmt::print(
-        stderr,
-        "\rProcessing: Node({}k {:.1f}k/s) Way({}k {:.2f}k/s)"
-        " Relation({} {:.1f}/s)",
-        m_node.count_k(), count_per_second(m_node.count_k(), nodes_time(now)),
-        m_way.count_k(), count_per_second(m_way.count_k(), ways_time(now)),
-        m_rel.count, count_per_second(m_rel.count, rels_time(now)));
+    print_status(now);
 }
 
 parse_osmium_t::parse_osmium_t(boost::optional<std::string> const &bbox,

--- a/src/parse-osmium.hpp
+++ b/src/parse-osmium.hpp
@@ -60,26 +60,27 @@ public:
 
     void update(parse_stats_t const &other);
     void print_summary() const;
-    void print_status();
+    void print_status(time_t now) const;
+    void possibly_print_status();
 
     void add_node(osmid_t id)
     {
         if (m_node.add(id)) {
-            print_status();
+            possibly_print_status();
         }
     }
 
     void add_way(osmid_t id)
     {
         if (m_way.add(id)) {
-            print_status();
+            possibly_print_status();
         }
     }
 
     void add_rel(osmid_t id)
     {
         if (m_rel.add(id)) {
-            print_status();
+            possibly_print_status();
         }
     }
 


### PR DESCRIPTION
This way we always get the correct relations count and more correct
count per second.

Fixes #1115