### PR TITLE
Add an example test for the geometries.lua file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ before_script:
   - proj | head -n1
 
 script:
-  - mkdir build && cd build
+  - mkdir build && pushd build
   - cmake .. -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_CXX_STANDARD=${CPPVERSION} -DWITH_LUAJIT=${LUAJIT_OPTION}
   - make -j2
   - echo "Running tests ... "
@@ -120,6 +120,7 @@ script:
         if [[ $? -ne "0" ]]; then exit 2; fi
       done
     fi
+  - popd && cd flex-config && lua test-geometries.lua
 
 after_failure:
   - # rerun make, but verbosely

--- a/flex-config/test-geometries.lua
+++ b/flex-config/test-geometries.lua
@@ -1,16 +1,21 @@
 -- This is an example of how to test the example geometries.lua file
 
--- Utility functions for testing
---- compare two tables.
--- @param t1 A table
--- @param t2 A table
--- @return true or false
-function equaltables (t1,t2)
-    for k, v in pairs(t1) do
-        if t2[k] ~= v then return false end
+--- Utility function to do a deep compare
+-- (C) Anonymous on snippets.luacode.org, MIT license
+function deepcompare(t1,t2)
+    local ty1 = type(t1)
+    local ty2 = type(t2)
+    if ty1 ~= ty2 then return false end
+    -- non-table types can be directly compared
+    if ty1 ~= 'table' and ty2 ~= 'table' then return t1 == t2 end
+
+    for k1,v1 in pairs(t1) do
+        local v2 = t2[k1]
+        if v2 == nil or not deepcompare(v1,v2) then return false end
     end
-    for k, v in pairs(t2) do
-        if t1[k] ~= v then return false end
+    for k2,v2 in pairs(t2) do
+        local v1 = t1[k2]
+        if v1 == nil or not deepcompare(v1,v2) then return false end
     end
     return true
 end
@@ -18,47 +23,86 @@ end
 -- Before testing we need to mock the supplied osm2pgsql object
 osm2pgsql = { srid = 3857}
 
-function osm2pgsql.define_node_table()
+-- Mock the table definition functions to store the definition locally so it can be checked later
+node_tables = {}
+way_tables = {}
+area_tables = {}
+relation_tables = {}
+
+table_contents = {pois = {}}
+
+function osm2pgsql.define_node_table(name, cols)
+    node_tables[name] = cols
+    table_contents[name] = {}
+    return {add_row = function(self, obj) table.insert(table_contents[name], obj) end}
 end
-function osm2pgsql.define_way_table()
+function osm2pgsql.define_way_table(name, cols)
+    way_tables[name] = cols
+    table_contents[name] = {}
+    return {add_row = function(self, obj) table.insert(table_contents[name], obj) end}
 end
-function osm2pgsql.define_area_table()
+function osm2pgsql.define_area_table(name, cols)
+    area_tables[name] = cols
+    table_contents[name] = {}
+    return {add_row = function(self, obj) table.insert(table_contents[name], obj) end}
 end
-function osm2pgsql.define_relation_table()
+function osm2pgsql.define_relation_table(name, cols)
+    relation_tables[name] = cols
+    table_contents[name] = {}
+    return {add_row = function(self, obj) table.insert(table_contents[name], obj) end}
 end
 
 require("geometries")
 
-assert(max_length == 100000)
+print("TESTING: definitions")
+assert(max_length == 100000, "max_length")
+
+assert(deepcompare(node_tables["pois"], {
+    { column = 'tags', type = 'hstore' },
+    { column = 'geom', type = 'point' }}), "poi table columns")
+
+assert(deepcompare(way_tables["ways"], {
+    { column = 'tags', type = 'hstore' },
+    { column = 'geom', type = 'linestring' }}), "ways table columns")
+
+assert(deepcompare(area_tables["polygons"], {
+    { column = 'tags', type = 'hstore' },
+    { column = 'geom', type = 'geometry' },
+    { column = 'area', type = 'area' }}), "polygons table columns")
+
+assert(deepcompare(relation_tables["boundaries"], {
+    { column = 'type', type = 'text' },
+    { column = 'tags', type = 'hstore' },
+    { column = 'geom', type = 'multilinestring' }}), "boundaries table columns")
 
 print("TESTING: clean_tags")
 tags = {}
 assert(clean_tags(tags) == true, "empty tags return")
-assert(equaltables(tags, {}), "empty tags modifying")
+assert(deepcompare(tags, {}), "empty tags modifying")
 
 tags = {odbl = "foo"}
 assert(clean_tags(tags) == true, "strips odbl return")
-assert(equaltables(tags, {}), "strips odbl modifying")
+assert(deepcompare(tags, {}), "strips odbl modifying")
 
 tags = {created_by = "foo"}
 assert(clean_tags(tags) == true, "strips created_by return")
-assert(equaltables(tags, {}), "strips created_by modifying")
+assert(deepcompare(tags, {}), "strips created_by modifying")
 
 tags = {source = "foo"}
 assert(clean_tags(tags) == true, "strips source return")
-assert(equaltables(tags, {}), "strips source modifying")
+assert(deepcompare(tags, {}), "strips source modifying")
 
 tags = {["source:ref"] = "foo"}
 assert(clean_tags(tags) == true, "strips source:ref return")
-assert(equaltables(tags, {}), "strips source:ref modifying")
+assert(deepcompare(tags, {}), "strips source:ref modifying")
 
 tags = {foo = "bar"}
 assert(clean_tags(tags) == false, "doesn't strip other tags return")
-assert(equaltables(tags, {foo = "bar"}), "doesn't strip other tags modifying")
+assert(deepcompare(tags, {foo = "bar"}), "doesn't strip other tags modifying")
 
 tags = {foo = "bar", odbl = "baz"}
 assert(clean_tags(tags) == false, "mixed tags return")
-assert(equaltables(tags, {foo = "bar"}), "mixed tags modifying")
+assert(deepcompare(tags, {foo = "bar"}), "mixed tags modifying")
 
 print("TESTING: has_area_tags")
 assert(not has_area_tags({}), "no tags")
@@ -71,3 +115,14 @@ assert(has_area_tags({foo = "bar", area = "yes"}), "linear tag with explicit are
 
 assert(has_area_tags({landuse = "bar"}), "area tag")
 assert(not has_area_tags({landuse = "bar", area = "no"}), "area tag with explicit area")
+
+print("TESTING: process_node")
+osm2pgsql.process_node({tags = {}})
+-- No objects added
+assert(deepcompare(table_contents["pois"], {}), "Untagged node pois")
+
+osm2pgsql.process_node({tags = {foo = "bar"}})
+assert(deepcompare(table_contents.pois, {{tags = {foo = "bar"}}}), "Tagged node pois")
+
+osm2pgsql.process_node({tags = {baz = "qux", odbl = "yes"}})
+assert(deepcompare(table_contents.pois, {{tags = {foo = "bar"}}, {tags = {baz = "qux"}}}), "2nd tagged node poi")

--- a/flex-config/test-geometries.lua
+++ b/flex-config/test-geometries.lua
@@ -1,0 +1,73 @@
+-- This is an example of how to test the example geometries.lua file
+
+-- Utility functions for testing
+--- compare two tables.
+-- @param t1 A table
+-- @param t2 A table
+-- @return true or false
+function equaltables (t1,t2)
+    for k, v in pairs(t1) do
+        if t2[k] ~= v then return false end
+    end
+    for k, v in pairs(t2) do
+        if t1[k] ~= v then return false end
+    end
+    return true
+end
+
+-- Before testing we need to mock the supplied osm2pgsql object
+osm2pgsql = { srid = 3857}
+
+function osm2pgsql.define_node_table()
+end
+function osm2pgsql.define_way_table()
+end
+function osm2pgsql.define_area_table()
+end
+function osm2pgsql.define_relation_table()
+end
+
+require("geometries")
+
+assert(max_length == 100000)
+
+print("TESTING: clean_tags")
+tags = {}
+assert(clean_tags(tags) == true, "empty tags return")
+assert(equaltables(tags, {}), "empty tags modifying")
+
+tags = {odbl = "foo"}
+assert(clean_tags(tags) == true, "strips odbl return")
+assert(equaltables(tags, {}), "strips odbl modifying")
+
+tags = {created_by = "foo"}
+assert(clean_tags(tags) == true, "strips created_by return")
+assert(equaltables(tags, {}), "strips created_by modifying")
+
+tags = {source = "foo"}
+assert(clean_tags(tags) == true, "strips source return")
+assert(equaltables(tags, {}), "strips source modifying")
+
+tags = {["source:ref"] = "foo"}
+assert(clean_tags(tags) == true, "strips source:ref return")
+assert(equaltables(tags, {}), "strips source:ref modifying")
+
+tags = {foo = "bar"}
+assert(clean_tags(tags) == false, "doesn't strip other tags return")
+assert(equaltables(tags, {foo = "bar"}), "doesn't strip other tags modifying")
+
+tags = {foo = "bar", odbl = "baz"}
+assert(clean_tags(tags) == false, "mixed tags return")
+assert(equaltables(tags, {foo = "bar"}), "mixed tags modifying")
+
+print("TESTING: has_area_tags")
+assert(not has_area_tags({}), "no tags")
+
+assert(has_area_tags({area = "yes"}), "explicit area")
+assert(not has_area_tags({area = "no"}), "explicit not area")
+
+assert(not has_area_tags({foo = "bar"}), "linear tag")
+assert(has_area_tags({foo = "bar", area = "yes"}), "linear tag with explicit area")
+
+assert(has_area_tags({landuse = "bar"}), "area tag")
+assert(not has_area_tags({landuse = "bar", area = "no"}), "area tag with explicit area")


### PR DESCRIPTION
Although not complete, this tests the helper functions. Tests for the calls into osm2pgsql still need to be added.

I'm not sure at this point on how to test `osm2pgsql.process_node` or the `osm2pgsql.define_node_table` type calls.