### PR TITLE
Tests for middle around id-tracker

### DIFF
--- a/src/id-tracker.cpp
+++ b/src/id-tracker.cpp
@@ -185,6 +185,7 @@ osmid_t id_tracker::pop_mark()
 }
 
 size_t id_tracker::size() const { return impl->count; }
+bool id_tracker::empty() const { return impl->count == 0; }
 
 osmid_t id_tracker::last_returned() const { return impl->old_id; }
 

--- a/src/id-tracker.hpp
+++ b/src/id-tracker.hpp
@@ -37,6 +37,7 @@ struct id_tracker
      */
     osmid_t pop_mark();
     size_t size() const;
+    bool empty() const;
     osmid_t last_returned() const;
 
     static bool is_valid(osmid_t);

--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -804,7 +804,8 @@ middle_pgsql_t::get_query_instance()
     return std::shared_ptr<middle_query_t>(mid.release());
 }
 
-size_t middle_pgsql_t::pending_count() const
+bool middle_pgsql_t::has_pending() const
 {
-    return m_ways_pending_tracker->size() + m_rels_pending_tracker->size();
+    return (m_ways_pending_tracker->size() > 0) ||
+           (m_rels_pending_tracker->size() > 0);
 }

--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -806,6 +806,5 @@ middle_pgsql_t::get_query_instance()
 
 bool middle_pgsql_t::has_pending() const
 {
-    return (m_ways_pending_tracker->size() > 0) ||
-           (m_rels_pending_tracker->size() > 0);
+    return !m_ways_pending_tracker->empty() || !m_rels_pending_tracker->empty();
 }

--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -83,7 +83,7 @@ struct middle_pgsql_t : public slim_middle_t
     void iterate_ways(middle_t::pending_processor &pf) override;
     void iterate_relations(pending_processor &pf) override;
 
-    size_t pending_count() const override;
+    bool has_pending() const override;
 
     class table_desc
     {

--- a/src/middle-ram.cpp
+++ b/src/middle-ram.cpp
@@ -76,8 +76,6 @@ void middle_ram_t::iterate_relations(pending_processor &pf)
     pf.process_relations();
 }
 
-size_t middle_ram_t::pending_count() const { return 0; }
-
 void middle_ram_t::iterate_ways(middle_t::pending_processor &pf)
 {
     //let the outputs enqueue everything they have the non slim middle

--- a/src/middle-ram.hpp
+++ b/src/middle-ram.hpp
@@ -118,7 +118,7 @@ struct middle_ram_t : public middle_t, public middle_query_t
     void iterate_ways(middle_t::pending_processor &pf) override;
     void iterate_relations(pending_processor &pf) override;
 
-    size_t pending_count() const override;
+    bool has_pending() const override { return false; }
 
     std::shared_ptr<middle_query_t> get_query_instance() override;
 

--- a/src/middle.hpp
+++ b/src/middle.hpp
@@ -133,7 +133,7 @@ struct middle_t
     virtual void iterate_ways(pending_processor &pf) = 0;
     virtual void iterate_relations(pending_processor &pf) = 0;
 
-    virtual size_t pending_count() const = 0;
+    virtual bool has_pending() const = 0;
 
     virtual std::shared_ptr<middle_query_t> get_query_instance() = 0;
 };

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -403,7 +403,7 @@ private:
  */
 bool osmdata_t::has_pending() const noexcept
 {
-    if (m_mid->pending_count() > 0) {
+    if (m_mid->has_pending()) {
         return true;
     }
 

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -409,7 +409,7 @@ bool osmdata_t::has_pending() const noexcept
 
     return std::any_of(m_outs.cbegin(), m_outs.cend(),
                        [](std::shared_ptr<output_t> const &out) {
-                           return out->pending_count() > 0;
+                           return out->has_pending();
                        });
 }
 

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1412,15 +1412,15 @@ void output_flex_t::init_lua(std::string const &filename)
     lua_remove(lua_state(), 1); // global "osm2pgsql"
 }
 
-std::size_t output_flex_t::pending_count() const
+bool output_flex_t::has_pending() const
 {
-    return m_ways_pending_tracker.size() + m_rels_pending_tracker.size();
+    return !m_ways_pending_tracker.empty() || !m_rels_pending_tracker.empty();
 }
 
 void output_flex_t::stage2_proc()
 {
-    bool const has_marked_ways = m_stage2_ways_tracker->size() > 0;
-    bool const has_marked_rels = m_stage2_rels_tracker->size() > 0;
+    bool const has_marked_ways = !m_stage2_ways_tracker->empty();
+    bool const has_marked_rels = !m_stage2_rels_tracker->empty();
 
     if (!has_marked_ways && !has_marked_rels) {
         fmt::print(stderr, "Skipping stage 2 (no marked objects).\n");

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -81,7 +81,7 @@ public:
     void way_delete(osmid_t id) override;
     void relation_delete(osmid_t id) override;
 
-    std::size_t pending_count() const override;
+    bool has_pending() const override;
 
     void merge_pending_relations(output_t *other) override;
     void merge_expire_trees(output_t *other) override;

--- a/src/output-multi.cpp
+++ b/src/output-multi.cpp
@@ -70,9 +70,9 @@ void output_multi_t::start()
                    m_options.tblsmain_data);
 }
 
-size_t output_multi_t::pending_count() const
+bool output_multi_t::has_pending() const
 {
-    return ways_pending_tracker.size() + rels_pending_tracker.size();
+    return !ways_pending_tracker.empty() || !rels_pending_tracker.empty();
 }
 
 void output_multi_t::enqueue_ways(pending_queue_t &job_queue, osmid_t id,

--- a/src/output-multi.hpp
+++ b/src/output-multi.hpp
@@ -66,7 +66,7 @@ public:
     void way_delete(osmid_t id) override;
     void relation_delete(osmid_t id) override;
 
-    size_t pending_count() const override;
+    bool has_pending() const override;
 
     void merge_pending_relations(output_t *other) override;
     void merge_expire_trees(output_t *other) override;

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -510,9 +510,9 @@ output_pgsql_t::output_pgsql_t(
 
 output_pgsql_t::~output_pgsql_t() = default;
 
-size_t output_pgsql_t::pending_count() const
+bool output_pgsql_t::has_pending() const
 {
-    return ways_pending_tracker.size() + rels_pending_tracker.size();
+    return !ways_pending_tracker.empty() || !rels_pending_tracker.empty();
 }
 
 void output_pgsql_t::merge_pending_relations(output_t *other)

--- a/src/output-pgsql.hpp
+++ b/src/output-pgsql.hpp
@@ -66,7 +66,7 @@ public:
     void way_delete(osmid_t id) override;
     void relation_delete(osmid_t id) override;
 
-    size_t pending_count() const override;
+    bool has_pending() const override;
 
     void merge_pending_relations(output_t *other) override;
     void merge_expire_trees(output_t *other) override;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -197,7 +197,7 @@ output_t::output_t(std::shared_ptr<middle_query_t> const &mid,
 
 output_t::~output_t() = default;
 
-size_t output_t::pending_count() const { return 0; }
+bool output_t::has_pending() const { return false; }
 
 options_t const *output_t::get_options() const { return &m_options; }
 

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -73,7 +73,7 @@ public:
     virtual void way_delete(osmid_t id) = 0;
     virtual void relation_delete(osmid_t id) = 0;
 
-    virtual size_t pending_count() const;
+    virtual bool has_pending() const;
 
     const options_t *get_options() const;
 

--- a/tests/test-middle.cpp
+++ b/tests/test-middle.cpp
@@ -693,8 +693,8 @@ TEMPLATE_TEST_CASE("middle: add way with attributes", "", options_slim_default,
 {
     options_t options = TestType::options(db);
 
-    SECTION("with attributes") { options.extra_attributes = true; }
-    SECTION("no attributes") { options.extra_attributes = false; }
+    SECTION("With attributes") { options.extra_attributes = true; }
+    SECTION("No attributes") { options.extra_attributes = false; }
 
     testing::cleanup::file_t flatnode_cleaner{
         options.flat_node_file.get_value_or("")};
@@ -946,8 +946,8 @@ TEMPLATE_TEST_CASE("middle: add relation with attributes", "",
 {
     options_t options = TestType::options(db);
 
-    SECTION("with attributes") { options.extra_attributes = true; }
-    SECTION("no attributes") { options.extra_attributes = false; }
+    SECTION("With attributes") { options.extra_attributes = true; }
+    SECTION("No attributes") { options.extra_attributes = false; }
 
     testing::cleanup::file_t flatnode_cleaner{
         options.flat_node_file.get_value_or("")};
@@ -1014,9 +1014,9 @@ public:
 
     void enqueue_ways(osmid_t id) override { m_way_ids.push_back(id); }
 
-    void process_ways() override{};
-    void enqueue_relations(osmid_t) override{};
-    void process_relations() override{};
+    void process_ways() override {}
+    void enqueue_relations(osmid_t) override {}
+    void process_relations() override {}
 
     void check_way_ids_equal_to(std::initializer_list<osmid_t> list) noexcept
     {
@@ -1089,7 +1089,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
     // From now on use append mode to not destroy the data we just added.
     options.append = true;
 
-    SECTION("single way affected")
+    SECTION("Single way affected")
     {
         auto mid = std::make_shared<middle_pgsql_t>(&options);
         mid->start();
@@ -1110,7 +1110,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
         mid->commit();
     }
 
-    SECTION("two ways affected")
+    SECTION("Two ways affected")
     {
         {
             auto mid = std::make_shared<middle_pgsql_t>(&options);
@@ -1145,7 +1145,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
         }
     }
 
-    SECTION("change way so the changing node isn't in it any more")
+    SECTION("Change way so the changing node isn't in it any more")
     {
         {
             auto mid = std::make_shared<middle_pgsql_t>(&options);

--- a/tests/test-middle.cpp
+++ b/tests/test-middle.cpp
@@ -516,13 +516,11 @@ static void check_way_nodes(std::shared_ptr<middle_pgsql_t> const &mid,
     REQUIRE(mid_q->nodes_get_list(&way.nodes()) == way.nodes().size());
     REQUIRE(way.nodes().size() == nodes.size());
 
-    auto it = way.nodes().cbegin();
-    for (auto const *nptr : nodes) {
-        REQUIRE(nptr->id() == it->ref());
-        REQUIRE(nptr->location() == it->location());
-        ++it;
-    }
-    REQUIRE(it == way.nodes().cend());
+    REQUIRE(std::equal(way.nodes().cbegin(), way.nodes().cend(), nodes.cbegin(),
+                       [](osmium::NodeRef const &nr, osmium::Node const *node) {
+                           return nr.ref() == node->id() &&
+                                  nr.location() == node->location();
+                       }));
 }
 
 /// Return true if the way with the specified id is not in the mid.

--- a/tests/test-parse-osmium.cpp
+++ b/tests/test-parse-osmium.cpp
@@ -28,7 +28,7 @@ struct counting_slim_middle_t : public slim_middle_t
 
     void iterate_ways(pending_processor &) override {}
     void iterate_relations(pending_processor &) override {}
-    size_t pending_count() const override { return 0; }
+    bool has_pending() const override { return false; }
 
     std::shared_ptr<middle_query_t> get_query_instance() override
     {


### PR DESCRIPTION
Also refactors `pending_count()` into `has_pending()` because the count is never used.