### PR TITLE
Quick fix for problem with updating data in flex backend

### DIFF
--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -38,9 +38,11 @@ public:
                   bool has_process_relation = false,
                   std::shared_ptr<std::vector<flex_table_t>> tables =
                       std::make_shared<std::vector<flex_table_t>>(),
-                  std::shared_ptr<id_tracker> ways_tracker =
+                  std::shared_ptr<id_tracker> ways_tracker_1c =
                       std::make_shared<id_tracker>(),
-                  std::shared_ptr<id_tracker> rels_tracker =
+                  std::shared_ptr<id_tracker> ways_tracker_2 =
+                      std::make_shared<id_tracker>(),
+                  std::shared_ptr<id_tracker> rels_tracker_2 =
                       std::make_shared<id_tracker>());
 
     output_flex_t(output_flex_t const &) = delete;
@@ -59,6 +61,7 @@ public:
     void stop(osmium::thread::Pool *pool) override;
     void commit() override;
 
+    void stage1c_proc(slim_middle_t *) override;
     void stage2_proc() override;
 
     void enqueue_ways(pending_queue_t &job_queue, osmid_t id,
@@ -82,6 +85,7 @@ public:
     void relation_delete(osmid_t id) override;
 
     bool has_pending() const override;
+    bool has_stage1c_pending() const override;
 
     void merge_pending_relations(output_t *other) override;
     void merge_expire_trees(output_t *other) override;
@@ -143,6 +147,7 @@ private:
     id_tracker m_rels_pending_tracker;
     std::shared_ptr<id_tracker> m_ways_done_tracker;
 
+    std::shared_ptr<id_tracker> m_stage1c_ways_tracker;
     std::shared_ptr<id_tracker> m_stage2_ways_tracker;
     std::shared_ptr<id_tracker> m_stage2_rels_tracker;
 
@@ -162,7 +167,14 @@ private:
 
     std::size_t m_num_way_nodes = std::numeric_limits<std::size_t>::max();
 
-    bool m_in_stage2 = false;
+    enum class stage : int8_t {
+        stage1a,
+        stage1b,
+        stage1c,
+        stage2,
+    };
+
+    stage m_stage = stage::stage1a;
     bool m_has_process_node = false;
     bool m_has_process_way = false;
     bool m_has_process_relation = false;

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -19,6 +19,7 @@
 struct expire_tiles;
 struct id_tracker;
 struct middle_query_t;
+struct slim_middle_t;
 class db_copy_thread_t;
 
 struct pending_job_t
@@ -51,6 +52,7 @@ public:
     virtual void stop(osmium::thread::Pool *pool) = 0;
     virtual void commit() = 0;
 
+    virtual void stage1c_proc(slim_middle_t *) {}
     virtual void stage2_proc() {}
 
     virtual void enqueue_ways(pending_queue_t &job_queue, osmid_t id,
@@ -74,6 +76,7 @@ public:
     virtual void relation_delete(osmid_t id) = 0;
 
     virtual bool has_pending() const;
+    virtual bool has_stage1c_pending() const { return false; }
 
     const options_t *get_options() const;
 


### PR DESCRIPTION
Under some circumstances when using the two-stage processing of the flex
backend data was not updated correctly. This happens when a way changes
that is in a relation and that relation has another way in common with
a different relation.

The solution for this is introducing a stage1c processing, which this
commit does in a really hacky way. To do this cleanly we need to
refactor a lot of the middle and id_tracker code.

Processing happens in these stages:

* stage 1a: Read input file and process all objects in it.
* stage 1b: Process dependent objects of objects from 1a (ie changed
  nodes trigger changes in ways with those nodes, changes in all
  objects potentially trigger changes in relations).
* stage 1c: Process dependent objects (currently only relations) of
  objects marked during stage 1a/1b (this one is new). No more marking
  is done in stage 1c.
* stage 2: Process objects marked in stage 1a or 1b.