### PR TITLE
Provide a stack trace on a lua error with flex backend

### DIFF
--- a/src/lua-utils.hpp
+++ b/src/lua-utils.hpp
@@ -49,4 +49,6 @@ char const *luaX_get_table_string(lua_State *lua_state, char const *key,
 bool luaX_get_table_bool(lua_State *lua_state, char const *key, int table_index,
                          char const *error_msg, bool default_value);
 
+int luaX_pcall(lua_State *lua_state, int narg, int nres);
+
 #endif // OSM2PGSQL_FLEX_LUA_HPP

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -100,7 +100,6 @@ private:
     void init_clone();
 
     void call_process_function(int index, osmium::OSMObject const &object);
-    int do_pcall(int narg, int nres);
 
     void init_lua(std::string const &filename);
 

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -100,6 +100,7 @@ private:
     void init_clone();
 
     void call_process_function(int index, osmium::OSMObject const &object);
+    int do_pcall(int narg, int nres);
 
     void init_lua(std::string const &filename);
 


### PR DESCRIPTION
Closes #1136

Almost exactly the same code that is in use in the Lua interpreter, except for the signal handling: https://github.com/lua/lua/blob/master/lua.c#L109-L142

