### PR TITLE
Refactor dependency tracking step1

### DIFF
--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -445,8 +445,6 @@ void middle_pgsql_t::iterate_ways(middle_t::pending_processor &pf)
     while (id_tracker::is_valid(id = m_ways_pending_tracker->pop_mark())) {
         pf.enqueue_ways(id);
     }
-    // in case we had higher ones than the middle
-    pf.enqueue_ways(id_tracker::max());
 
     //let the threads work on them
     pf.process_ways();

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -244,7 +244,10 @@ struct pending_threaded_processor : public middle_t::pending_processor
     void enqueue_ways(osmid_t id) override
     {
         for (size_t i = 0; i < outs.size(); ++i) {
-            outs[i]->enqueue_ways(queue, id, i, ids_queued);
+            if (outs[i]->need_forward_dependencies()) {
+                queue.emplace(id, i);
+                ++ids_queued;
+            }
         }
     }
 

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1002,13 +1002,6 @@ void output_flex_t::call_process_function(int index,
     }
 }
 
-void output_flex_t::enqueue_ways(pending_queue_t &job_queue, osmid_t id,
-                                 std::size_t output_id, std::size_t &added)
-{
-    job_queue.emplace(id, output_id);
-    ++added;
-}
-
 void output_flex_t::pending_way(osmid_t id, int exists)
 {
     if (!m_has_process_way) {

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1005,10 +1005,8 @@ void output_flex_t::call_process_function(int index,
 void output_flex_t::enqueue_ways(pending_queue_t &job_queue, osmid_t id,
                                  std::size_t output_id, std::size_t &added)
 {
-    if (id_tracker::is_valid(id)) {
-        job_queue.emplace(id, output_id);
-        ++added;
-    }
+    job_queue.emplace(id, output_id);
+    ++added;
 }
 
 void output_flex_t::pending_way(osmid_t id, int exists)

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -61,8 +61,6 @@ public:
 
     void stage2_proc() override;
 
-    void enqueue_ways(pending_queue_t &job_queue, osmid_t id,
-                      std::size_t output_id, std::size_t &added) override;
     void pending_way(osmid_t id, int exists) override;
 
     void enqueue_relations(pending_queue_t &job_queue, osmid_t id,

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -139,9 +139,7 @@ private:
     std::shared_ptr<std::vector<flex_table_t>> m_tables;
     std::vector<table_connection_t> m_table_connections;
 
-    id_tracker m_ways_pending_tracker;
     id_tracker m_rels_pending_tracker;
-    std::shared_ptr<id_tracker> m_ways_done_tracker;
 
     std::shared_ptr<id_tracker> m_stage2_ways_tracker;
     std::shared_ptr<id_tracker> m_stage2_rels_tracker;

--- a/src/output-gazetteer.hpp
+++ b/src/output-gazetteer.hpp
@@ -46,7 +46,8 @@ public:
     void stop(osmium::thread::Pool *) override {}
     void commit() override;
 
-    void enqueue_ways(pending_queue_t &, osmid_t, size_t, size_t &) override {}
+    bool need_forward_dependencies() const noexcept override { return false; }
+
     void pending_way(osmid_t, int) override {}
 
     void enqueue_relations(pending_queue_t &, osmid_t, size_t,

--- a/src/output-multi.cpp
+++ b/src/output-multi.cpp
@@ -70,13 +70,6 @@ bool output_multi_t::has_pending() const
     return !rels_pending_tracker.empty();
 }
 
-void output_multi_t::enqueue_ways(pending_queue_t &job_queue, osmid_t id,
-                                  size_t output_id, size_t &added)
-{
-    job_queue.emplace(id, output_id);
-    ++added;
-}
-
 void output_multi_t::pending_way(osmid_t id, int exists)
 {
     // Try to fetch the way from the DB

--- a/src/output-multi.cpp
+++ b/src/output-multi.cpp
@@ -73,10 +73,8 @@ bool output_multi_t::has_pending() const
 void output_multi_t::enqueue_ways(pending_queue_t &job_queue, osmid_t id,
                                   size_t output_id, size_t &added)
 {
-    if (id_tracker::is_valid(id)) {
-        job_queue.emplace(id, output_id);
-        ++added;
-    }
+    job_queue.emplace(id, output_id);
+    ++added;
 }
 
 void output_multi_t::pending_way(osmid_t id, int exists)

--- a/src/output-multi.hpp
+++ b/src/output-multi.hpp
@@ -88,7 +88,6 @@ protected:
     osmium::item_type const m_osm_type;
     std::unique_ptr<table_t> m_table;
     id_tracker ways_pending_tracker, rels_pending_tracker;
-    std::shared_ptr<id_tracker> ways_done_tracker;
     expire_tiles m_expire;
     relation_helper m_relation_helper;
     osmium::memory::Buffer buffer;

--- a/src/output-multi.hpp
+++ b/src/output-multi.hpp
@@ -46,8 +46,6 @@ public:
     void stop(osmium::thread::Pool *pool) override;
     void commit() override;
 
-    void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id,
-                      size_t &added) override;
     void pending_way(osmid_t id, int exists) override;
 
     void enqueue_relations(pending_queue_t &job_queue, osmid_t id,

--- a/src/output-multi.hpp
+++ b/src/output-multi.hpp
@@ -87,7 +87,7 @@ protected:
     std::shared_ptr<reprojection> m_proj;
     osmium::item_type const m_osm_type;
     std::unique_ptr<table_t> m_table;
-    id_tracker ways_pending_tracker, rels_pending_tracker;
+    id_tracker rels_pending_tracker;
     expire_tiles m_expire;
     relation_helper m_relation_helper;
     osmium::memory::Buffer buffer;

--- a/src/output-null.hpp
+++ b/src/output-null.hpp
@@ -22,9 +22,7 @@ public:
     void commit() override {}
     void cleanup() {}
 
-    void enqueue_ways(pending_queue_t & /*job_queue*/, osmid_t /*id*/, size_t /*output_id*/,
-                      size_t & /*added*/) override
-    {}
+    bool need_forward_dependencies() const noexcept override { return false; }
 
     void pending_way(osmid_t /*id*/, int /*exists*/) override {}
 

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -69,10 +69,8 @@ void output_pgsql_t::pgsql_out_way(osmium::Way const &way, taglist_t *tags,
 void output_pgsql_t::enqueue_ways(pending_queue_t &job_queue, osmid_t id,
                                   size_t output_id, size_t &added)
 {
-    if (id_tracker::is_valid(id)) {
-        job_queue.emplace(id, output_id);
-        ++added;
-    }
+    job_queue.emplace(id, output_id);
+    ++added;
 }
 
 void output_pgsql_t::pending_way(osmid_t id, int exists)

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -69,43 +69,9 @@ void output_pgsql_t::pgsql_out_way(osmium::Way const &way, taglist_t *tags,
 void output_pgsql_t::enqueue_ways(pending_queue_t &job_queue, osmid_t id,
                                   size_t output_id, size_t &added)
 {
-    osmid_t const prev = ways_pending_tracker.last_returned();
-    if (id_tracker::is_valid(prev) && prev >= id) {
-        if (prev > id) {
-            job_queue.push(pending_job_t(id, output_id));
-        }
-        // already done the job
-        return;
-    }
-
-    //make sure we get the one passed in
-    if (!ways_done_tracker->is_marked(id) && id_tracker::is_valid(id)) {
-        job_queue.push(pending_job_t(id, output_id));
+    if (id_tracker::is_valid(id)) {
+        job_queue.emplace(id, output_id);
         ++added;
-    }
-
-    //grab the first one or bail if its not valid
-    osmid_t popped = ways_pending_tracker.pop_mark();
-    if (!id_tracker::is_valid(popped)) {
-        return;
-    }
-
-    //get all the ones up to the id that was passed in
-    while (popped < id) {
-        if (!ways_done_tracker->is_marked(popped)) {
-            job_queue.push(pending_job_t(popped, output_id));
-            ++added;
-        }
-        popped = ways_pending_tracker.pop_mark();
-    }
-
-    //make sure to get this one as well and move to the next
-    if (popped > id) {
-        if (!ways_done_tracker->is_marked(popped) &&
-            id_tracker::is_valid(popped)) {
-            job_queue.push(pending_job_t(popped, output_id));
-            ++added;
-        }
     }
 }
 
@@ -436,7 +402,6 @@ output_pgsql_t::output_pgsql_t(
     std::shared_ptr<db_copy_thread_t> const &copy_thread)
 : output_t(mid, o), m_builder(o.projection),
   expire(o.expire_tiles_zoom, o.expire_tiles_max_bbox, o.projection),
-  ways_done_tracker(new id_tracker{}),
   buffer(32768, osmium::memory::Buffer::auto_grow::yes),
   rels_buffer(1024, osmium::memory::Buffer::auto_grow::yes)
 {
@@ -495,9 +460,6 @@ output_pgsql_t::output_pgsql_t(
   m_builder(m_options.projection),
   expire(m_options.expire_tiles_zoom, m_options.expire_tiles_max_bbox,
          m_options.projection),
-  //NOTE: we need to know which ways were used by relations so each thread
-  //must have a copy of the original marked done ways, its read only so its ok
-  ways_done_tracker(other->ways_done_tracker),
   buffer(1024, osmium::memory::Buffer::auto_grow::yes),
   rels_buffer(1024, osmium::memory::Buffer::auto_grow::yes)
 {
@@ -512,7 +474,7 @@ output_pgsql_t::~output_pgsql_t() = default;
 
 bool output_pgsql_t::has_pending() const
 {
-    return !ways_pending_tracker.empty() || !rels_pending_tracker.empty();
+    return !rels_pending_tracker.empty();
 }
 
 void output_pgsql_t::merge_pending_relations(output_t *other)

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -66,13 +66,6 @@ void output_pgsql_t::pgsql_out_way(osmium::Way const &way, taglist_t *tags,
     }
 }
 
-void output_pgsql_t::enqueue_ways(pending_queue_t &job_queue, osmid_t id,
-                                  size_t output_id, size_t &added)
-{
-    job_queue.emplace(id, output_id);
-    ++added;
-}
-
 void output_pgsql_t::pending_way(osmid_t id, int exists)
 {
     // Try to fetch the way from the DB

--- a/src/output-pgsql.hpp
+++ b/src/output-pgsql.hpp
@@ -88,8 +88,7 @@ protected:
     geom::osmium_builder_t m_builder;
     expire_tiles expire;
 
-    id_tracker ways_pending_tracker, rels_pending_tracker;
-    std::shared_ptr<id_tracker> ways_done_tracker;
+    id_tracker rels_pending_tracker;
     osmium::memory::Buffer buffer;
     osmium::memory::Buffer rels_buffer;
 };

--- a/src/output-pgsql.hpp
+++ b/src/output-pgsql.hpp
@@ -46,8 +46,6 @@ public:
     void stop(osmium::thread::Pool *pool) override;
     void commit() override;
 
-    void enqueue_ways(pending_queue_t &job_queue, osmid_t id, size_t output_id,
-                      size_t &added) override;
     void pending_way(osmid_t id, int exists) override;
 
     void enqueue_relations(pending_queue_t &job_queue, osmid_t id,

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -53,8 +53,8 @@ public:
 
     virtual void stage2_proc() {}
 
-    virtual void enqueue_ways(pending_queue_t &job_queue, osmid_t id,
-                              size_t output_id, size_t &added) = 0;
+    virtual bool need_forward_dependencies() const noexcept { return true; }
+
     virtual void pending_way(osmid_t id, int exists) = 0;
 
     virtual void enqueue_relations(pending_queue_t &job_queue, osmid_t id,

--- a/tests/test-middle.cpp
+++ b/tests/test-middle.cpp
@@ -1018,12 +1018,6 @@ public:
 
     void check_way_ids_equal_to(std::initializer_list<osmid_t> list) noexcept
     {
-        REQUIRE(!m_way_ids.empty());
-
-        // The last tracked id is always the invalid id, which we ignore
-        REQUIRE_FALSE(id_tracker::is_valid(m_way_ids.back()));
-        m_way_ids.pop_back();
-
         REQUIRE(m_way_ids.size() == list.size());
         REQUIRE(std::equal(m_way_ids.cbegin(), m_way_ids.cend(), list.begin()));
     }


### PR DESCRIPTION
Refactoring of the dependency tracking code split between middle and outputs. This basically just removes some code that wasn't used anyway in several steps in each commit. Further work will follow.