### PR TITLE
Move constructor/assignment of db_copy_thread_t is deleted anyway

### DIFF
--- a/src/db-copy.hpp
+++ b/src/db-copy.hpp
@@ -230,8 +230,8 @@ public:
     db_copy_thread_t(db_copy_thread_t const &) = delete;
     db_copy_thread_t &operator=(db_copy_thread_t const &) = delete;
 
-    db_copy_thread_t(db_copy_thread_t &&) = default;
-    db_copy_thread_t &operator=(db_copy_thread_t &&) = default;
+    db_copy_thread_t(db_copy_thread_t &&) = delete;
+    db_copy_thread_t &operator=(db_copy_thread_t &&) = delete;
 
     ~db_copy_thread_t();
 


### PR DESCRIPTION
Because of the std::mutex inside the class. This makes this clear.