### PR TITLE
New dependency manager

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 set(osm2pgsql_lib_SOURCES
+  dependency-manager.cpp
   db-copy.cpp
   expire-tiles.cpp
   gazetteer-style.cpp
@@ -31,6 +32,7 @@ set(osm2pgsql_lib_SOURCES
   tagtransform.cpp
   util.cpp
   wildcmp.cpp
+  dependency-manager.hpp
   db-copy.hpp
   expire-tiles.hpp
   gazetteer-style.hpp

--- a/src/dependency-manager.cpp
+++ b/src/dependency-manager.cpp
@@ -1,0 +1,60 @@
+
+#include "dependency-manager.hpp"
+
+void full_dependency_manager_t::node_changed(osmid_t id) {
+    for (auto const way_id : m_object_store->get_ways_by_node(id)) {
+        way_changed(way_id);
+        m_ways_pending_tracker.mark(way_id);
+    }
+
+    for (auto const rel_id : m_object_store->get_rels_by_node(id)) {
+        m_rels_pending_tracker.mark(rel_id);
+    }
+}
+
+void full_dependency_manager_t::way_changed(osmid_t id) {
+    if (m_ways_pending_tracker.is_marked(id)) {
+        return;
+    }
+
+    for (auto const rel_id : m_object_store->get_rels_by_way(id)) {
+        m_rels_pending_tracker.mark(rel_id);
+    }
+}
+
+void full_dependency_manager_t::relation_changed(osmid_t id) {
+    if (m_rels_pending_tracker.is_marked(id)) {
+        return;
+    }
+
+    for (auto const rel_id : m_object_store->get_rels_by_rel(id)) {
+        m_rels_pending_tracker.mark(rel_id);
+    }
+}
+
+void full_dependency_manager_t::relation_deleted(osmid_t id) {
+    for (auto const rel_id : m_object_store->get_ways_by_rel(id)) {
+        m_ways_pending_tracker.mark(rel_id);
+    }
+}
+
+bool full_dependency_manager_t::has_pending() const noexcept
+{
+    return !m_ways_pending_tracker.empty() || !m_rels_pending_tracker.empty();
+}
+
+void full_dependency_manager_t::process_pending(middle_t::pending_processor &pf)
+{
+    osmid_t id;
+    while (id_tracker::is_valid(id = m_ways_pending_tracker.pop_mark())) {
+        pf.enqueue_ways(id);
+    }
+
+    pf.process_ways();
+
+    while (id_tracker::is_valid(id = m_rels_pending_tracker.pop_mark())) {
+        pf.enqueue_relations(id);
+    }
+
+    pf.process_relations();
+}

--- a/src/dependency-manager.cpp
+++ b/src/dependency-manager.cpp
@@ -26,10 +26,6 @@ void full_dependency_manager_t::way_changed(osmid_t id)
 
 void full_dependency_manager_t::relation_changed(osmid_t id)
 {
-    if (m_rels_pending_tracker.is_marked(id)) {
-        return;
-    }
-
     for (auto const rel_id : m_object_store->get_rels_by_rel(id)) {
         m_rels_pending_tracker.mark(rel_id);
     }

--- a/src/dependency-manager.cpp
+++ b/src/dependency-manager.cpp
@@ -43,18 +43,18 @@ bool full_dependency_manager_t::has_pending() const noexcept
     return !m_ways_pending_tracker.empty() || !m_rels_pending_tracker.empty();
 }
 
-void full_dependency_manager_t::process_pending(middle_t::pending_processor &pf)
+void full_dependency_manager_t::process_pending(pending_processor &proc)
 {
     osmid_t id;
     while (id_tracker::is_valid(id = m_ways_pending_tracker.pop_mark())) {
-        pf.enqueue_ways(id);
+        proc.enqueue_way(id);
     }
 
-    pf.process_ways();
+    proc.process_ways();
 
     while (id_tracker::is_valid(id = m_rels_pending_tracker.pop_mark())) {
-        pf.enqueue_relations(id);
+        proc.enqueue_relation(id);
     }
 
-    pf.process_relations();
+    proc.process_relations();
 }

--- a/src/dependency-manager.cpp
+++ b/src/dependency-manager.cpp
@@ -1,7 +1,8 @@
 
 #include "dependency-manager.hpp"
 
-void full_dependency_manager_t::node_changed(osmid_t id) {
+void full_dependency_manager_t::node_changed(osmid_t id)
+{
     for (auto const way_id : m_object_store->get_ways_by_node(id)) {
         way_changed(way_id);
         m_ways_pending_tracker.mark(way_id);
@@ -12,7 +13,8 @@ void full_dependency_manager_t::node_changed(osmid_t id) {
     }
 }
 
-void full_dependency_manager_t::way_changed(osmid_t id) {
+void full_dependency_manager_t::way_changed(osmid_t id)
+{
     if (m_ways_pending_tracker.is_marked(id)) {
         return;
     }
@@ -22,7 +24,8 @@ void full_dependency_manager_t::way_changed(osmid_t id) {
     }
 }
 
-void full_dependency_manager_t::relation_changed(osmid_t id) {
+void full_dependency_manager_t::relation_changed(osmid_t id)
+{
     if (m_rels_pending_tracker.is_marked(id)) {
         return;
     }
@@ -32,7 +35,8 @@ void full_dependency_manager_t::relation_changed(osmid_t id) {
     }
 }
 
-void full_dependency_manager_t::relation_deleted(osmid_t id) {
+void full_dependency_manager_t::relation_deleted(osmid_t id)
+{
     for (auto const rel_id : m_object_store->get_ways_by_rel(id)) {
         m_ways_pending_tracker.mark(rel_id);
     }

--- a/src/dependency-manager.hpp
+++ b/src/dependency-manager.hpp
@@ -40,7 +40,7 @@ public:
      *
      * This has to be called *after* the object was stored in the object store.
      */
-    virtual void node_changed(osmid_t) {};
+    virtual void node_changed(osmid_t) {}
 
     /**
      * Mark a way as changed to trigger the propagation of this change to
@@ -48,7 +48,7 @@ public:
      *
      * This has to be called *after* the object was stored in the object store.
      */
-    virtual void way_changed(osmid_t) {};
+    virtual void way_changed(osmid_t) {}
 
     /**
      * Mark a relation as changed to trigger the propagation of this change to
@@ -56,13 +56,13 @@ public:
      *
      * This has to be called *after* the object was stored in the object store.
      */
-    virtual void relation_changed(osmid_t) {};
+    virtual void relation_changed(osmid_t) {}
 
     /**
      * Mark a relation as deleted to trigger the propagation of this change to
      * the way members.
      */
-    virtual void relation_deleted(osmid_t) {};
+    virtual void relation_deleted(osmid_t) {}
 
     /// Are there pending objects that need to be processed?
     virtual bool has_pending() const noexcept { return false; }
@@ -89,7 +89,6 @@ public:
 class full_dependency_manager_t : public dependency_manager_t
 {
 public:
-
     /**
      * Constructor.
      *
@@ -125,7 +124,8 @@ public:
      *        must be of type osmid_t.
      */
     template <typename TOutputIterator>
-    void get_pending_way_ids(TOutputIterator &&it) {
+    void get_pending_way_ids(TOutputIterator &&it)
+    {
         osmid_t id;
         while (id_tracker::is_valid(id = m_ways_pending_tracker.pop_mark())) {
             *it++ = id;
@@ -144,7 +144,8 @@ public:
      *        must be of type osmid_t.
      */
     template <typename TOutputIterator>
-    void get_pending_relation_ids(TOutputIterator &&it) {
+    void get_pending_relation_ids(TOutputIterator &&it)
+    {
         osmid_t id;
         while (id_tracker::is_valid(id = m_rels_pending_tracker.pop_mark())) {
             *it++ = id;
@@ -152,7 +153,7 @@ public:
     }
 
 private:
-    middle_t* m_object_store;
+    middle_t *m_object_store;
 
     id_tracker m_ways_pending_tracker;
     id_tracker m_rels_pending_tracker;

--- a/src/dependency-manager.hpp
+++ b/src/dependency-manager.hpp
@@ -102,6 +102,44 @@ public:
 
     void process_pending(middle_t::pending_processor &pf) override;
 
+    /**
+     * Get access to the pending way ids. This is for debugging only.
+     *
+     * Note that the list of pending way ids will be empty after calling
+     * this.
+     *
+     * \tparam TOutputIterator Some output iterator type, for instance
+     *         created with std::back_inserter(some vector).
+     * \param it output iterator to which all ids should be written. *it
+     *        must be of type osmid_t.
+     */
+    template <typename TOutputIterator>
+    void get_pending_way_ids(TOutputIterator &&it) {
+        osmid_t id;
+        while (id_tracker::is_valid(id = m_ways_pending_tracker.pop_mark())) {
+            *it++ = id;
+        }
+    }
+
+    /**
+     * Get access to the pending relation ids. This is for debugging only.
+     *
+     * Note that the list of pending relation ids will be empty after calling
+     * this.
+     *
+     * \tparam TOutputIterator Some output iterator type, for instance
+     *         created with std::back_inserter(some vector).
+     * \param it output iterator to which all ids should be written. *it
+     *        must be of type osmid_t.
+     */
+    template <typename TOutputIterator>
+    void get_pending_relation_ids(TOutputIterator &&it) {
+        osmid_t id;
+        while (id_tracker::is_valid(id = m_rels_pending_tracker.pop_mark())) {
+            *it++ = id;
+        }
+    }
+
 private:
     middle_t* m_object_store;
 

--- a/src/dependency-manager.hpp
+++ b/src/dependency-manager.hpp
@@ -1,0 +1,112 @@
+#ifndef OSM2PGSQL_DEPENDENCY_MANAGER_HPP
+#define OSM2PGSQL_DEPENDENCY_MANAGER_HPP
+
+#include "id-tracker.hpp"
+#include "middle.hpp"
+#include "osmtypes.hpp"
+
+#include <cassert>
+
+/**
+ * The job of the dependency manager is to keep track of the dependencies
+ * between OSM objects, that is nodes in ways and members of relations.
+ *
+ * Whenever an OSM object changes, this class is notified and can remember
+ * the ids for later use.
+ *
+ * This base class doesn't actually do the dependency management but is a
+ * dummy for cases where no dependency management is needed. See the
+ * full_dependency_manager_t class for the real dependency manager.
+ */
+class dependency_manager_t
+{
+public:
+    virtual ~dependency_manager_t() = default;
+
+    /**
+     * Mark a node as changed to trigger the propagation of this change to
+     * ways and relations.
+     *
+     * This has to be called *after* the object was stored in the object store.
+     */
+    virtual void node_changed(osmid_t) {};
+
+    /**
+     * Mark a way as changed to trigger the propagation of this change to
+     * relations.
+     *
+     * This has to be called *after* the object was stored in the object store.
+     */
+    virtual void way_changed(osmid_t) {};
+
+    /**
+     * Mark a relation as changed to trigger the propagation of this change to
+     * other relations.
+     *
+     * This has to be called *after* the object was stored in the object store.
+     */
+    virtual void relation_changed(osmid_t) {};
+
+    /**
+     * Mark a relation as deleted to trigger the propagation of this change to
+     * the way members.
+     */
+    virtual void relation_deleted(osmid_t) {};
+
+    /// Are there pending objects that need to be processed?
+    virtual bool has_pending() const noexcept { return false; }
+
+    /**
+     * Process all pending objects.
+     *
+     * \param pf Processor that we should feed the objects to and that
+     *        will handle the actual processing.
+     *
+     * \post !has_pending()
+     */
+    virtual void process_pending(middle_t::pending_processor &) {}
+};
+
+/**
+ * The job of the dependency manager is to keep track of the dependencies
+ * between OSM objects, that is nodes in ways and members of relations.
+ *
+ * Whenever an OSM object changes, this class is notified and remembers
+ * the ids for later use. Later on the class can be told to process the
+ * ids it has remembered.
+ */
+class full_dependency_manager_t : public dependency_manager_t
+{
+public:
+
+    /**
+     * Constructor.
+     *
+     * \param object_store Pointer to the middle that keeps the actual
+     *        database of objects and their relationsships.
+     *
+     * \pre object_store != nullptr
+     */
+    explicit full_dependency_manager_t(middle_t *object_store)
+    : m_object_store(object_store)
+    {
+        assert(object_store != nullptr);
+    }
+
+    void node_changed(osmid_t id) override;
+    void way_changed(osmid_t id) override;
+    void relation_changed(osmid_t id) override;
+    void relation_deleted(osmid_t id) override;
+
+    bool has_pending() const noexcept override;
+
+    void process_pending(middle_t::pending_processor &pf) override;
+
+private:
+    middle_t* m_object_store;
+
+    id_tracker m_ways_pending_tracker;
+    id_tracker m_rels_pending_tracker;
+};
+
+#endif // OSM2PGSQL_DEPENDENCY_MANAGER_HPP

--- a/src/dependency-manager.hpp
+++ b/src/dependency-manager.hpp
@@ -6,6 +6,7 @@
 #include "osmtypes.hpp"
 
 #include <cassert>
+#include <memory>
 
 struct pending_processor
 {
@@ -97,10 +98,10 @@ public:
      *
      * \pre object_store != nullptr
      */
-    explicit full_dependency_manager_t(middle_t *object_store)
-    : m_object_store(object_store)
+    explicit full_dependency_manager_t(std::shared_ptr<middle_t> object_store)
+    : m_object_store(std::move(object_store))
     {
-        assert(object_store != nullptr);
+        assert(m_object_store != nullptr);
     }
 
     void node_changed(osmid_t id) override;
@@ -153,7 +154,7 @@ public:
     }
 
 private:
-    middle_t *m_object_store;
+    std::shared_ptr<middle_t> m_object_store;
 
     id_tracker m_ways_pending_tracker;
     id_tracker m_rels_pending_tracker;

--- a/src/dependency-manager.hpp
+++ b/src/dependency-manager.hpp
@@ -7,6 +7,17 @@
 
 #include <cassert>
 
+struct pending_processor
+{
+    virtual ~pending_processor() = default;
+
+    virtual void enqueue_way(osmid_t id) = 0;
+    virtual void enqueue_relation(osmid_t id) = 0;
+
+    virtual void process_ways() = 0;
+    virtual void process_relations() = 0;
+};
+
 /**
  * The job of the dependency manager is to keep track of the dependencies
  * between OSM objects, that is nodes in ways and members of relations.
@@ -64,7 +75,7 @@ public:
      *
      * \post !has_pending()
      */
-    virtual void process_pending(middle_t::pending_processor &) {}
+    virtual void process_pending(pending_processor &) {}
 };
 
 /**
@@ -100,7 +111,7 @@ public:
 
     bool has_pending() const noexcept override;
 
-    void process_pending(middle_t::pending_processor &pf) override;
+    void process_pending(pending_processor &proc) override;
 
     /**
      * Get access to the pending way ids. This is for debugging only.

--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -12,7 +12,6 @@
 #include <memory>
 
 #include "db-copy-mgr.hpp"
-#include "id-tracker.hpp"
 #include "middle.hpp"
 #include "node-persistent-cache.hpp"
 #include "node-ram-cache.hpp"
@@ -65,22 +64,20 @@ struct middle_pgsql_t : public slim_middle_t
 
     void node_set(osmium::Node const &node) override;
     void node_delete(osmid_t id) override;
-    void node_changed(osmid_t id) override;
 
     void way_set(osmium::Way const &way) override;
     void way_delete(osmid_t id) override;
-    void way_changed(osmid_t id) override;
 
     void relation_set(osmium::Relation const &rel) override;
     void relation_delete(osmid_t id) override;
-    void relation_changed(osmid_t id) override;
 
     void flush() override;
 
-    void iterate_ways(pending_processor &pf) override;
-    void iterate_relations(pending_processor &pf) override;
-
-    bool has_pending() const override;
+    idlist_t get_ways_by_node(osmid_t osm_id) override;
+    idlist_t get_rels_by_node(osmid_t osm_id) override;
+    idlist_t get_rels_by_way(osmid_t osm_id) override;
+    idlist_t get_rels_by_rel(osmid_t osm_id) override;
+    idlist_t get_ways_by_rel(osmid_t osm_id) override;
 
     class table_desc
     {
@@ -115,6 +112,8 @@ private:
 
     void buffer_store_tags(osmium::OSMObject const &obj, bool attrs);
 
+    idlist_t get_ids(const char* stmt, osmid_t osm_id);
+
     table_desc m_tables[NUM_TABLES];
 
     bool m_append;
@@ -123,8 +122,6 @@ private:
 
     std::shared_ptr<node_ram_cache> m_cache;
     std::shared_ptr<node_persistent_cache> m_persistent_cache;
-
-    std::shared_ptr<id_tracker> m_ways_pending_tracker, m_rels_pending_tracker;
 
     pg_conn_t m_db_connection;
 

--- a/src/middle-ram.hpp
+++ b/src/middle-ram.hpp
@@ -115,11 +115,6 @@ struct middle_ram_t : public middle_t, public middle_query_t
 
     idlist_t relations_using_way(osmid_t way_id) const override;
 
-    void iterate_ways(pending_processor &) override {}
-    void iterate_relations(pending_processor &) override {}
-
-    bool has_pending() const override { return false; }
-
     std::shared_ptr<middle_query_t> get_query_instance() override;
 
 private:

--- a/src/middle.hpp
+++ b/src/middle.hpp
@@ -121,6 +121,12 @@ struct middle_t
      */
     virtual void flush() = 0;
 
+    virtual idlist_t get_ways_by_node(osmid_t) { return {}; }
+    virtual idlist_t get_rels_by_node(osmid_t) { return {}; }
+    virtual idlist_t get_rels_by_way(osmid_t) { return {}; }
+    virtual idlist_t get_rels_by_rel(osmid_t) { return {}; }
+    virtual idlist_t get_ways_by_rel(osmid_t) { return {}; }
+
     struct pending_processor
     {
         virtual ~pending_processor() {}
@@ -129,11 +135,6 @@ struct middle_t
         virtual void enqueue_relations(osmid_t id) = 0;
         virtual void process_relations() = 0;
     };
-
-    virtual void iterate_ways(pending_processor &pf) = 0;
-    virtual void iterate_relations(pending_processor &pf) = 0;
-
-    virtual bool has_pending() const = 0;
 
     virtual std::shared_ptr<middle_query_t> get_query_instance() = 0;
 };
@@ -154,37 +155,16 @@ struct slim_middle_t : public middle_t
     virtual void node_delete(osmid_t id) = 0;
 
     /**
-     * Mark a node as changed. This has to be called *after* node_delete()
-     * and node_set() is called to trigger the propagation of this change
-     * to ways and relations.
-     */
-    virtual void node_changed(osmid_t id) = 0;
-
-    /**
      * Delete a way from data storage. Either because you want it removed
      * entirely or before you can way_set() a new version of it.
      */
     virtual void way_delete(osmid_t id) = 0;
 
     /**
-     * Mark a way as changed. This has to be called *after* way_delete()
-     * and way_set() is called to trigger the propagation of this change
-     * to relations.
-     */
-    virtual void way_changed(osmid_t id) = 0;
-
-    /**
      * Delete a relation from data storage. Either because you want it removed
      * entirely or before you can relation_set() a new version of it.
      */
     virtual void relation_delete(osmid_t id) = 0;
-
-    /**
-     * Mark a relation as changed. This has to be called *after*
-     * relation_delete() and relation_set() is called to trigger the
-     * propagation of this change to other relations.
-     */
-    virtual void relation_changed(osmid_t id) = 0;
 };
 
 inline slim_middle_t::~slim_middle_t() = default;

--- a/src/middle.hpp
+++ b/src/middle.hpp
@@ -127,15 +127,6 @@ struct middle_t
     virtual idlist_t get_rels_by_rel(osmid_t) { return {}; }
     virtual idlist_t get_ways_by_rel(osmid_t) { return {}; }
 
-    struct pending_processor
-    {
-        virtual ~pending_processor() {}
-        virtual void enqueue_ways(osmid_t id) = 0;
-        virtual void process_ways() = 0;
-        virtual void enqueue_relations(osmid_t id) = 0;
-        virtual void process_relations() = 0;
-    };
-
     virtual std::shared_ptr<middle_query_t> get_query_instance() = 0;
 };
 

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
                         });
 
         auto dependency_manager = std::unique_ptr<dependency_manager_t>(
-            need_dependencies ? new full_dependency_manager_t{middle.get()}
+            need_dependencies ? new full_dependency_manager_t{middle}
                               : new dependency_manager_t{});
 
         osmdata_t osmdata{dependency_manager.get(), middle, outputs};

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -63,7 +63,17 @@ int main(int argc, char *argv[])
         auto const outputs =
             output_t::create_outputs(middle->get_query_instance(), options);
 
-        osmdata_t osmdata{middle, outputs};
+        bool const need_dependencies =
+            std::any_of(outputs.cbegin(), outputs.cend(),
+                        [](std::shared_ptr<output_t> const &output) {
+                            return output->need_forward_dependencies();
+                        });
+
+        auto dependency_manager = std::unique_ptr<dependency_manager_t>(
+            need_dependencies ? new full_dependency_manager_t{middle.get()}
+                              : new dependency_manager_t{});
+
+        osmdata_t osmdata{dependency_manager.get(), middle, outputs};
 
         fmt::print(stderr, "Using projection SRS {} ({})\n",
                    options.projection->target_srs(),

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
             need_dependencies ? new full_dependency_manager_t{middle}
                               : new dependency_manager_t{});
 
-        osmdata_t osmdata{dependency_manager.get(), middle, outputs};
+        osmdata_t osmdata{std::move(dependency_manager), middle, outputs};
 
         fmt::print(stderr, "Using projection SRS {} ({})\n",
                    options.projection->target_srs(),

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -18,12 +18,12 @@
 #include "output.hpp"
 #include "util.hpp"
 
-osmdata_t::osmdata_t(dependency_manager_t *dependency_manager,
+osmdata_t::osmdata_t(std::unique_ptr<dependency_manager_t> dependency_manager,
                      std::shared_ptr<middle_t> mid,
                      std::vector<std::shared_ptr<output_t>> const &outs)
-: m_dependency_manager(dependency_manager), m_mid(mid), m_outs(outs)
+: m_dependency_manager(std::move(dependency_manager)), m_mid(mid), m_outs(outs)
 {
-    assert(dependency_manager != nullptr);
+    assert(m_dependency_manager);
     assert(m_mid);
     assert(!m_outs.empty());
 

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <vector>
 
+#include "dependency-manager.hpp"
 #include "osmtypes.hpp"
 
 class output_t;
@@ -13,7 +14,8 @@ struct slim_middle_t;
 class osmdata_t
 {
 public:
-    osmdata_t(std::shared_ptr<middle_t> mid,
+    osmdata_t(dependency_manager_t *dependency_manager,
+              std::shared_ptr<middle_t> mid,
               std::vector<std::shared_ptr<output_t>> const &outs);
 
     void start() const;
@@ -35,6 +37,7 @@ public:
 private:
     slim_middle_t &slim_middle() const noexcept;
 
+    dependency_manager_t *m_dependency_manager;
     std::shared_ptr<middle_t> m_mid;
     std::vector<std::shared_ptr<output_t>> m_outs;
     bool m_with_extra_attrs;

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -14,7 +14,7 @@ struct slim_middle_t;
 class osmdata_t
 {
 public:
-    osmdata_t(dependency_manager_t *dependency_manager,
+    osmdata_t(std::unique_ptr<dependency_manager_t> dependency_manager,
               std::shared_ptr<middle_t> mid,
               std::vector<std::shared_ptr<output_t>> const &outs);
 
@@ -37,7 +37,7 @@ public:
 private:
     slim_middle_t &slim_middle() const noexcept;
 
-    dependency_manager_t *m_dependency_manager;
+    std::unique_ptr<dependency_manager_t> m_dependency_manager;
     std::shared_ptr<middle_t> m_mid;
     std::vector<std::shared_ptr<output_t>> m_outs;
     bool m_with_extra_attrs;

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -10,27 +10,12 @@
  * Associated tags: name, type etc.
 */
 
-#include <stack>
-
 #include <osmium/thread/pool.hpp>
 
 #include "options.hpp"
 
-struct expire_tiles;
-struct id_tracker;
 struct middle_query_t;
 class db_copy_thread_t;
-
-struct pending_job_t
-{
-    osmid_t osm_id;
-    size_t output_id;
-
-    pending_job_t() : osm_id(0), output_id(0) {}
-    pending_job_t(osmid_t id, size_t oid) : osm_id(id), output_id(oid) {}
-};
-
-using pending_queue_t = std::stack<pending_job_t>;
 
 class output_t
 {

--- a/tests/common-import.hpp
+++ b/tests/common-import.hpp
@@ -88,7 +88,7 @@ public:
                         });
 
         auto dependency_manager = std::unique_ptr<dependency_manager_t>(
-            need_dependencies ? new full_dependency_manager_t{middle.get()}
+            need_dependencies ? new full_dependency_manager_t{middle}
                               : new dependency_manager_t{});
 
         osmdata_t osmdata{dependency_manager.get(), middle, outputs};
@@ -112,7 +112,7 @@ public:
         auto const outputs =
             output_t::create_outputs(middle->get_query_instance(), options);
 
-        full_dependency_manager_t dependency_manager{middle.get()};
+        full_dependency_manager_t dependency_manager{middle};
 
         parse_file(options, &dependency_manager, middle, outputs, file);
     }
@@ -143,7 +143,7 @@ public:
             std::make_shared<db_copy_thread_t>(
                 options.database_options.conninfo()));
 
-        full_dependency_manager_t dependency_manager{mid_pgsql.get()};
+        full_dependency_manager_t dependency_manager{mid_pgsql};
 
         parse_file(options, &dependency_manager, mid_pgsql, {out_test},
                    file);

--- a/tests/test-middle.cpp
+++ b/tests/test-middle.cpp
@@ -1032,7 +1032,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
     // closed properly.
     {
         auto mid = std::make_shared<middle_pgsql_t>(&options);
-        full_dependency_manager_t dependency_manager{mid.get()};
+        full_dependency_manager_t dependency_manager{mid};
         mid->start();
 
         mid->node_set(node10);
@@ -1062,7 +1062,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
     SECTION("Single way affected")
     {
         auto mid = std::make_shared<middle_pgsql_t>(&options);
-        full_dependency_manager_t dependency_manager{mid.get()};
+        full_dependency_manager_t dependency_manager{mid};
         mid->start();
 
         mid->node_delete(10);
@@ -1095,7 +1095,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
         }
         {
             auto mid = std::make_shared<middle_pgsql_t>(&options);
-            full_dependency_manager_t dependency_manager{mid.get()};
+            full_dependency_manager_t dependency_manager{mid};
             mid->start();
 
             mid->node_delete(10);
@@ -1135,7 +1135,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
 
         {
             auto mid = std::make_shared<middle_pgsql_t>(&options);
-            full_dependency_manager_t dependency_manager{mid.get()};
+            full_dependency_manager_t dependency_manager{mid};
             mid->start();
 
             mid->node_delete(10);
@@ -1198,7 +1198,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in relation", "", options_slim_default,
     SECTION("Single relation directly affected")
     {
         auto mid = std::make_shared<middle_pgsql_t>(&options);
-        full_dependency_manager_t dependency_manager{mid.get()};
+        full_dependency_manager_t dependency_manager{mid};
         mid->start();
 
         mid->node_delete(10);
@@ -1219,7 +1219,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in relation", "", options_slim_default,
     SECTION("Single relation indirectly affected (through way)")
     {
         auto mid = std::make_shared<middle_pgsql_t>(&options);
-        full_dependency_manager_t dependency_manager{mid.get()};
+        full_dependency_manager_t dependency_manager{mid};
         mid->start();
 
         mid->node_delete(11);

--- a/tests/test-output-multi-point-multi-table.cpp
+++ b/tests/test-output-multi-point-multi-table.cpp
@@ -45,10 +45,11 @@ TEST_CASE("parse point")
         outputs.push_back(out_test);
     }
 
-    dependency_manager_t dependency_manager{};
+    auto dependency_manager =
+        std::unique_ptr<dependency_manager_t>(new dependency_manager_t{});
 
-    testing::parse_file(options, &dependency_manager, mid_pgsql, outputs,
-                        "liechtenstein-2013-08-03.osm.pbf");
+    testing::parse_file(options, std::move(dependency_manager), mid_pgsql,
+                        outputs, "liechtenstein-2013-08-03.osm.pbf");
 
     auto conn = db.db().connect();
 

--- a/tests/test-output-multi-point-multi-table.cpp
+++ b/tests/test-output-multi-point-multi-table.cpp
@@ -45,7 +45,9 @@ TEST_CASE("parse point")
         outputs.push_back(out_test);
     }
 
-    testing::parse_file(options, mid_pgsql, outputs,
+    dependency_manager_t dependency_manager{};
+
+    testing::parse_file(options, &dependency_manager, mid_pgsql, outputs,
                         "liechtenstein-2013-08-03.osm.pbf");
 
     auto conn = db.db().connect();

--- a/tests/test-parse-osmium.cpp
+++ b/tests/test-parse-osmium.cpp
@@ -26,23 +26,14 @@ struct counting_slim_middle_t : public slim_middle_t
     void way_set(osmium::Way const &) override { ++way.added; }
     void relation_set(osmium::Relation const &) override { ++relation.added; }
 
-    void iterate_ways(pending_processor &) override {}
-    void iterate_relations(pending_processor &) override {}
-    bool has_pending() const override { return false; }
-
     std::shared_ptr<middle_query_t> get_query_instance() override
     {
         return std::shared_ptr<middle_query_t>{};
     }
 
     void node_delete(osmid_t) override { ++node.deleted; }
-    void node_changed(osmid_t) override { ++node.modified; }
-
     void way_delete(osmid_t) override { ++way.deleted; }
-    void way_changed(osmid_t) override { ++way.modified; }
-
     void relation_delete(osmid_t) override { ++relation.deleted; }
-    void relation_changed(osmid_t) override { ++relation.modified; }
 
     type_stats_t node, way, relation;
 };
@@ -101,6 +92,21 @@ struct counting_output_t : public output_null_t
     unsigned sum_members = 0;
 };
 
+/**
+ * This pseudo-dependency manager is just used for testing. It counts how
+ * often the *_changed() member functions are called.
+ */
+struct counting_dependency_manager_t : public dependency_manager_t
+{
+    void node_changed(osmid_t) override { ++nodes_changed; }
+    void way_changed(osmid_t) override { ++ways_changed; }
+    void relation_changed(osmid_t) override { ++relations_changed; }
+
+    std::size_t nodes_changed = 0;
+    std::size_t ways_changed = 0;
+    std::size_t relations_changed = 0;
+};
+
 TEST_CASE("parse xml file")
 {
     options_t const options = testing::opt_t().slim();
@@ -108,7 +114,10 @@ TEST_CASE("parse xml file")
     auto const middle = std::make_shared<counting_slim_middle_t>();
     std::shared_ptr<output_t> output{new counting_output_t{options}};
 
-    testing::parse_file(options, middle, {output}, "test_multipolygon.osm");
+    counting_dependency_manager_t dependency_manager;
+
+    testing::parse_file(options, &dependency_manager, middle, {output},
+                        "test_multipolygon.osm");
 
     auto const *out_test = static_cast<counting_output_t *>(output.get());
     REQUIRE(out_test->sum_ids == 4728);
@@ -126,14 +135,15 @@ TEST_CASE("parse xml file")
 
     auto const *mid_test = static_cast<counting_slim_middle_t *>(middle.get());
     REQUIRE(mid_test->node.added == 353);
-    REQUIRE(mid_test->node.modified == 0);
     REQUIRE(mid_test->node.deleted == 0);
     REQUIRE(mid_test->way.added == 140);
-    REQUIRE(mid_test->way.modified == 0);
     REQUIRE(mid_test->way.deleted == 0);
     REQUIRE(mid_test->relation.added == 40);
-    REQUIRE(mid_test->relation.modified == 0);
     REQUIRE(mid_test->relation.deleted == 0);
+
+    REQUIRE(dependency_manager.nodes_changed == 0);
+    REQUIRE(dependency_manager.ways_changed == 0);
+    REQUIRE(dependency_manager.relations_changed == 0);
 }
 
 TEST_CASE("parse diff file")
@@ -143,7 +153,10 @@ TEST_CASE("parse diff file")
     auto const middle = std::make_shared<counting_slim_middle_t>();
     std::shared_ptr<output_t> output{new counting_output_t{options}};
 
-    testing::parse_file(options, middle, {output}, "008-ch.osc.gz");
+    counting_dependency_manager_t dependency_manager;
+
+    testing::parse_file(options, &dependency_manager, middle, {output},
+                        "008-ch.osc.gz");
 
     auto const *out_test = static_cast<counting_output_t *>(output.get());
     REQUIRE(out_test->node.added == 0);
@@ -158,14 +171,15 @@ TEST_CASE("parse diff file")
 
     auto *mid_test = static_cast<counting_slim_middle_t *>(middle.get());
     REQUIRE(mid_test->node.added == 1176);
-    REQUIRE(mid_test->node.modified == 1176);
     REQUIRE(mid_test->node.deleted == 17949);
     REQUIRE(mid_test->way.added == 161);
-    REQUIRE(mid_test->way.modified == 161);
     REQUIRE(mid_test->way.deleted == 165);
     REQUIRE(mid_test->relation.added == 11);
-    REQUIRE(mid_test->relation.modified == 11);
     REQUIRE(mid_test->relation.deleted == 12);
+
+    REQUIRE(dependency_manager.nodes_changed == 1176);
+    REQUIRE(dependency_manager.ways_changed == 161);
+    REQUIRE(dependency_manager.relations_changed == 11);
 }
 
 TEST_CASE("parse xml file with extra args")
@@ -176,7 +190,10 @@ TEST_CASE("parse xml file with extra args")
     auto const middle = std::make_shared<counting_slim_middle_t>();
     std::shared_ptr<output_t> output{new counting_output_t{options}};
 
-    testing::parse_file(options, middle, {output}, "test_multipolygon.osm");
+    counting_dependency_manager_t dependency_manager;
+
+    testing::parse_file(options, &dependency_manager, middle, {output},
+                        "test_multipolygon.osm");
 
     auto const *out_test = static_cast<counting_output_t *>(output.get());
     REQUIRE(out_test->sum_ids == 73514);
@@ -194,12 +211,13 @@ TEST_CASE("parse xml file with extra args")
 
     auto const *mid_test = static_cast<counting_slim_middle_t *>(middle.get());
     REQUIRE(mid_test->node.added == 353);
-    REQUIRE(mid_test->node.modified == 0);
     REQUIRE(mid_test->node.deleted == 0);
     REQUIRE(mid_test->way.added == 140);
-    REQUIRE(mid_test->way.modified == 0);
     REQUIRE(mid_test->way.deleted == 0);
     REQUIRE(mid_test->relation.added == 40);
-    REQUIRE(mid_test->relation.modified == 0);
     REQUIRE(mid_test->relation.deleted == 0);
+
+    REQUIRE(dependency_manager.nodes_changed == 0);
+    REQUIRE(dependency_manager.ways_changed == 0);
+    REQUIRE(dependency_manager.relations_changed == 0);
 }


### PR DESCRIPTION
The new dependency manager takes over some of the responsibilities of the middle. This way we decouple the dependency tracking from the object storage. It makes the code easier to understand and to change.

There are more refactorings coming after this.