### PR TITLE
Get options into osmdata

### DIFF
--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -73,7 +73,8 @@ int main(int argc, char *argv[])
             need_dependencies ? new full_dependency_manager_t{middle}
                               : new dependency_manager_t{});
 
-        osmdata_t osmdata{std::move(dependency_manager), middle, outputs};
+        osmdata_t osmdata{std::move(dependency_manager), middle, outputs,
+                          options};
 
         fmt::print(stderr, "Using projection SRS {} ({})\n",
                    options.projection->target_srs(),

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -13,23 +13,21 @@
 #include "db-copy.hpp"
 #include "format.hpp"
 #include "middle.hpp"
+#include "options.hpp"
 #include "osmdata.hpp"
 #include "output.hpp"
 #include "util.hpp"
 
 osmdata_t::osmdata_t(std::unique_ptr<dependency_manager_t> dependency_manager,
                      std::shared_ptr<middle_t> mid,
-                     std::vector<std::shared_ptr<output_t>> outs)
+                     std::vector<std::shared_ptr<output_t>> outs,
+                     options_t const &options)
 : m_dependency_manager(std::move(dependency_manager)), m_mid(std::move(mid)),
-  m_outs(std::move(outs))
+  m_outs(std::move(outs)), m_with_extra_attrs(options.extra_attributes)
 {
     assert(m_dependency_manager);
     assert(m_mid);
     assert(!m_outs.empty());
-
-    // Get the "extra_attributes" option from the first output. We expect
-    // all others to be the same.
-    m_with_extra_attrs = m_outs[0]->get_options()->extra_attributes;
 }
 
 /**

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -43,7 +43,13 @@ private:
     std::shared_ptr<middle_t> m_mid;
     std::vector<std::shared_ptr<output_t>> m_outs;
 
+    std::string m_conninfo;
+    int m_num_procs;
+    bool m_append;
+    bool m_droptemp;
+    bool m_parallel_indexing;
     bool m_with_extra_attrs;
+
 };
 
 #endif // OSM2PGSQL_OSMDATA_HPP

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -7,6 +7,7 @@
 #include "dependency-manager.hpp"
 #include "osmtypes.hpp"
 
+class options_t;
 class output_t;
 struct middle_t;
 struct slim_middle_t;
@@ -16,7 +17,8 @@ class osmdata_t
 public:
     osmdata_t(std::unique_ptr<dependency_manager_t> dependency_manager,
               std::shared_ptr<middle_t> mid,
-              std::vector<std::shared_ptr<output_t>> outs);
+              std::vector<std::shared_ptr<output_t>> outs,
+              options_t const &options);
 
     void start() const;
     void flush() const;
@@ -40,6 +42,7 @@ private:
     std::unique_ptr<dependency_manager_t> m_dependency_manager;
     std::shared_ptr<middle_t> m_mid;
     std::vector<std::shared_ptr<output_t>> m_outs;
+
     bool m_with_extra_attrs;
 };
 

--- a/tests/common-import.hpp
+++ b/tests/common-import.hpp
@@ -27,7 +27,7 @@ inline void parse_file(options_t const &options,
                        std::vector<std::shared_ptr<output_t>> const &outs,
                        char const *filename = nullptr)
 {
-    osmdata_t osmdata{std::move(dependency_manager), mid, outs};
+    osmdata_t osmdata{std::move(dependency_manager), mid, outs, options};
 
     osmdata.start();
     parse_osmium_t parser{options.bbox, options.append, &osmdata};
@@ -91,7 +91,8 @@ public:
             need_dependencies ? new full_dependency_manager_t{middle}
                               : new dependency_manager_t{});
 
-        osmdata_t osmdata{std::move(dependency_manager), middle, outputs};
+        osmdata_t osmdata{std::move(dependency_manager), middle, outputs,
+                          options};
 
         osmdata.start();
 


### PR DESCRIPTION
Give options to `osmdata_t` constructor instead of getting them from outputs.