### PR TITLE
Rename file format option and simplify default (auto) case

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -488,7 +488,7 @@ options_t::options_t(int argc, char *argv[]) : options_t()
             enable_multi = true;
             break;
         case 'r':
-            input_reader = optarg;
+            input_format = optarg;
             break;
         case 'h':
             long_usage_bool = true;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -488,7 +488,9 @@ options_t::options_t(int argc, char *argv[]) : options_t()
             enable_multi = true;
             break;
         case 'r':
-            input_format = optarg;
+            if (std::strcmp(optarg, "auto") != 0) {
+                input_format = optarg;
+            }
             break;
         case 'h':
             long_usage_bool = true;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -124,7 +124,7 @@ public:
 
     database_options_t database_options;
     std::string output_backend{"pgsql"};
-    std::string input_reader{"auto"};
+    std::string input_format; ///< input file format (default: autodetect)
     osmium::Box bbox;
     bool extra_attributes = false;
 

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
             util::timer_t timer_parse;
 
             parse_osmium_t parser{options.bbox, options.append, &osmdata};
-            parser.stream_file(filename, options.input_reader);
+            parser.stream_file(filename, options.input_format);
 
             stats.update(parser.stats());
 

--- a/src/parse-osmium.cpp
+++ b/src/parse-osmium.cpp
@@ -78,10 +78,9 @@ parse_osmium_t::parse_osmium_t(osmium::Box const &bbox, bool append,
 {}
 
 void parse_osmium_t::stream_file(std::string const &filename,
-                                 std::string const &fmt)
+                                 std::string const &format)
 {
-    std::string const &osmium_format = (fmt == "auto" ? "" : fmt);
-    osmium::io::File infile{filename, osmium_format};
+    osmium::io::File infile{filename, format};
 
     if (!m_append && infile.has_multiple_object_versions()) {
         throw std::runtime_error{
@@ -90,9 +89,9 @@ void parse_osmium_t::stream_file(std::string const &filename,
 
     if (infile.format() == osmium::io::file_format::unknown) {
         throw std::runtime_error{
-            fmt == "auto"
+            format.empty()
                 ? std::string{"Cannot detect file format. Try using -r."}
-                : "Unknown file format '{}'."_format(fmt)};
+                : "Unknown file format '{}'."_format(format)};
     }
 
     fmt::print(stderr, "Using {} parser.\n",


### PR DESCRIPTION
* Rename option "input_reader" to "input_format".
* Also rename a parameter from "fmt" to "format" because "fmt"
  is used as namespace for the format library we are using.
* Change default setting for autodetecting the file format from
  "auto" to simply the empty string. This matches the way the
  underlying osmium library does it.