### PR TITLE
Move file reading functionality from parse_osmium_t to osmdata_t

### DIFF
--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -4,8 +4,12 @@
 #include <memory>
 #include <vector>
 
+#include <osmium/fwd.hpp>
+#include <osmium/io/file.hpp>
+
 #include "dependency-manager.hpp"
 #include "osmtypes.hpp"
+#include "parse-osmium.hpp"
 
 class options_t;
 class output_t;
@@ -22,6 +26,18 @@ public:
 
     void start() const;
     void flush() const;
+
+    /**
+     * Process the specified OSM file (stage 1a). This is called once for
+     * each input file.
+     */
+    parse_stats_t process_file(osmium::io::File const &file,
+                               osmium::Box const &bbox) const;
+
+    /**
+     * Rest of the processing (stages 1b, 2, and 3). This is called once
+     * after process_file() was called for each input file.
+     */
     void stop() const;
 
     void node_add(osmium::Node const &node) const;
@@ -37,6 +53,7 @@ public:
     void relation_delete(osmid_t id) const;
 
 private:
+
     /**
      * Run stage 1b processing: Process dependent objects.
      * In append mode we need to process dependent objects that were marked

--- a/src/parse-osmium.cpp
+++ b/src/parse-osmium.cpp
@@ -23,12 +23,8 @@
 #include "parse-osmium.hpp"
 #include "format.hpp"
 #include "osmdata.hpp"
-#include "reprojection.hpp"
 
-#include <osmium/handler.hpp>
-#include <osmium/io/any_input.hpp>
 #include <osmium/osm.hpp>
-#include <osmium/visitor.hpp>
 
 void parse_stats_t::update(parse_stats_t const &other)
 {
@@ -73,35 +69,9 @@ void parse_stats_t::possibly_print_status()
 }
 
 parse_osmium_t::parse_osmium_t(osmium::Box const &bbox, bool append,
-                               osmdata_t *osmdata)
+                               osmdata_t const *osmdata)
 : m_data(osmdata), m_bbox(bbox), m_append(append)
 {}
-
-void parse_osmium_t::stream_file(std::string const &filename,
-                                 std::string const &format)
-{
-    osmium::io::File infile{filename, format};
-
-    if (!m_append && infile.has_multiple_object_versions()) {
-        throw std::runtime_error{
-            "Reading an OSM change file only works in append mode."};
-    }
-
-    if (infile.format() == osmium::io::file_format::unknown) {
-        throw std::runtime_error{
-            format.empty()
-                ? std::string{"Cannot detect file format. Try using -r."}
-                : "Unknown file format '{}'."_format(format)};
-    }
-
-    fmt::print(stderr, "Using {} parser.\n",
-               osmium::io::as_string(infile.format()));
-
-    m_type = osmium::item_type::node;
-    osmium::io::Reader reader{infile};
-    osmium::apply(reader, *this);
-    reader.close();
-}
 
 void parse_osmium_t::node(osmium::Node const &node)
 {

--- a/src/parse-osmium.hpp
+++ b/src/parse-osmium.hpp
@@ -130,9 +130,8 @@ private:
 class parse_osmium_t : public osmium::handler::Handler
 {
 public:
-    parse_osmium_t(osmium::Box const &bbox, bool append, osmdata_t *osmdata);
-
-    void stream_file(std::string const &filename, std::string const &fmt);
+    parse_osmium_t(osmium::Box const &bbox, bool append,
+                   osmdata_t const *osmdata);
 
     void node(osmium::Node const &node);
     void way(osmium::Way &way);
@@ -141,7 +140,7 @@ public:
     parse_stats_t const &stats() const noexcept { return m_stats; }
 
 private:
-    osmdata_t *m_data;
+    osmdata_t const *m_data;
 
     // Bounding box for node import or invalid Box if everything is imported
     osmium::Box m_bbox;
@@ -149,7 +148,7 @@ private:
     parse_stats_t m_stats;
 
     // Current type being parsed.
-    osmium::item_type m_type = osmium::item_type::undefined;
+    osmium::item_type m_type = osmium::item_type::node;
 
     // Are we running in append mode?
     bool m_append;


### PR DESCRIPTION
This leaves only the functionality as Osmium handler in parse_osmium_t.

This commit also leverages the ability of osmium::io::Reader to read
from either a file or a buffer when it is called with an
osmium::io::File parameter. By creating the osmium::io::File outside the
process_file() function, we don't need the special class test_parse_t
any more.