### PR TITLE
Fix multistage processing

### DIFF
--- a/docs/lua-lib.md
+++ b/docs/lua-lib.md
@@ -36,6 +36,23 @@ if object.tags.highway then
 end
 ```
 
+## `mark_member_ways`
+
+Synopsis: `osm2pgsql.mark_member_ways(RELATION)`
+
+Description: Mark all way members of the specified RELATION (for stage 2
+processing).
+
+Example:
+
+```
+function osm2pgsql.check_relation(object)
+    if object.tags.type == 'route' then
+        osm2pgsql.mark_member_ways(object)
+    end
+end
+```
+
 ## `make_clean_tags_func`
 
 Synopsis: `osm2pgsql.make_clean_tags_func(KEYS)`

--- a/flex-config/route-relations.lua
+++ b/flex-config/route-relations.lua
@@ -22,8 +22,9 @@ tables.routes = osm2pgsql.define_relation_table('routes', {
     { column = 'tags', type = 'hstore' },
 })
 
--- This will be used to store lists of relation ids queryable by way id
-by_way_id = {}
+-- This will be used to store information about relations queryable by member
+-- way id
+local w2r = {}
 
 function clean_tags(tags)
     tags.odbl = nil
@@ -40,54 +41,53 @@ function osm2pgsql.process_way(object)
         return
     end
 
-    -- In stage 1: Mark all remaining ways so we will see them again in stage 2
-    if osm2pgsql.stage == 1 then
-        osm2pgsql.mark_way(object.id)
-        return
-    end
-
-    -- We are now in stage 2
-
     clean_tags(object.tags)
 
-    -- Data we will store in the "highways" table always has the way tags
+    -- Data we will store in the "highways" table always has the tags from
+    -- the way
     local row = {
         tags = object.tags
     }
 
-    -- If there is any data from relations, add it in
-    local d = by_way_id[object.id]
+    -- If there is any data from parent relations, add it in
+    local d = w2r[object.id]
     if d then
-        table.sort(d.refs)
-        table.sort(d.ids)
-        row.rel_refs = table.concat(d.refs, ',')
-        row.rel_ids = '{' .. table.concat(d.ids, ',') .. '}'
+        local refs = {}
+        local ids = {}
+        for rel_id, rel_ref in pairs(d) do
+            refs[#refs + 1] = rel_ref
+            ids[#ids + 1] = rel_id
+        end
+        table.sort(refs)
+        table.sort(ids)
+        row.rel_refs = table.concat(refs, ',')
+        row.rel_ids = '{' .. table.concat(ids, ',') .. '}'
     end
 
     tables.highways:add_row(row)
 end
 
-function osm2pgsql.process_relation(object)
+function osm2pgsql.check_relation(object)
     -- Only interested in relations with type=route, route=road and a ref
     if object.tags.type == 'route' and object.tags.route == 'road' and object.tags.ref then
+        osm2pgsql.mark_member_ways(object)
+    end
+end
+
+function osm2pgsql.process_relation(object)
+    if object.tags.type == 'route' and object.tags.route == 'road' and object.tags.ref then
         tables.routes:add_row({
-            tags = object.tags,
-            geom = { create = 'line' }
+            tags = object.tags
         })
 
-        -- Go through all the members and store relation ids and refs so it
+        -- Go through all the members and store relation ids and refs so they
         -- can be found by the way id.
         for _, member in ipairs(object.members) do
             if member.type == 'w' then
-                if not by_way_id[member.ref] then
-                    by_way_id[member.ref] = {
-                        ids = {},
-                        refs = {}
-                    }
+                if not w2r[member.ref] then
+                    w2r[member.ref] = {}
                 end
-                local d = by_way_id[member.ref]
-                table.insert(d.ids, object.id)
-                table.insert(d.refs, object.tags.ref)
+                w2r[member.ref][object.id] = object.tags.ref
             end
         end
     end

--- a/src/init.lua
+++ b/src/init.lua
@@ -29,12 +29,12 @@ function osm2pgsql.define_area_table(_name, _columns)
     return _define_table_impl('area', _name, _columns)
 end
 
-function osm2pgsql.mark_way(id)
-    return osm2pgsql.mark('w', id)
-end
-
-function osm2pgsql.mark_relation(id)
-    return osm2pgsql.mark('r', id)
+function osm2pgsql.mark_member_ways(relation)
+    for _, member in ipairs(relation.members) do
+        if member.type == 'w' then
+            osm2pgsql.mark_way(member.ref)
+        end
+    end
 end
 
 function osm2pgsql.clamp(value, low, high)

--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -580,8 +580,6 @@ void middle_pgsql_t::commit()
     m_db_copy.sync();
     // release the copy thread and its query connection
     m_copy_thread->finish();
-
-    m_db_connection.close();
 }
 
 void middle_pgsql_t::flush() { m_db_copy.sync(); }

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -68,11 +68,11 @@ public:
 private:
 
     /**
-     * Run stage 1b processing: Process dependent objects.
+     * Run stage 1b and stage 1c processing: Process dependent objects.
      * In append mode we need to process dependent objects that were marked
      * earlier.
      */
-    void process_stage1b() const;
+    void process_stage1bc() const;
 
     /**
      * Run stage 2 processing: Process objects marked in stage 1 (if any).

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -54,6 +54,18 @@ private:
     int m_index = 0;
 };
 
+inline bool operator==(prepared_lua_function_t a,
+                       prepared_lua_function_t b) noexcept
+{
+    return a.index() == b.index();
+}
+
+inline bool operator!=(prepared_lua_function_t a,
+                       prepared_lua_function_t b) noexcept
+{
+    return !(a == b);
+}
+
 class output_flex_t : public output_t
 {
 
@@ -185,10 +197,18 @@ private:
 
     std::size_t m_num_way_nodes = std::numeric_limits<std::size_t>::max();
 
-    bool m_in_stage2 = false;
     prepared_lua_function_t m_process_node;
     prepared_lua_function_t m_process_way;
     prepared_lua_function_t m_process_relation;
+
+    /**
+     * Before a Lua function is called from C++, we store it in here. When
+     * C++ code is called back from the Lua code we can check whether the
+     * C++ function called is allowed in this context.
+     */
+    prepared_lua_function_t m_context;
+
+    bool m_in_stage2 = false;
 };
 
 #endif // OSM2PGSQL_OUTPUT_FLEX_HPP

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -36,12 +36,16 @@ public:
     virtual void stop(osmium::thread::Pool *pool) = 0;
     virtual void sync() = 0;
 
+    virtual bool has_stage2_processing() const noexcept { return false; }
+    virtual idlist_t get_stage1c_way_ids() { return {}; }
     virtual void stage2_proc() {}
 
     virtual bool need_forward_dependencies() const noexcept { return true; }
 
     virtual void pending_way(osmid_t id) = 0;
     virtual void pending_relation(osmid_t id) = 0;
+
+    virtual void check_relation(osmid_t) {}
 
     virtual void node_add(osmium::Node const &node) = 0;
     virtual void way_add(osmium::Way *way) = 0;
@@ -54,6 +58,8 @@ public:
     virtual void node_delete(osmid_t id) = 0;
     virtual void way_delete(osmid_t id) = 0;
     virtual void relation_delete(osmid_t id) = 0;
+
+    virtual bool has_stage1c_pending() const { return false; }
 
     const options_t *get_options() const;
 

--- a/tests/test-output-flex-extra.cpp
+++ b/tests/test-output-flex-extra.cpp
@@ -182,3 +182,134 @@ TEST_CASE("relation data on ways")
     CHECK(0 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
     CHECK(2 == conn.get_count("osm2pgsql_test_highways", "refs IS NULL"));
 }
+
+TEST_CASE("relation data on ways: delete or re-tag relation")
+{
+    testing::opt_t options = testing::opt_t()
+                                 .slim()
+                                 .flex("test_output_flex_extra.lua")
+                                 .srs(PROJ_LATLONG);
+
+    // create database with three ways and a relation on two of them
+    REQUIRE_NOTHROW(
+        db.run_import(options, "n10 v1 dV x10.0 y10.0\n"
+                               "n11 v1 dV x10.0 y10.2\n"
+                               "n12 v1 dV x10.2 y10.2\n"
+                               "n13 v1 dV x10.2 y10.0\n"
+                               "n14 v1 dV x10.3 y10.0\n"
+                               "n15 v1 dV x10.4 y10.0\n"
+                               "w20 v1 dV Thighway=primary Nn10,n11,n12\n"
+                               "w21 v1 dV Thighway=secondary Nn12,n13\n"
+                               "w22 v1 dV Thighway=secondary Nn13,n14,n15\n"
+                               "r30 v1 dV Ttype=route,ref=X11 Mw20@,w21@\n"));
+
+    auto conn = db.db().connect();
+
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'primary'"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'secondary'"));
+
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs IS NULL"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '20,21'"));
+
+    SECTION("delete relation")
+    {
+        REQUIRE_NOTHROW(db.run_import(options.append(), "r30 v2 dD\n"));
+    }
+
+    SECTION("change tags on relation")
+    {
+        REQUIRE_NOTHROW(db.run_import(options.append(),
+                                      "r30 v2 dV Ttype=foo Mw20@,w21@\n"));
+    }
+
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways"));
+    CHECK(0 == conn.get_count("osm2pgsql_test_routes"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'primary'"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'secondary'"));
+
+    CHECK(0 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways", "refs IS NULL"));
+
+    CHECK(0 == conn.get_count("osm2pgsql_test_routes", "members = '20,21'"));
+}
+
+TEST_CASE("relation data on ways: delete way in other relation")
+{
+    testing::opt_t options = testing::opt_t()
+                                 .slim()
+                                 .flex("test_output_flex_extra.lua")
+                                 .srs(PROJ_LATLONG);
+
+    // create database with three ways and two relations on them
+    REQUIRE_NOTHROW(
+        db.run_import(options, "n10 v1 dV x10.0 y10.0\n"
+                               "n11 v1 dV x10.0 y10.2\n"
+                               "n12 v1 dV x10.2 y10.2\n"
+                               "n13 v1 dV x10.2 y10.0\n"
+                               "n14 v1 dV x10.3 y10.0\n"
+                               "n15 v1 dV x10.4 y10.0\n"
+                               "w20 v1 dV Thighway=primary Nn10,n11,n12\n"
+                               "w21 v1 dV Thighway=secondary Nn12,n13\n"
+                               "w22 v1 dV Thighway=secondary Nn13,n14,n15\n"
+                               "r30 v1 dV Ttype=no-route Mw20@,w21@\n"
+                               "r31 v1 dV Ttype=route,ref=X11 Mw21@,w22@\n"));
+
+    auto conn = db.db().connect();
+
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'primary'"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'secondary'"));
+
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs IS NULL"));
+
+    CHECK(0 == conn.get_count("osm2pgsql_test_routes", "members = '20,21'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '21,22'"));
+
+    SECTION("change way node list")
+    {
+        REQUIRE_NOTHROW(db.run_import(options.append(),
+                                      "w20 v2 dV Thighway=primary Nn10,n11\n"));
+    }
+
+    SECTION("change way tags")
+    {
+        REQUIRE_NOTHROW(db.run_import(
+            options.append(),
+            "w20 v2 dV Thighway=primary,name=foo Nn10,n11,n12\n"));
+    }
+
+    SECTION("change way node")
+    {
+        REQUIRE_NOTHROW(
+            db.run_import(options.append(), "n10 v2 dV x11.0 y10.0\n"));
+    }
+
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'primary'"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'secondary'"));
+
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs IS NULL"));
+
+    CHECK(0 == conn.get_count("osm2pgsql_test_routes", "members = '20,21'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '21,22'"));
+}


### PR DESCRIPTION
The multi-stage processing in the flex output has some problems when updating data, for instance when relations are deleted after their member ways use their tags.

This commit reorganizes how the multi-stage processing is done to address these problems.

1. The way "marking" of objects is done is now different. Instead of doing this in the process_* Lua functions a new Lua function "check_relation()" is introduced. This will be called not only for all new relations but also for deleted relations, or when a relation changed, for the old relation. This is needed so that we also mark and then re-create way entries in the database that used to depend on a parent relations tags, but don't do that any more.
2. We remove the Lua mark() function and replace it by mark_way(). It was never possible to mark nodes anyway. And there is no use case I am aware of currently that needs marking relations. Both can be reintroduced later when we have a better idea how to handle them. For the time being we concentrate on the important use case where member ways of relations are handled specially.
3. This introduces a new processing stage 1c:
    * stage 1a: Read input file and process all objects in it.
    * stage 1b: Process dependent objects of objects from 1a (ie
      changed nodes trigger changes in ways with those nodes, changes
      in all objects potentially trigger changes in parent relations).
    * stage 1c: Process dependent objects (currently only relations)
      of objects marked during stage 1a/1b (this one is new).
    * stage 2: Process objects marked in stage 1a or 1b.
4. Add more checks for which C++ functions can be called from which Lua functions.
5. New Lua helper function osm2pgsql.mark_member_ways() that iterates over way members of a relation and marks them all. This is more convenient than doing it "mannually". If you need more complex processing, for instance use the member roles to decide which ways need stage 2 processing, you can still write your own loop.