### PR TITLE
Fix multistage processing (take 2)

### DIFF
--- a/docs/lua-lib.md
+++ b/docs/lua-lib.md
@@ -36,6 +36,22 @@ if object.tags.highway then
 end
 ```
 
+## `way_member_ids`
+
+Synopsis: `osm2pgsql.way_member_ids(RELATION)`
+
+Description: Return an array table with the ids of all way members of RELATION.
+
+Example:
+
+```
+function osm2pgsql.select_relation_members(relation)
+    if relation.tags.type == 'route' then
+        return { ways = osm2pgsql.way_member_ids(relation) }
+    end
+end
+```
+
 ## `make_clean_tags_func`
 
 Synopsis: `osm2pgsql.make_clean_tags_func(KEYS)`

--- a/src/init.lua
+++ b/src/init.lua
@@ -29,8 +29,14 @@ function osm2pgsql.define_area_table(_name, _columns, _options)
     return _define_table_impl('area', _name, _columns, _options)
 end
 
-function osm2pgsql.mark_way(id)
-    return osm2pgsql.mark('w', id)
+function osm2pgsql.way_member_ids(relation)
+    local ids = {}
+    for _, member in ipairs(relation.members) do
+        if member.type == 'w' then
+            ids[#ids + 1] = member.ref
+        end
+    end
+    return ids
 end
 
 function osm2pgsql.clamp(value, low, high)

--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -580,8 +580,6 @@ void middle_pgsql_t::commit()
     m_db_copy.sync();
     // release the copy thread and its query connection
     m_copy_thread->finish();
-
-    m_db_connection.close();
 }
 
 void middle_pgsql_t::flush() { m_db_copy.sync(); }

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -48,8 +48,8 @@ public:
                                     osmium::Box const &bbox) const;
 
     /**
-     * Rest of the processing (stages 1b, 2, and 3). This is called once
-     * after process_file() was called for each input file.
+     * Rest of the processing (stages 1b, 1c, 2, and database postprocessing).
+     * This is called once after process_file() was called for each input file.
      */
     void stop() const;
 
@@ -68,21 +68,20 @@ public:
 private:
 
     /**
-     * Run stage 1b processing: Process dependent objects.
-     * In append mode we need to process dependent objects that were marked
-     * earlier.
+     * Run stage 1b and stage 1c processing: Process dependent objects in
+     * append mode.
      */
-    void process_stage1b() const;
+    void process_dependents() const;
 
     /**
-     * Run stage 2 processing: Process objects marked in stage 1 (if any).
+     * Run stage 2 processing: Reprocess objects marked in stage 1 (if any).
      */
-    void process_stage2() const;
+    void reprocess_marked() const;
 
     /**
-     * Run stage 3 processing: Clustering and index creation.
+     * Run postprocessing on database: Clustering and index creation.
      */
-    void process_stage3() const;
+    void postprocess_database() const;
 
     slim_middle_t &slim_middle() const noexcept;
 

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -10,6 +10,8 @@
  * Associated tags: name, type etc.
 */
 
+#include <osmium/index/id_set.hpp>
+
 #include "options.hpp"
 #include "thread-pool.hpp"
 
@@ -35,12 +37,21 @@ public:
     virtual void stop(thread_pool_t *pool) = 0;
     virtual void sync() = 0;
 
-    virtual void stage2_proc() {}
+    virtual osmium::index::IdSetSmall<osmid_t> const &get_marked_way_ids()
+    {
+        static osmium::index::IdSetSmall<osmid_t> const ids{};
+        return ids;
+    }
+
+    virtual void reprocess_marked() {}
 
     virtual bool need_forward_dependencies() const noexcept { return true; }
 
     virtual void pending_way(osmid_t id) = 0;
     virtual void pending_relation(osmid_t id) = 0;
+    virtual void pending_relation_stage1c(osmid_t) {}
+
+    virtual void select_relation_members(osmid_t) {}
 
     virtual void node_add(osmium::Node const &node) = 0;
     virtual void way_add(osmium::Way *way) = 0;

--- a/tests/data/test_output_flex_extra.lua
+++ b/tests/data/test_output_flex_extra.lua
@@ -21,32 +21,32 @@ tables.routes = osm2pgsql.define_table{
     }
 }
 
-local by_way_id = {}
+local w2r = {}
 
 function osm2pgsql.process_way(object)
-    if osm2pgsql.stage == 1 then
-        osm2pgsql.mark_way(object.id)
-        return
-    end
-
     local row = {
         tags = object.tags,
         geom = { create = 'line' }
     }
 
-    -- if there is any data from relations, add it in
-    local d = by_way_id[object.id]
+    local d = w2r[object.id]
     if d then
-        local keys = {}
-        for k,v in pairs(d.refs) do
-            keys[#keys + 1] = k
+        local refs = {}
+        for rel_id, rel_ref in pairs(d) do
+            refs[#refs + 1] = rel_ref
         end
+        table.sort(refs)
 
-        row.refs = table.concat(keys, ',')
-    --    row.rel_ids = '{' .. table.concat(d.ids, ',') .. '}'
+        row.refs = table.concat(refs, ',')
     end
 
     tables.highways:add_row(row)
+end
+
+function osm2pgsql.select_relation_members(relation)
+    if relation.tags.type == 'route' then
+        return { ways = osm2pgsql.way_member_ids(relation) }
+    end
 end
 
 function osm2pgsql.process_relation(object)
@@ -55,18 +55,12 @@ function osm2pgsql.process_relation(object)
     end
 
     local mlist = {}
-    for i, member in ipairs(object.members) do
+    for _, member in ipairs(object.members) do
         if member.type == 'w' then
-            osm2pgsql.mark_way(member.ref)
-            if not by_way_id[member.ref] then
-                by_way_id[member.ref] = {
-                    ids = {},
-                    refs = {}
-                }
+            if not w2r[member.ref] then
+                w2r[member.ref] = {}
             end
-            local d = by_way_id[member.ref]
-            table.insert(d.ids, object.id)
-            d.refs[object.tags.ref] = 1
+            w2r[member.ref][object.id] = object.tags.ref
             mlist[#mlist + 1] = member.ref
         end
     end

--- a/tests/regression.py
+++ b/tests/regression.py
@@ -601,7 +601,7 @@ class TestPgsqlUpdate(BaseUpdateRunner, unittest.TestCase,
 
 class TestPgsqlUpdateParallel(BaseUpdateRunner, unittest.TestCase,
                               PgsqlBaseTests):
-    extra_params = ['--slim', '--number-processes', '16']
+    extra_params = ['--slim', '--number-processes', '15']
 
 class TestPgsqlUpdateSmallCache(BaseUpdateRunner, unittest.TestCase,
                                 PgsqlBaseTests):

--- a/tests/test-output-flex-extra.cpp
+++ b/tests/test-output-flex-extra.cpp
@@ -182,3 +182,348 @@ TEST_CASE("relation data on ways")
     CHECK(0 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
     CHECK(2 == conn.get_count("osm2pgsql_test_highways", "refs IS NULL"));
 }
+
+TEST_CASE("relation data on ways: delete or re-tag relation")
+{
+    testing::opt_t options = testing::opt_t()
+                                 .slim()
+                                 .flex("test_output_flex_extra.lua")
+                                 .srs(PROJ_LATLONG);
+
+    // create database with three ways and a relation on two of them
+    REQUIRE_NOTHROW(
+        db.run_import(options, "n10 v1 dV x10.0 y10.0\n"
+                               "n11 v1 dV x10.0 y10.2\n"
+                               "n12 v1 dV x10.2 y10.2\n"
+                               "n13 v1 dV x10.2 y10.0\n"
+                               "n14 v1 dV x10.3 y10.0\n"
+                               "n15 v1 dV x10.4 y10.0\n"
+                               "w20 v1 dV Thighway=primary Nn10,n11,n12\n"
+                               "w21 v1 dV Thighway=secondary Nn12,n13\n"
+                               "w22 v1 dV Thighway=secondary Nn13,n14,n15\n"
+                               "r30 v1 dV Ttype=route,ref=X11 Mw20@,w21@\n"));
+
+    auto conn = db.db().connect();
+
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'primary'"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'secondary'"));
+
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs IS NULL"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '20,21'"));
+
+    SECTION("delete relation")
+    {
+        REQUIRE_NOTHROW(db.run_import(options.append(), "r30 v2 dD\n"));
+    }
+
+    SECTION("change tags on relation")
+    {
+        REQUIRE_NOTHROW(db.run_import(options.append(),
+                                      "r30 v2 dV Ttype=foo Mw20@,w21@\n"));
+    }
+
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways"));
+    CHECK(0 == conn.get_count("osm2pgsql_test_routes"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'primary'"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'secondary'"));
+
+    CHECK(0 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways", "refs IS NULL"));
+
+    CHECK(0 == conn.get_count("osm2pgsql_test_routes", "members = '20,21'"));
+}
+
+TEST_CASE("relation data on ways: delete way in other relation")
+{
+    testing::opt_t options = testing::opt_t()
+                                 .slim()
+                                 .flex("test_output_flex_extra.lua")
+                                 .srs(PROJ_LATLONG);
+
+    // create database with three ways and two relations on them
+    REQUIRE_NOTHROW(
+        db.run_import(options, "n10 v1 dV x10.0 y10.0\n"
+                               "n11 v1 dV x10.0 y10.2\n"
+                               "n12 v1 dV x10.2 y10.2\n"
+                               "n13 v1 dV x10.2 y10.0\n"
+                               "n14 v1 dV x10.3 y10.0\n"
+                               "n15 v1 dV x10.4 y10.0\n"
+                               "w20 v1 dV Thighway=primary Nn10,n11,n12\n"
+                               "w21 v1 dV Thighway=secondary Nn12,n13\n"
+                               "w22 v1 dV Thighway=secondary Nn13,n14,n15\n"
+                               "r30 v1 dV Ttype=no-route Mw20@,w21@\n"
+                               "r31 v1 dV Ttype=route,ref=X11 Mw21@,w22@\n"));
+
+    auto conn = db.db().connect();
+
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'primary'"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'secondary'"));
+
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs IS NULL"));
+
+    CHECK(0 == conn.get_count("osm2pgsql_test_routes", "members = '20,21'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '21,22'"));
+
+    SECTION("change way node list")
+    {
+        REQUIRE_NOTHROW(db.run_import(options.append(),
+                                      "w20 v2 dV Thighway=primary Nn10,n11\n"));
+    }
+
+    SECTION("change way tags")
+    {
+        REQUIRE_NOTHROW(db.run_import(
+            options.append(),
+            "w20 v2 dV Thighway=primary,name=foo Nn10,n11,n12\n"));
+    }
+
+    SECTION("change way node")
+    {
+        REQUIRE_NOTHROW(
+            db.run_import(options.append(), "n10 v2 dV x11.0 y10.0\n"));
+    }
+
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'primary'"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'secondary'"));
+
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs IS NULL"));
+
+    CHECK(0 == conn.get_count("osm2pgsql_test_routes", "members = '20,21'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '21,22'"));
+}
+
+TEST_CASE("relation data on ways: changing things in one relation should not change output")
+{
+    testing::opt_t options = testing::opt_t()
+                                 .slim()
+                                 .flex("test_output_flex_extra.lua")
+                                 .srs(PROJ_LATLONG);
+
+    // create database with three ways and two relations on them
+    REQUIRE_NOTHROW(
+        db.run_import(options, "n10 v1 dV x10.0 y10.0\n"
+                               "n11 v1 dV x10.0 y10.2\n"
+                               "n12 v1 dV x10.2 y10.2\n"
+                               "n13 v1 dV x10.2 y10.0\n"
+                               "n14 v1 dV x10.3 y10.0\n"
+                               "n15 v1 dV x10.4 y10.0\n"
+                               "w20 v1 dV Thighway=primary Nn10,n11,n12\n"
+                               "w21 v1 dV Thighway=secondary Nn12,n13\n"
+                               "w22 v1 dV Thighway=secondary Nn13,n14,n15\n"
+                               "r30 v1 dV Ttype=route,ref=Y11 Mw20@,w21@\n"
+                               "r31 v1 dV Ttype=route,ref=X11 Mw21@,w22@\n"));
+
+    auto conn = db.db().connect();
+
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_routes"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'primary'"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'secondary'"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'Y11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11,Y11'"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '20,21'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '21,22'"));
+
+    SECTION("new version of relation")
+    {
+        REQUIRE_NOTHROW(db.run_import(
+            options.append(), "r30 v2 dV Ttype=route,ref=Y11 Mw20@,w21@\n"));
+    }
+
+    SECTION("change way node list")
+    {
+        REQUIRE_NOTHROW(db.run_import(options.append(),
+                                      "w20 v2 dV Thighway=primary Nn10,n11\n"));
+    }
+
+    SECTION("change way tags")
+    {
+        REQUIRE_NOTHROW(db.run_import(
+            options.append(),
+            "w20 v2 dV Thighway=primary,name=foo Nn10,n11,n12\n"));
+    }
+
+    SECTION("change way node")
+    {
+        REQUIRE_NOTHROW(
+            db.run_import(options.append(), "n10 v2 dV x11.0 y10.0\n"));
+    }
+
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_routes"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'primary'"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'secondary'"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'Y11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11,Y11'"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '20,21'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '21,22'"));
+}
+
+TEST_CASE("relation data on ways: change relation (two rels)")
+{
+    testing::opt_t options = testing::opt_t()
+                                 .slim()
+                                 .flex("test_output_flex_extra.lua")
+                                 .srs(PROJ_LATLONG);
+
+    // create database with three ways and two relations on them
+    REQUIRE_NOTHROW(
+        db.run_import(options, "n10 v1 dV x10.0 y10.0\n"
+                               "n11 v1 dV x10.0 y10.2\n"
+                               "n12 v1 dV x10.2 y10.2\n"
+                               "n13 v1 dV x10.2 y10.0\n"
+                               "n14 v1 dV x10.3 y10.0\n"
+                               "n15 v1 dV x10.4 y10.0\n"
+                               "w20 v1 dV Thighway=primary Nn10,n11,n12\n"
+                               "w21 v1 dV Thighway=secondary Nn12,n13\n"
+                               "w22 v1 dV Thighway=secondary Nn13,n14,n15\n"
+                               "r30 v1 dV Ttype=route,ref=Y11 Mw20@,w21@\n"
+                               "r31 v1 dV Ttype=route,ref=X11 Mw21@,w22@\n"));
+
+    auto conn = db.db().connect();
+
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_routes"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'primary'"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'secondary'"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'Y11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11,Y11'"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '20,21'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '21,22'"));
+
+    REQUIRE_NOTHROW(db.run_import(
+        options.append(), "r30 v2 dV Ttype=route,ref=Z11 Mw20@,w21@\n"));
+
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_routes"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'primary'"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'secondary'"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'Z11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11,Z11'"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '20,21'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '21,22'"));
+}
+
+TEST_CASE("relation data on ways: change relation (three rels)")
+{
+    testing::opt_t options = testing::opt_t()
+                                 .slim()
+                                 .flex("test_output_flex_extra.lua")
+                                 .srs(PROJ_LATLONG);
+
+    // create database with three ways and two relations on them
+    REQUIRE_NOTHROW(
+        db.run_import(options, "n10 v1 dV x10.0 y10.0\n"
+                               "n11 v1 dV x10.0 y10.2\n"
+                               "n12 v1 dV x10.2 y10.2\n"
+                               "n13 v1 dV x10.2 y10.0\n"
+                               "n14 v1 dV x10.3 y10.0\n"
+                               "n15 v1 dV x10.4 y10.0\n"
+                               "w20 v1 dV Thighway=primary Nn10,n11,n12\n"
+                               "w21 v1 dV Thighway=secondary Nn12,n13\n"
+                               "w22 v1 dV Thighway=secondary Nn13,n14,n15\n"
+                               "r30 v1 dV Ttype=route,ref=Y11 Mw20@,w21@\n"
+                               "r31 v1 dV Ttype=route,ref=X11 Mw21@,w22@\n"
+                               "r32 v1 dV Ttype=route,ref=Z11 Mw22@\n"));
+
+    auto conn = db.db().connect();
+
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways"));
+    CHECK(3 == conn.get_count("osm2pgsql_test_routes"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'primary'"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'secondary'"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'Y11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11,Y11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11,Z11'"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '20,21'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '21,22'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '22'"));
+
+    SECTION("change way node list")
+    {
+        REQUIRE_NOTHROW(db.run_import(options.append(),
+                                      "w20 v2 dV Thighway=primary Nn10,n11\n"));
+    }
+
+    SECTION("change way tags")
+    {
+        REQUIRE_NOTHROW(db.run_import(
+            options.append(),
+            "w20 v2 dV Thighway=primary,name=foo Nn10,n11,n12\n"));
+    }
+
+    SECTION("change way node")
+    {
+        REQUIRE_NOTHROW(
+            db.run_import(options.append(), "n10 v2 dV x11.0 y10.0\n"));
+    }
+
+
+    CHECK(3 == conn.get_count("osm2pgsql_test_highways"));
+    CHECK(3 == conn.get_count("osm2pgsql_test_routes"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'primary'"));
+    CHECK(2 == conn.get_count("osm2pgsql_test_highways",
+                              "tags->'highway' = 'secondary'"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'Y11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11,Y11'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11,Z11'"));
+    CHECK(0 == conn.get_count("osm2pgsql_test_highways", "refs = 'X11'"));
+
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '20,21'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '21,22'"));
+    CHECK(1 == conn.get_count("osm2pgsql_test_routes", "members = '22'"));
+}


### PR DESCRIPTION
(This is a replacement for #1208.)

The multi-stage processing in the flex output has some problems when
updating data, for instance when relations are deleted after their
member ways use their tags.

This commit reorganizes how the multi-stage processing is done to
address these problems.

1. The way "marking" of objects is done is now different. Instead of
   doing this in the process_* Lua functions a new Lua function
   "mark_relation_members()" is introduced. This will be called not only
   for all new relations but also for deleted relations, or when a relation
   changed, for the old relation. This is needed so that we also mark and
   then re-create way entries in the database that used to depend on a
   parent relations tags, but don't do that any more. This function
   must return the way ids that need to be re-processed in stage 2.
2. We remove the Lua mark() function. Instead the return value of
   "mark_relation_members()" is used to mark way ids. Marking of nodes
   and relations isn't supported. It was never possible to mark nodes
   anyway. And there is no use case I am aware of currently that needs
   marking relations. Both can be reintroduced later when we have a
   better idea how to handle them. For the time being we concentrate on
   the important use case where member ways of relations are handled
   specially.
3. This introduces a new processing stage 1c:
    * stage 1a: Read input file and process all objects in it.
    * stage 1b: Process dependent objects of objects from 1a (ie
      changed nodes trigger changes in ways with those nodes, changes
      in all objects potentially trigger changes in parent relations).
    * stage 1c: Process dependent relations of objects marked during
      stage 1a/1b (this one is new).
    * stage 2: Process objects marked in stage 1a or 1b.
4. New Lua helper function osm2pgsql.way_member_ids() that returns
   the ids of all way members of the specified relation. This is often
   needed in mark_relation_members(). If you need more complex processing,
   for instance use the member roles to decide which ways need stage 2
   processing, you can still write your own loop.