### PR TITLE
Fix: Results of tasks run in thread pool were not checked

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ set(osm2pgsql_lib_SOURCES
   taginfo-impl.hpp
   taginfo.hpp
   tagtransform.hpp
+  thread-pool.hpp
   util.hpp
   wildcmp.hpp
   wkb.hpp

--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -586,7 +586,7 @@ void middle_pgsql_t::commit()
 
 void middle_pgsql_t::flush() { m_db_copy.sync(); }
 
-void middle_pgsql_t::stop(osmium::thread::Pool &pool)
+void middle_pgsql_t::stop(thread_pool_t &pool)
 {
     m_cache.reset();
     if (m_out_options->flat_node_cache_enabled) {

--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -58,7 +58,7 @@ struct middle_pgsql_t : public slim_middle_t
     middle_pgsql_t(options_t const *options);
 
     void start() override;
-    void stop(osmium::thread::Pool &pool) override;
+    void stop(thread_pool_t &pool) override;
     void analyze() override;
     void commit() override;
 

--- a/src/middle-ram.cpp
+++ b/src/middle-ram.cpp
@@ -110,7 +110,7 @@ bool middle_ram_t::relation_get(osmid_t id,
     return true;
 }
 
-void middle_ram_t::stop(osmium::thread::Pool &)
+void middle_ram_t::stop(thread_pool_t &)
 {
     m_cache.reset();
     m_ways.clear();

--- a/src/middle-ram.hpp
+++ b/src/middle-ram.hpp
@@ -95,7 +95,7 @@ struct middle_ram_t : public middle_t, public middle_query_t
     virtual ~middle_ram_t() noexcept = default;
 
     void start() override {}
-    void stop(osmium::thread::Pool &pool) override;
+    void stop(thread_pool_t &pool) override;
     void analyze() override {}
     void commit() override {}
 

--- a/src/middle.hpp
+++ b/src/middle.hpp
@@ -12,10 +12,9 @@
 #include <cstddef>
 #include <memory>
 
-#include <osmium/thread/pool.hpp>
-
 #include "osmtypes.hpp"
 #include "reprojection.hpp"
+#include "thread-pool.hpp"
 
 /**
  * Interface for returning information about raw OSM input data from a cache.
@@ -88,7 +87,7 @@ struct middle_t
     virtual ~middle_t() = 0;
 
     virtual void start() = 0;
-    virtual void stop(osmium::thread::Pool &pool) = 0;
+    virtual void stop(thread_pool_t &pool) = 0;
     virtual void analyze(void) = 0;
     virtual void commit(void) = 0;
 

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1092,7 +1092,7 @@ void output_flex_t::sync()
     }
 }
 
-void output_flex_t::stop(osmium::thread::Pool *pool)
+void output_flex_t::stop(thread_pool_t *pool)
 {
     for (auto &table : m_table_connections) {
         pool->submit([&]() {

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -112,7 +112,7 @@ public:
           std::shared_ptr<db_copy_thread_t> const &copy_thread) const override;
 
     void start() override;
-    void stop(osmium::thread::Pool *pool) override;
+    void stop(thread_pool_t *pool) override;
     void sync() override;
 
     void stage2_proc() override;

--- a/src/output-gazetteer.hpp
+++ b/src/output-gazetteer.hpp
@@ -42,7 +42,7 @@ public:
     }
 
     void start() override;
-    void stop(osmium::thread::Pool *) noexcept override {}
+    void stop(thread_pool_t *) noexcept override {}
     void sync() override;
 
     bool need_forward_dependencies() const noexcept override { return false; }

--- a/src/output-multi.cpp
+++ b/src/output-multi.cpp
@@ -85,7 +85,7 @@ void output_multi_t::pending_relation(osmid_t id)
     }
 }
 
-void output_multi_t::stop(osmium::thread::Pool *pool)
+void output_multi_t::stop(thread_pool_t *pool)
 {
     pool->submit([this]() {
         m_table->stop(m_options.slim & !m_options.droptemp,

--- a/src/output-multi.hpp
+++ b/src/output-multi.hpp
@@ -43,7 +43,7 @@ public:
           std::shared_ptr<db_copy_thread_t> const &copy_thread) const override;
 
     void start() override;
-    void stop(osmium::thread::Pool *pool) override;
+    void stop(thread_pool_t *pool) override;
     void sync() override;
 
     void pending_way(osmid_t id) override;

--- a/src/output-null.hpp
+++ b/src/output-null.hpp
@@ -18,7 +18,7 @@ public:
           std::shared_ptr<db_copy_thread_t> const &copy_thread) const override;
 
     void start() override {}
-    void stop(osmium::thread::Pool * /*pool*/) override {}
+    void stop(thread_pool_t * /*pool*/) override {}
     void sync() override {}
     void cleanup() {}
 

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -109,7 +109,7 @@ void output_pgsql_t::sync()
     }
 }
 
-void output_pgsql_t::stop(osmium::thread::Pool *pool)
+void output_pgsql_t::stop(thread_pool_t *pool)
 {
     // attempt to stop tables in parallel
     for (auto &t : m_tables) {

--- a/src/output-pgsql.hpp
+++ b/src/output-pgsql.hpp
@@ -43,7 +43,7 @@ public:
           std::shared_ptr<db_copy_thread_t> const &copy_thread) const override;
 
     void start() override;
-    void stop(osmium::thread::Pool *pool) override;
+    void stop(thread_pool_t *pool) override;
     void sync() override;
 
     void pending_way(osmid_t id) override;

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -10,9 +10,8 @@
  * Associated tags: name, type etc.
 */
 
-#include <osmium/thread/pool.hpp>
-
 #include "options.hpp"
+#include "thread-pool.hpp"
 
 struct middle_query_t;
 class db_copy_thread_t;
@@ -33,7 +32,7 @@ public:
           std::shared_ptr<db_copy_thread_t> const &copy_thread) const = 0;
 
     virtual void start() = 0;
-    virtual void stop(osmium::thread::Pool *pool) = 0;
+    virtual void stop(thread_pool_t *pool) = 0;
     virtual void sync() = 0;
 
     virtual void stage2_proc() {}

--- a/src/thread-pool.hpp
+++ b/src/thread-pool.hpp
@@ -17,7 +17,7 @@
 
 /**
  * This is a simple thread pool class. You can submit tasks using the submit()
- * function. Tasks can only return void. Use the check_results() function
+ * function. Tasks can only return void. Use the check_for_exceptions() function
  * before destructing the pool to make sure all functions finished without
  * throwing an exception.
  */

--- a/src/thread-pool.hpp
+++ b/src/thread-pool.hpp
@@ -1,0 +1,50 @@
+#ifndef OSM2PGSQL_THREAD_POOL_HPP
+#define OSM2PGSQL_THREAD_POOL_HPP
+
+/**
+ * \file
+ *
+ * This file is part of osm2pgsql (https://github.com/openstreetmap/osm2pgsql).
+ *
+ * Contains the class thread_pool_t.
+ */
+
+#include <osmium/thread/pool.hpp>
+
+#include <future>
+#include <utility>
+#include <vector>
+
+/**
+ * This is a simple thread pool class. You can submit tasks using the submit()
+ * function. Tasks can only return void. Use the check_results() function
+ * before destructing the pool to make sure all functions finished without
+ * throwing an exception.
+ */
+class thread_pool_t
+{
+public:
+    explicit thread_pool_t(int num_threads) : m_pool(num_threads, 512) {}
+
+    template <typename FUNC>
+    void submit(FUNC &&func)
+    {
+        m_results.push_back(m_pool.submit(std::forward<FUNC>(func)));
+    }
+
+    // This will throw if any of the tasks run in the thread pool did throw
+    // an exception.
+    void check_for_exceptions()
+    {
+        for (auto &&result : m_results) {
+            result.get();
+        }
+        m_results.clear();
+    }
+
+private:
+    osmium::thread::Pool m_pool;
+    std::vector<std::future<void>> m_results;
+};
+
+#endif // OSM2PGSQL_THREAD_POOL_HPP

--- a/tests/test-parse-osmium.cpp
+++ b/tests/test-parse-osmium.cpp
@@ -16,7 +16,7 @@ struct type_stats_t
 struct counting_slim_middle_t : public slim_middle_t
 {
     void start() override {}
-    void stop(osmium::thread::Pool &) override {}
+    void stop(thread_pool_t &) override {}
     void flush() override {}
     void cleanup() {}
     void analyze() override {}


### PR DESCRIPTION
If a function run in the thread pool throws an exception, this exception
was never "collected", it was silently ignored. This commit fixes this
by wrapping the osmium::thread::Pool class in a class of our own that
keeps track of the futures returned by submit() and allows checking
them.