### PR TITLE
Remove legacy calls from dependency manager

### DIFF
--- a/src/dependency-manager.cpp
+++ b/src/dependency-manager.cpp
@@ -25,20 +25,6 @@ void full_dependency_manager_t::way_changed(osmid_t id)
     }
 }
 
-void full_dependency_manager_t::relation_changed(osmid_t id)
-{
-    for (auto const rel_id : m_object_store->get_rels_by_rel(id)) {
-        m_rels_pending_tracker.mark(rel_id);
-    }
-}
-
-void full_dependency_manager_t::relation_deleted(osmid_t id)
-{
-    for (auto const rel_id : m_object_store->get_ways_by_rel(id)) {
-        m_ways_pending_tracker.mark(rel_id);
-    }
-}
-
 bool full_dependency_manager_t::has_pending() const noexcept
 {
     return !m_ways_pending_tracker.empty() || !m_rels_pending_tracker.empty();

--- a/src/dependency-manager.hpp
+++ b/src/dependency-manager.hpp
@@ -41,20 +41,6 @@ public:
      */
     virtual void way_changed(osmid_t) {}
 
-    /**
-     * Mark a relation as changed to trigger the propagation of this change to
-     * other relations.
-     *
-     * This has to be called *after* the object was stored in the object store.
-     */
-    virtual void relation_changed(osmid_t) {}
-
-    /**
-     * Mark a relation as deleted to trigger the propagation of this change to
-     * the way members.
-     */
-    virtual void relation_deleted(osmid_t) {}
-
     /// Are there pending objects that need to be processed?
     virtual bool has_pending() const noexcept { return false; }
 
@@ -97,8 +83,6 @@ public:
 
     void node_changed(osmid_t id) override;
     void way_changed(osmid_t id) override;
-    void relation_changed(osmid_t id) override;
-    void relation_deleted(osmid_t id) override;
 
     bool has_pending() const noexcept override;
 

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -124,8 +124,6 @@ void osmdata_t::relation_modify(osmium::Relation const &rel) const
     for (auto &out : m_outs) {
         out->relation_modify(rel);
     }
-
-    m_dependency_manager->relation_changed(rel.id());
 }
 
 void osmdata_t::node_delete(osmid_t id) const
@@ -153,8 +151,6 @@ void osmdata_t::relation_delete(osmid_t id) const
     }
 
     slim_middle().relation_delete(id);
-
-    m_dependency_manager->relation_deleted(id);
 }
 
 void osmdata_t::start() const

--- a/tests/data/test_output_flex_stage2_alt.lua
+++ b/tests/data/test_output_flex_stage2_alt.lua
@@ -1,0 +1,78 @@
+
+local tables = {}
+
+tables.highways = osm2pgsql.define_table{
+    name = 'osm2pgsql_test_highways',
+    ids = { type = 'way', id_column = 'way_id' },
+    columns = {
+        { column = 'tags',  type = 'hstore' },
+        { column = 'refs',  type = 'text' },
+        { column = 'geom',  type = 'linestring' },
+    }
+}
+
+tables.routes = osm2pgsql.define_table{
+    name = 'osm2pgsql_test_routes',
+    ids = { type = 'relation', id_column = 'rel_id' },
+    columns = {
+        { column = 'tags',    type = 'hstore' },
+        { column = 'members', type = 'text' },
+        { column = 'geom',    type = 'multilinestring' },
+    }
+}
+
+local w2r = {}
+
+function osm2pgsql.process_way(object)
+    if osm2pgsql.stage == 1 then
+        return
+    end
+
+    local row = {
+        tags = object.tags,
+        geom = { create = 'line' }
+    }
+
+    local d = w2r[object.id]
+    if d then
+        local refs = {}
+        for rel_id, rel_ref in pairs(d) do
+            refs[#refs + 1] = rel_ref
+        end
+        table.sort(refs)
+
+        row.refs = table.concat(refs, ',')
+    end
+
+    tables.highways:add_row(row)
+end
+
+function osm2pgsql.select_relation_members(relation)
+    if relation.tags.type == 'route' then
+        return { ways = osm2pgsql.way_member_ids(relation) }
+    end
+end
+
+function osm2pgsql.process_relation(object)
+    if object.tags.type ~= 'route' then
+        return
+    end
+
+    local mlist = {}
+    for _, member in ipairs(object.members) do
+        if member.type == 'w' then
+            if not w2r[member.ref] then
+                w2r[member.ref] = {}
+            end
+            w2r[member.ref][object.id] = object.tags.ref
+            mlist[#mlist + 1] = member.ref
+        end
+    end
+
+    tables.routes:add_row({
+        tags = object.tags,
+        members = table.concat(mlist, ','),
+        geom = { create = 'line' }
+    })
+end
+

--- a/tests/test-parse-osmium.cpp
+++ b/tests/test-parse-osmium.cpp
@@ -95,7 +95,6 @@ struct counting_output_t : public output_null_t
 struct counts_t {
     std::size_t nodes_changed = 0;
     std::size_t ways_changed = 0;
-    std::size_t relations_changed = 0;
 };
 
 /**
@@ -111,7 +110,6 @@ public:
 
     void node_changed(osmid_t) override { ++m_counts->nodes_changed; }
     void way_changed(osmid_t) override { ++m_counts->ways_changed; }
-    void relation_changed(osmid_t) override { ++m_counts->relations_changed; }
 
 private:
     std::shared_ptr<counts_t> m_counts;
@@ -155,7 +153,6 @@ TEST_CASE("parse xml file")
 
     REQUIRE(counts->nodes_changed == 0);
     REQUIRE(counts->ways_changed == 0);
-    REQUIRE(counts->relations_changed == 0);
 }
 
 TEST_CASE("parse diff file")
@@ -193,7 +190,6 @@ TEST_CASE("parse diff file")
 
     REQUIRE(counts->nodes_changed == 1176);
     REQUIRE(counts->ways_changed == 161);
-    REQUIRE(counts->relations_changed == 11);
 }
 
 TEST_CASE("parse xml file with extra args")
@@ -235,5 +231,4 @@ TEST_CASE("parse xml file with extra args")
 
     REQUIRE(counts->nodes_changed == 0);
     REQUIRE(counts->ways_changed == 0);
-    REQUIRE(counts->relations_changed == 0);
 }


### PR DESCRIPTION
These were needed for old-style multipolygons but are not needed any more.