### PR TITLE
Check for negative object ids in input files and output a warning

### DIFF
--- a/src/input-handler.hpp
+++ b/src/input-handler.hpp
@@ -36,6 +36,8 @@ public:
     progress_display_t const &progress() const noexcept { return m_progress; }
 
 private:
+    void negative_id_warning();
+
     osmdata_t const *m_data;
 
     // Bounding box for node import (or invalid Box if everything should be
@@ -50,6 +52,9 @@ private:
 
     // Are we running in append mode?
     bool m_append;
+
+    // Has a warning about a negative id already been issued?
+    bool m_issued_warning_negative_id = false;
 };
 
 #endif // OSM2PGSQL_INPUT_HANDLER_HPP


### PR DESCRIPTION
Negative ids for OSM objects never worked correctly in all cases and
will not be supported in future versions of osm2pgsql.

See #1097

@pnorman Can you please review?