### PR TITLE
Disable PostgreSQL JIT and parallel workers in middle

### DIFF
--- a/src/pgsql.cpp
+++ b/src/pgsql.cpp
@@ -41,6 +41,17 @@ pg_result_t pg_conn_t::query(ExecStatusType expect,
     return query(expect, sql.c_str());
 }
 
+void pg_conn_t::set_config(char const *setting, char const *value) const
+{
+    // Update pg_settings instead of using SET because it does not yield
+    // errors on older versions of PostgreSQL where the settings are not
+    // implemented.
+    auto const sql =
+        "UPDATE pg_settings SET setting = '{}' WHERE name = '{}'"_format(
+            setting, value);
+    query(PGRES_TUPLES_OK, sql);
+}
+
 void pg_conn_t::exec(char const *sql) const { query(PGRES_COMMAND_OK, sql); }
 
 void pg_conn_t::exec(std::string const &sql) const

--- a/src/pgsql.hpp
+++ b/src/pgsql.hpp
@@ -123,6 +123,8 @@ public:
 
     pg_result_t query(ExecStatusType expect, std::string const &sql) const;
 
+    void set_config(char const *setting, char const *value) const;
+
     void exec(char const *sql) const;
 
     void exec(std::string const &sql) const;


### PR DESCRIPTION
They are known to have problems with the int arrays.

See #1045