### PR TITLE
CI: move OSX build to Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on: [ push ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install prerequisits
+        run: |
+          brew install lua boost postgis
+          pip3 install psycopg2
+        shell: bash
+
+      - name: Setup database
+        run: |
+          pg_ctl -D /usr/local/var/postgres start
+          psql -d postgres -c 'CREATE EXTENSION postgis'
+          psql -d postgres -c 'CREATE EXTENSION hstore'
+          psql -d postgres -c 'SELECT PostGIS_Full_Version()'
+          mkdir -m 700 $GITHUB_WORKSPACE/tablespacetest
+          psql -d postgres -c "CREATE TABLESPACE tablespacetest LOCATION '$GITHUB_WORKSPACE/tablespacetest'"
+        shell: bash
+
+      - name: configure
+        run: mkdir build && cd build && cmake -LA -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=11 -DWITH_LUA=ON ..
+        shell: bash
+
+      - name: build
+        run: cd build && make -j2
+        shell: bash
+
+      - name: test
+        run: cd build && ctest --output-on-failure
+        shell: bash
+        env:
+          PGHOST: /tmp
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,18 +58,6 @@ matrix:
            CXXFLAGS="-pedantic -Wextra -Werror"
            CC=clang-7 CXX=clang++-7 CPPVERSION=14
 
-  # ---- OSX + CLANG ---------------------------
-  #  - os: osx
-  #    compiler: clang
-  #    env: T="osx_clang_NoDB"
-  #         BUILD_TYPE="Debug" LUAJIT_OPTION="OFF" TEST_NODB=1
-  #         CXXFLAGS="-pedantic -Wextra -Werror" CPPVERSION=11
-  #    before_install:
-  #      - brew install lua; brew install lua
-  #    before_script:
-  #      - proj | head -n1
-  #      - lua -v
-
   # ---- Linux + GCC ---------------------------
     - os: linux
       dist: xenial


### PR DESCRIPTION
This resurrects the OXS builds on Github Actions. This even has a Postgresql database installed, so that we can now run the full suite of tests. 

For a successful CI run, see https://github.com/lonvia/osm2pgsql/actions/runs/192937489

Fixes #1035.