### PR TITLE
Way node index using shifted node ids

### DIFF
--- a/docs/bucket-index.md
+++ b/docs/bucket-index.md
@@ -1,0 +1,88 @@
+
+NOTE: This is only available from osm2pgsql version 1.4.0!
+
+NOTE: The default is still to create the old index for now.
+
+# Bucket index for slim mode
+
+Osm2pgsql can use an index for way node lookups in slim mode that needs a lot
+less disk space than earlier versions did. For a planet the savings can be
+about 200 GB! Lookup times are slightly slower, but this shouldn't be an issue
+for most people.
+
+*If you are not using slim mode and/or not doing updates of your database, this
+does not apply to you.*
+
+For backwards compatibility osm2pgsql will never update an existing database
+to the new index. It will keep using the old index. So you do not have to do
+anything when upgrading osm2pgsql.
+
+If you want to use the new index, there are two ways of doing this: The "safe"
+way for most users and the "doit-it-yourself" way for expert users. Note that
+once you switched to the new index, older versions of osm2pgsql will not work
+correctly any more.
+
+## Update for most users
+
+NOTE: This does not work yet. Currently the default is still to create the
+old type of index.
+
+If your database was created with an older version of osm2pgsql you might want
+to start again from an empty database. Just do a reimport and osm2pgsql will
+use the new space-saving index.
+
+## Update for expert users
+
+This is only for users who are very familiar with osm2pgsql and PostgreSQL
+operation. You can break your osm2pgsql database beyond repair if something
+goes wrong here and you might not even notice.
+
+You can create the index yourself by following these steps:
+
+Drop the existing index. Replace `{prefix}` by the prefix you are using.
+Usually this is `planet_osm`:
+
+```
+DROP INDEX {prefix}_ways_nodes_idx;
+```
+
+Create the `index_bucket` function needed for the index. Replace
+`{way_node_index_id_shift}` by the number of bits you want the id to be
+shifted. If you don't have a reason to use something else, use `5`:
+
+```
+CREATE FUNCTION {prefix}_index_bucket(int8[]) RETURNS int8[] AS $$
+  SELECT ARRAY(SELECT DISTINCT unnest($1) >> {way_node_index_id_shift})
+$$ LANGUAGE SQL IMMUTABLE;
+```
+
+Now you can create the new index. Again, replace `{prefix}` by the prefix
+you are using:
+
+```
+CREATE INDEX {prefix}_ways_nodes_bucket_idx ON {prefix}_ways
+  USING GIN ({prefix}_index_bucket(nodes))
+  WITH (fastupdate = off);
+```
+
+If you want to create the index in a specific tablespace you can do this:
+
+```
+CREATE INDEX {prefix}_ways_nodes_bucket_idx ON {prefix}_ways
+  USING GIN ({prefix}_index_bucket(nodes))
+  WITH (fastupdate = off) TABLESPACE {tablespace};
+```
+
+## Id shift (for experts)
+
+When creating a new database (when used in create mode with slim option),
+osm2pgsql can create a bucket index using a configurable id shift.
+
+You can set the shift with the command line option
+`--middle-way-node-index-id-shift`. Values between about 3 and 6 might make
+sense.
+
+To completely disable the bucket index and create an index compatible with
+earlier versions of osm2pgsql, use `--middle-way-node-index-id-shift=0`.
+(This is currently still the default.)
+

--- a/docs/osm2pgsql.md
+++ b/docs/osm2pgsql.md
@@ -220,6 +220,10 @@ starting with two dashes (`--`). A summary of options is included below.
 -v, \--verbose
 :   Verbose output.
 
+--middle-way-node-index-id-shift shift
+:   Set ID shift for way node bucket index in middle. Experts only. See
+    documentation for details.
+
 
 # SUPPORTED PROJECTIONS
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -58,6 +58,7 @@ const struct option long_options[] = {
     {"keep-coastlines", no_argument, nullptr, 'K'},
     {"latlong", no_argument, nullptr, 'l'},
     {"merc", no_argument, nullptr, 'm'},
+    {"middle-way-node-index-id-shift", required_argument, nullptr, 300},
     {"multi-geometry", no_argument, nullptr, 'G'},
     {"number-processes", required_argument, nullptr, 205},
     {"output", required_argument, nullptr, 'O'},
@@ -181,6 +182,10 @@ void long_usage(char const *arg0, bool verbose)
                         The default is \"sparse\"\n");
 #endif
         printf("%s", "\
+    \n\
+    Middle options (experts only):\n\
+          --middle-way-node-index-id-shift shift  Set ID shift for bucket\
+                             index. See documentation for details.\
     \n\
     Expiry options:\n\
        -e|--expire-tiles [min_zoom-]max_zoom    Create a tile expiry list.\n\
@@ -566,6 +571,9 @@ options_t::options_t(int argc, char *argv[]) : options_t()
 #endif
             fprintf(stderr, "\n");
             exit(EXIT_SUCCESS);
+            break;
+        case 300:
+            way_node_index_id_shift = atoi(optarg);
             break;
         case '?':
         default:

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -130,6 +130,14 @@ public:
 
     std::vector<std::string> input_files;
 
+    /**
+     * How many bits should the node id be shifted for the way node index?
+     * Use 0 to disable for backwards compatibility.
+     * Currently the default is 0, making osm2pgsql backwards compatible to
+     * earlier versions.
+     */
+    uint8_t way_node_index_id_shift = 0;
+
 private:
     /**
      * Check input options for sanity


### PR DESCRIPTION
OSM ways have a locality property that we can use to reduce the size of
the index looking up ways a node is in: they are often made up of
sequential node ids. If node N is contained in the way, then there is a
good chance that N+1, N+2, ... are contained in it as well. Thus, if we
group nearby nodes and create an index from node groups to ways, the
index will be significantly smaller. The drawback is that a lookup in
such an index returns false positives, i.e. ways that do not contain the
node of interest. So the smaller index is paid for with a performance
loss for updates.

"Grouping" the ids happens by shifting the id a few bits to the right.
How many exactly can be configured with the
OSM2PGSQL_WAY_NODE_INDEX_ID_SHIFT environment variable.

This commit sets the default shift for the node ids to 0, i.e. no shift,
so it is completely backwards compatible. Users can set a different
shift using the environment. See docs/bucket-index.md for details.

Setting the shift to something like 4 or 5 can significantly reduce the
disk space needed (saves something like 200 GB on a full planet), but
it costs some performance on updates (they are about 30% slower).

This is an improved version of
https://github.com/openstreetmap/osm2pgsql/pull/1058