### PR TITLE
Make test-output-flex-validgeom use its own config file

### DIFF
--- a/tests/data/test_output_flex_validgeom.lua
+++ b/tests/data/test_output_flex_validgeom.lua
@@ -1,0 +1,29 @@
+
+local polygons = osm2pgsql.define_table{
+    name = 'osm2pgsql_test_polygon',
+    ids = { type = 'area', id_column = 'osm_id' },
+    columns = {
+        { column = 'geom', type = 'geometry' },
+    }
+}
+
+function is_empty(some_table)
+    return next(some_table) == nil
+end
+
+function osm2pgsql.process_way(object)
+    if is_empty(object.tags) then
+        return
+    end
+
+    polygons:add_row({
+        geom = { create = 'area' }
+    })
+end
+
+function osm2pgsql.process_relation(object)
+    polygons:add_row({
+        geom = { create = 'area', multi = false }
+    })
+end
+

--- a/tests/test-output-flex-validgeom.cpp
+++ b/tests/test-output-flex-validgeom.cpp
@@ -5,7 +5,7 @@
 
 static testing::db::import_t db;
 
-static char const *const conf_file = "test_output_flex_area.lua";
+static char const *const conf_file = "test_output_flex_validgeom.lua";
 static char const *const data_file = "test_output_pgsql_validgeom.osm";
 
 TEST_CASE("no invalid geometries should end up in the database")


### PR DESCRIPTION
Instead of reusing the one from the area test.