### PR TITLE
Set projection in flex output in column config

### DIFF
--- a/docs/flex.md
+++ b/docs/flex.md
@@ -19,8 +19,6 @@ All configuration is done through the `osm2pgsql` object in Lua. It has the
 following fields:
 
 * `osm2pgsql.version`: The version of osm2pgsql as a string.
-* `osm2pgsql.srid`: The SRID set on the command line (with `-l|--latlong`,
-  `-m|--merc`, or `-E|--proj`).
 * `osm2pgsql.mode`: Either `"create"` or `"append"` depending on the command
   line options (`--create` or `-a|--append`).
 * `osm2pgsql.stage`: Either `1` or `2` (1st/2nd stage processing of the data).
@@ -104,8 +102,18 @@ The supported geometry types are:
 * `geometry`: Any kind of geometry. Also used for area tables that should hold
   both polygon and multipolygon geometries.
 
-A column of type `area` will be filled automatically with the area of the
-geometry. This will only work for (multi)polygons.
+By default geometry columns will be created in web mercator (EPSG 3857). To
+change this, set the `projection` parameter of the column to the EPSG code
+you want (or one of the strings `latlon(g)`, `WGS84`, or 'merc(ator)', case
+is ignored).
+
+There is one special geometry column type called `area`. It can be used in
+addition to a `polygon` or `multipolygon` column. Unlike the normal geometry
+column types, the resulting database type will not be a geometry type, but
+`real`. It will be filled automatically with the area of the geometry. The area
+will be calculated in web mercator, or you can set the `projection` parameter
+of the column to `4326` to calculate it with WGS84 coordinates. Other
+projections are currently not supported.
 
 In addition to id and geometry columns, each table can have any number of
 "normal" columns using any type supported by PostgreSQL. Some types are
@@ -343,6 +351,11 @@ flex backend, because they don't make sense in that context:
   flex backend.)
 * `--tag-transform-script` (Set the Lua config file with the `-S|--style`
   option.)
+* `-l|--latlong` (Set `projection = 'latlong'` on geometry columns instead.)
+* `-m|--merc` (This is the default for all geometry columns.)
+* `-E|--proj NUM` (Set `projection = NUM` on geometry columns instead.)
+* `--reproject-area` (This is the default, set `projection = 4326` on the area
+  column to calculate the area using WGS84 coordinates.)
 * `-G|--multi-geometry` (Use the `multi` option on the geometry transformation
   instead, see the "Geometry transformation" section above for details.)
 * The command line options to set the tablespace (`-i|--tablespace-index`,

--- a/flex-config/compatible.lua
+++ b/flex-config/compatible.lua
@@ -3,6 +3,11 @@
 -- original pgsql c-transform backend. There might be some corner cases but
 -- it should mostly do exactly the same.
 
+-- The output projection used (3857, web mercator is the default). Set this
+-- to 'latlong' if you were using the -l|--latlong option or to the EPSG
+-- code you were using on the -E|-proj option.
+local srid = 3857
+
 -- Set this to true if you were using option -K|--keep-coastlines.
 local keep_coastlines = false
 
@@ -44,7 +49,7 @@ if hstore and hstore_all then
 end
 
 -- Used for splitting up long linestrings
-if osm2pgsql.srid == 4326 then
+if srid == 4326 then
     max_length = 1
 else
     max_length = 100000

--- a/src/flex-table-column.hpp
+++ b/src/flex-table-column.hpp
@@ -2,6 +2,7 @@
 #define OSM2PGSQL_FLEX_TABLE_COLUMN_HPP
 
 #include "format.hpp"
+#include "reprojection.hpp"
 
 #include <cstdint>
 #include <string>
@@ -85,9 +86,13 @@ public:
 
     void set_create_only(bool value = true) noexcept { m_create_only = value; }
 
-    std::string sql_type_name(int srid) const;
+    void set_projection(char const *projection);
+
+    std::string sql_type_name() const;
     std::string sql_modifiers() const;
-    std::string sql_create(int srid) const;
+    std::string sql_create() const;
+
+    int srid() const noexcept { return m_srid; }
 
 private:
     /// The name of the database table column.
@@ -104,6 +109,12 @@ private:
      * in which case m_type_name is the SQL type used in the database.
      */
     table_column_type m_type;
+
+    /**
+     * For geometry and area columns only: The projection SRID. Default is
+     * web mercator.
+     */
+    int m_srid = 3857;
 
     /// NOT NULL constraint
     bool m_not_null = false;

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -177,16 +177,19 @@ private:
                       flex_table_column_t const &column);
     void write_row(table_connection_t *table_connection,
                    osmium::item_type id_type, osmid_t id,
-                   std::string const &geom);
+                   std::string const &geom, int srid);
 
     geom::osmium_builder_t::wkbs_t
-    run_transform(geom_transform_t const *transform, osmium::Node const &node);
+    run_transform(geom::osmium_builder_t *builder,
+                  geom_transform_t const *transform, osmium::Node const &node);
 
     geom::osmium_builder_t::wkbs_t
-    run_transform(geom_transform_t const *transform, osmium::Way const &way);
+    run_transform(geom::osmium_builder_t *builder,
+                  geom_transform_t const *transform, osmium::Way const &way);
 
     geom::osmium_builder_t::wkbs_t
-    run_transform(geom_transform_t const *transform,
+    run_transform(geom::osmium_builder_t *builder,
+                  geom_transform_t const *transform,
                   osmium::Relation const &relation);
 
     template <typename OBJECT>
@@ -213,7 +216,6 @@ private:
     // accessed while protected using the lua_mutex.
     std::shared_ptr<lua_State> m_lua_state;
 
-    geom::osmium_builder_t m_builder;
     expire_tiles m_expire;
 
     osmium::memory::Buffer m_buffer;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,8 @@ function(set_test test_name)
     target_link_libraries(${test_name} osm2pgsql_lib catch_main_lib)
     add_test(NAME ${test_name} COMMAND ${test_name})
 
-    set_tests_properties(${test_name} PROPERTIES TIMEOUT ${TESTING_TIMEOUT})
+    set_tests_properties(${test_name} PROPERTIES TIMEOUT ${TESTING_TIMEOUT}
+                                                 ENVIRONMENT SRCPATH=${CMAKE_CURRENT_SOURCE_DIR})
 
     if (DEFINED test_param_LABELS)
         list(FIND test_param_LABELS Tablespace test_num_labels)

--- a/tests/data/test_output_flex_area.lua
+++ b/tests/data/test_output_flex_area.lua
@@ -4,8 +4,8 @@ local polygons = osm2pgsql.define_table{
     ids = { type = 'area', id_column = 'osm_id' },
     columns = {
         { column = 'name', type = 'text' },
-        { column = 'geom', type = 'geometry' },
-        { column = 'area', type = 'area' },
+        { column = 'geom', type = 'geometry', projection = test.geom_proj },
+        { column = 'area', type = 'area', projection = test.area_proj },
     }
 }
 

--- a/tests/data/test_output_flex_area_3857.lua
+++ b/tests/data/test_output_flex_area_3857.lua
@@ -1,0 +1,5 @@
+
+test = { geom_proj = 3857, area_proj = 3857 }
+
+dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_area.lua')
+

--- a/tests/data/test_output_flex_area_4326.lua
+++ b/tests/data/test_output_flex_area_4326.lua
@@ -1,0 +1,5 @@
+
+test = { geom_proj = 4326, area_proj = 4326 }
+
+dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_area.lua')
+

--- a/tests/data/test_output_flex_area_mix.lua
+++ b/tests/data/test_output_flex_area_mix.lua
@@ -1,0 +1,5 @@
+
+test = { geom_proj = 'latlong', area_proj = 'merc' }
+
+dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_area.lua')
+

--- a/tests/data/test_output_flex_bbox.lua
+++ b/tests/data/test_output_flex_bbox.lua
@@ -5,7 +5,7 @@ local points = osm2pgsql.define_node_table('osm2pgsql_test_points', {
     { column = 'min_y', type = 'real' },
     { column = 'max_x', type = 'real' },
     { column = 'max_y', type = 'real' },
-    { column = 'geom',  type = 'point' },
+    { column = 'geom',  type = 'point', projection = 4326 },
 })
 
 local highways = osm2pgsql.define_way_table('osm2pgsql_test_highways', {
@@ -14,7 +14,7 @@ local highways = osm2pgsql.define_way_table('osm2pgsql_test_highways', {
     { column = 'min_y', type = 'real' },
     { column = 'max_x', type = 'real' },
     { column = 'max_y', type = 'real' },
-    { column = 'geom',  type = 'linestring' },
+    { column = 'geom',  type = 'linestring', projection = 4326 },
 })
 
 function osm2pgsql.process_node(object)

--- a/tests/data/test_output_flex_invalid_geom.lua
+++ b/tests/data/test_output_flex_invalid_geom.lua
@@ -6,7 +6,7 @@ tables.line = osm2pgsql.define_table{
     ids = { type = 'way', id_column = 'osm_id' },
     columns = {
         { column = 'tags', type = 'hstore' },
-        { column = 'geom', type = 'linestring' },
+        { column = 'geom', type = 'linestring', projection = 4326 },
     }
 }
 
@@ -15,7 +15,7 @@ tables.polygon = osm2pgsql.define_table{
     ids = { type = 'area', id_column = 'osm_id' },
     columns = {
         { column = 'tags', type = 'hstore' },
-        { column = 'geom', type = 'geometry' }
+        { column = 'geom', type = 'geometry', projection = 4326 }
     }
 }
 

--- a/tests/data/test_output_flex_line.lua
+++ b/tests/data/test_output_flex_line.lua
@@ -3,12 +3,12 @@ local tables = {}
 
 tables.line = osm2pgsql.define_way_table('osm2pgsql_test_line', {
     { column = 'tags', type = 'hstore' },
-    { column = 'geom', type = 'linestring' }
+    { column = 'geom', type = 'linestring', projection = 4326 }
 })
 
 tables.split = osm2pgsql.define_way_table('osm2pgsql_test_split', {
     { column = 'tags', type = 'hstore' },
-    { column = 'geom', type = 'linestring' }
+    { column = 'geom', type = 'linestring', projection = 4326 }
 })
 
 function osm2pgsql.process_way(object)

--- a/tests/data/test_output_flex_stage2.lua
+++ b/tests/data/test_output_flex_stage2.lua
@@ -7,7 +7,7 @@ tables.highways = osm2pgsql.define_table{
     columns = {
         { column = 'tags',  type = 'hstore' },
         { column = 'refs',  type = 'text' },
-        { column = 'geom',  type = 'linestring' },
+        { column = 'geom',  type = 'linestring', projection = 4326 },
     }
 }
 
@@ -17,7 +17,7 @@ tables.routes = osm2pgsql.define_table{
     columns = {
         { column = 'tags',    type = 'hstore' },
         { column = 'members', type = 'text' },
-        { column = 'geom',    type = 'multilinestring' },
+        { column = 'geom',    type = 'multilinestring', projection = 4326 },
     }
 }
 

--- a/tests/test-output-flex-area.cpp
+++ b/tests/test-output-flex-area.cpp
@@ -5,12 +5,14 @@
 
 static testing::db::import_t db;
 
-static char const *const conf_file = "test_output_flex_area.lua";
+static char const *const conf_file_3857 = "test_output_flex_area_3857.lua";
+static char const *const conf_file_4326 = "test_output_flex_area_4326.lua";
+static char const *const conf_file_mix = "test_output_flex_area_mix.lua";
 static char const *const data_file = "test_output_pgsql_area.osm";
 
 TEST_CASE("area calculation in default projection")
 {
-    options_t const options = testing::opt_t().flex(conf_file);
+    options_t const options = testing::opt_t().flex(conf_file_3857);
 
     REQUIRE_NOTHROW(db.run_file(options, data_file));
 
@@ -37,8 +39,7 @@ TEST_CASE("area calculation in default projection")
 
 TEST_CASE("area calculation in latlon projection")
 {
-    options_t const options =
-        testing::opt_t().flex(conf_file).srs(PROJ_LATLONG);
+    options_t const options = testing::opt_t().flex(conf_file_4326);
 
     REQUIRE_NOTHROW(db.run_file(options, data_file));
 
@@ -59,8 +60,7 @@ TEST_CASE("area calculation in latlon projection")
 
 TEST_CASE("area calculation in latlon projection with way area reprojection")
 {
-    options_t options = testing::opt_t().flex(conf_file).srs(PROJ_LATLONG);
-    options.reproject_area = true;
+    options_t options = testing::opt_t().flex(conf_file_mix);
 
     REQUIRE_NOTHROW(db.run_file(options, data_file));
 

--- a/tests/test-output-flex-bbox.cpp
+++ b/tests/test-output-flex-bbox.cpp
@@ -9,8 +9,7 @@ static char const *const conf_file = "test_output_flex_bbox.lua";
 
 TEST_CASE("bbox on nodes and ways in 4326")
 {
-    options_t const options =
-        testing::opt_t().flex(conf_file).srs(PROJ_LATLONG);
+    options_t const options = testing::opt_t().flex(conf_file);
 
     REQUIRE_NOTHROW(db.run_import(options,
                                   "n10 v1 dV Ta=b x10.0 y10.0\n"

--- a/tests/test-output-flex-invalid-geom.cpp
+++ b/tests/test-output-flex-invalid-geom.cpp
@@ -9,8 +9,7 @@ static char const *const conf_file = "test_output_flex_invalid_geom.lua";
 
 TEST_CASE("invalid way geometry should be ignored")
 {
-    options_t const options =
-        testing::opt_t().flex(conf_file).srs(PROJ_LATLONG);
+    options_t const options = testing::opt_t().flex(conf_file);
 
     REQUIRE_NOTHROW(db.run_import(
         options,
@@ -33,8 +32,7 @@ TEST_CASE("invalid way geometry should be ignored")
 
 TEST_CASE("invalid area geometry from way should be ignored")
 {
-    options_t const options =
-        testing::opt_t().flex(conf_file).srs(PROJ_LATLONG);
+    options_t const options = testing::opt_t().flex(conf_file);
 
     REQUIRE_NOTHROW(db.run_import(
         options,
@@ -54,8 +52,7 @@ TEST_CASE("invalid area geometry from way should be ignored")
 
 TEST_CASE("area with self-intersection from way should be ignored")
 {
-    options_t const options =
-        testing::opt_t().flex(conf_file).srs(PROJ_LATLONG);
+    options_t const options = testing::opt_t().flex(conf_file);
 
     REQUIRE_NOTHROW(db.run_import(
         options, "n10 v1 dV x1.70 y1.78\n"
@@ -72,8 +69,7 @@ TEST_CASE("area with self-intersection from way should be ignored")
 
 TEST_CASE("invalid area geometry from relation should be ignored")
 {
-    options_t const options =
-        testing::opt_t().flex(conf_file).srs(PROJ_LATLONG);
+    options_t const options = testing::opt_t().flex(conf_file);
 
     REQUIRE_NOTHROW(db.run_import(options,
                                   "n10 v1 dV x10.0 y10.0\n"

--- a/tests/test-output-flex-line.cpp
+++ b/tests/test-output-flex-line.cpp
@@ -9,8 +9,7 @@ static char const *const conf_file = "test_output_flex_line.lua";
 
 TEST_CASE("linestring in latlon projection (unsplit and split)")
 {
-    options_t const options =
-        testing::opt_t().flex(conf_file).srs(PROJ_LATLONG);
+    options_t const options = testing::opt_t().flex(conf_file);
 
     REQUIRE_NOTHROW(db.run_import(options,
                                   "n10 v1 dV x1.0 y1.0\n"

--- a/tests/test-output-flex-nogeom.cpp
+++ b/tests/test-output-flex-nogeom.cpp
@@ -9,8 +9,7 @@ static char const *const conf_file = "test_output_flex_nogeom.lua";
 
 TEST_CASE("updating table without geometry should work")
 {
-    options_t options =
-        testing::opt_t().slim().flex(conf_file).srs(PROJ_LATLONG);
+    options_t options = testing::opt_t().slim().flex(conf_file);
 
     REQUIRE_NOTHROW(db.run_import(options,
                                   "n10 v1 dV Tamenity=restaurant x10.0 y10.0\n"

--- a/tests/test-output-flex-stage2.cpp
+++ b/tests/test-output-flex-stage2.cpp
@@ -9,8 +9,7 @@ static char const *const conf_file = "test_output_flex_stage2.lua";
 
 TEST_CASE("nodes and ways")
 {
-    options_t options =
-        testing::opt_t().slim().flex(conf_file).srs(PROJ_LATLONG);
+    options_t options = testing::opt_t().slim().flex(conf_file);
 
     REQUIRE_NOTHROW(db.run_import(options,
                                   "n10 v1 dV x10.0 y10.0\n"
@@ -88,8 +87,7 @@ TEST_CASE("nodes and ways")
 
 TEST_CASE("relation data on ways")
 {
-    options_t options =
-        testing::opt_t().slim().flex(conf_file).srs(PROJ_LATLONG);
+    options_t options = testing::opt_t().slim().flex(conf_file);
 
     // create database with three ways and a relation on two of them
     REQUIRE_NOTHROW(
@@ -187,8 +185,7 @@ TEST_CASE("relation data on ways")
 
 TEST_CASE("relation data on ways: delete or re-tag relation")
 {
-    options_t options =
-        testing::opt_t().slim().flex(conf_file).srs(PROJ_LATLONG);
+    options_t options = testing::opt_t().slim().flex(conf_file);
 
     // create database with three ways and a relation on two of them
     REQUIRE_NOTHROW(
@@ -247,8 +244,7 @@ TEST_CASE("relation data on ways: delete or re-tag relation")
 
 TEST_CASE("relation data on ways: delete way in other relation")
 {
-    options_t options =
-        testing::opt_t().slim().flex(conf_file).srs(PROJ_LATLONG);
+    options_t options = testing::opt_t().slim().flex(conf_file);
 
     // create database with three ways and two relations on them
     REQUIRE_NOTHROW(
@@ -317,8 +313,7 @@ TEST_CASE("relation data on ways: delete way in other relation")
 TEST_CASE("relation data on ways: changing things in one relation should not "
           "change output")
 {
-    options_t options =
-        testing::opt_t().slim().flex(conf_file).srs(PROJ_LATLONG);
+    options_t options = testing::opt_t().slim().flex(conf_file);
 
     // create database with three ways and two relations on them
     REQUIRE_NOTHROW(
@@ -394,8 +389,7 @@ TEST_CASE("relation data on ways: changing things in one relation should not "
 
 TEST_CASE("relation data on ways: change relation (two rels)")
 {
-    options_t options =
-        testing::opt_t().slim().flex(conf_file).srs(PROJ_LATLONG);
+    options_t options = testing::opt_t().slim().flex(conf_file);
 
     // create database with three ways and two relations on them
     REQUIRE_NOTHROW(
@@ -451,8 +445,7 @@ TEST_CASE("relation data on ways: change relation (two rels)")
 
 TEST_CASE("relation data on ways: change relation (three rels)")
 {
-    options_t options =
-        testing::opt_t().slim().flex(conf_file).srs(PROJ_LATLONG);
+    options_t options = testing::opt_t().slim().flex(conf_file);
 
     // create database with three ways and two relations on them
     REQUIRE_NOTHROW(db.run_import(options,
@@ -526,10 +519,8 @@ TEST_CASE("relation data on ways: change relation (three rels)")
 
 TEST_CASE("relation data on ways: delete relation")
 {
-    options_t options = testing::opt_t()
-                            .slim()
-                            .flex("test_output_flex_stage2_alt.lua")
-                            .srs(PROJ_LATLONG);
+    options_t options =
+        testing::opt_t().slim().flex("test_output_flex_stage2_alt.lua");
 
     // create database with a way and two relations on it
     REQUIRE_NOTHROW(db.run_import(options,


### PR DESCRIPTION
The projection set on the command line with -l|--latlong, -m|--merc, or
-E|--proj is now ignored in the flex output. Instead you can set it
individually on all geometry columns using the `projection` option which
either takes an EPSG code or a few commonly understood string values
such as "merc", "latlong", or "WGS84".

This also makes the flex output ignore the --reproject-area option.
The area is now calculated in web mercator by default and you can
change this by setting the `projection` option on the area column.
(This currently only allows setting 4326 and 3857, other projections
will not work. We have to fix this later. This is due to the way
the area is calculated from the WKB geometry.)

The osm2pgsql.srid variable is not set any more in the Lua config.

So there are some breaking changes here for the flex output, which
we can still do as it is marked experimental.

With this change the command line options -l, -m, -E, and
--reproject-area, that can be regarded as belonging to the style are not
used any more in the flex output. This completes the move away from
command line option to config file for the flex output.