### PR TITLE
Allow conninfo string in -d/--database option

### DIFF
--- a/docs/osm2pgsql.md
+++ b/docs/osm2pgsql.md
@@ -44,7 +44,10 @@ starting with two dashes (`--`). A summary of options is included below.
     default if **\--append** is not specified.
 
 -d, \--database name
-:   The name of the PostgreSQL database to connect to.
+:   The name of the PostgreSQL database to connect to. If this parameter
+    contains an `=` sign or starts with a valid URI prefix (`postgresql://` or
+    `postgres://`), it is treated as a conninfo string. See the PostgreSQL
+    manual for details.
 
 -i, \--tablespace-index tablespacename
 :   Store all indices in a separate PostgreSQL tablespace named by this parameter.

--- a/tests/regression.py
+++ b/tests/regression.py
@@ -143,7 +143,8 @@ class BaseRunner(object):
     @classmethod
     def run_import(cls, params, filename):
         cmdline = [CONFIG['executable']]
-        cmdline.extend(('-d', CONFIG['test_database']))
+        if not '-d' in params and not '--database' in params:
+            cmdline.extend(('-d', CONFIG['test_database']))
         cmdline.extend(params)
         cmdline.append(op.join(CONFIG['test_data_path'], filename))
         logging.info("Executing command: {}".format(' '.join(cmdline)))
@@ -734,4 +735,30 @@ class TestMPUpdateSlimLuaHstore(MultipolygonUpdateRunner, unittest.TestCase,
                                 MultipolygonTests):
     extra_params = ['--slim', '-k']
     use_lua_tagtransform = True
+
+# Database access tests
+
+class TestDBAccessNorm(BaseUpdateRunner, unittest.TestCase,
+                       PgsqlBaseTests):
+    extra_params = ['--slim', '-d', CONFIG['test_database']]
+
+class TestDBAccessNormLong(BaseUpdateRunner, unittest.TestCase,
+                       PgsqlBaseTests):
+    extra_params = ['--slim', '--database', CONFIG['test_database']]
+
+class TestDBAccessConninfo(BaseUpdateRunner, unittest.TestCase,
+                           PgsqlBaseTests):
+    extra_params = ['--slim', '-d', 'dbname=' + CONFIG['test_database']]
+
+class TestDBAccessConninfoLong(BaseUpdateRunner, unittest.TestCase,
+                           PgsqlBaseTests):
+    extra_params = ['--slim', '--database', 'dbname=' + CONFIG['test_database']]
+
+class TestDBAccessURIPostgresql(BaseUpdateRunner, unittest.TestCase,
+                           PgsqlBaseTests):
+    extra_params = ['--slim', '-d', 'postgresql:///' + CONFIG['test_database']]
+
+class TestDBAccessURIPostgres(BaseUpdateRunner, unittest.TestCase,
+                           PgsqlBaseTests):
+    extra_params = ['--slim', '-d', 'postgres:///' + CONFIG['test_database']]
 


### PR DESCRIPTION
Optionally allow a PostgreSQL conninfo string in the -d/--database
option instead of just a database name. Similar to what the psql comand
does.

Fixes #1242