### PR TITLE
Add a paranoia check to the database connection

### DIFF
--- a/src/pgsql.cpp
+++ b/src/pgsql.cpp
@@ -10,6 +10,9 @@
 pg_conn_t::pg_conn_t(std::string const &conninfo)
 : m_conn(PQconnectdb(conninfo.c_str()))
 {
+    if (!m_conn) {
+        throw std::runtime_error{"Connecting to database failed."};
+    }
     if (PQstatus(m_conn.get()) != CONNECTION_OK) {
         fmt::print(stderr, "Connection to database failed: {}\n", error_msg());
         throw std::runtime_error{"Connecting to database."};


### PR DESCRIPTION
From the documentation:
"Note that these functions will always return a non-null object pointer,
unless perhaps there is too little memory even to allocate the PGconn
object."