### PR TITLE
Extend manpage

### DIFF
--- a/docs/osm2pgsql.1
+++ b/docs/osm2pgsql.1
@@ -7,18 +7,15 @@ osm2pgsql \- Openstreetmap data to PostgreSQL converter
 \f[B]osm2pgsql\f[] [\f[I]OPTIONS\f[]] OSM\-FILE
 .SH DESCRIPTION
 .PP
-This manual page documents briefly the \f[B]osm2pgsql\f[] command.
+\f[B]osm2pgsql\f[] imports OpenStreetMap data into a PostgreSQL/PostGIS
+database.
+It is an essential part of many rendering toolchains, the Nominatim
+geocoder and other applications processing OSM data.
 .PP
-\f[B]osm2pgsql\f[] imports data from OSM file(s) into a PostgreSQL
-database suitable for use by the Mapnik renderer or the Nominatim
-geocoder.
 OSM planet snapshots can be downloaded from
 https://planet.openstreetmap.org/.
-Partial planet files (\[lq]extracts\[rq]) for various countries are
-available, see https://wiki.openstreetmap.org/wiki/Planet.osm.
-.PP
-Extracts in PBF (ProtoBufBinary) format are also available from
-https://download.geofabrik.de/.
+Data extracts for various countries or other areas are also available,
+see https://wiki.openstreetmap.org/wiki/Planet.osm.
 .PP
 When operating in \[lq]slim\[rq] mode (and on a database created in
 \[lq]slim\[rq] mode!), \f[B]osm2pgsql\f[] can also process OSM change
@@ -27,17 +24,17 @@ files (osc files), thereby bringing an existing database up to date.
 .PP
 This program follows the usual GNU command line syntax, with long
 options starting with two dashes (\f[C]\-\-\f[]).
-A summary of options is included below.
+.PP
+Mandatory arguments to long options are mandatory for short options too.
 .TP
 .B \-a, \-\-append
 Add the OSM file into the database without removing existing data.
 .RS
 .RE
 .TP
-.B \-b, \-\-bbox
+.B \-b, \-\-bbox=MINLON,MINLAT,MAXLON,MAXLAT
 Apply a bounding box filter on the imported data.
-Must be specified as: minlon,minlat,maxlon,maxlat e.g.
-\f[B]\-\-bbox\f[] \f[B]\-0.5,51.25,0.5,51.75\f[]
+Example: \f[B]\-\-bbox\f[] \f[B]\-0.5,51.25,0.5,51.75\f[]
 .RS
 .RE
 .TP
@@ -47,34 +44,38 @@ This is the default if \f[B]\-\-append\f[] is not specified.
 .RS
 .RE
 .TP
-.B \-d, \-\-database name
+.B \-d, \-\-database=NAME
 The name of the PostgreSQL database to connect to.
+If this parameter contains an \f[C]=\f[] sign or starts with a valid URI
+prefix (\f[C]postgresql://\f[] or \f[C]postgres://\f[]), it is treated
+as a conninfo string.
+See the PostgreSQL manual for details.
 .RS
 .RE
 .TP
-.B \-i, \-\-tablespace\-index tablespacename
+.B \-i, \-\-tablespace\-index=TABLESPACENAME
 Store all indices in a separate PostgreSQL tablespace named by this
 parameter.
 This allows one to e.g.\ store the indices on faster storage like SSDs.
 .RS
 .RE
 .TP
-.B \-\-tablespace\-main\-data tablespacename
+.B \-\-tablespace\-main\-data=TABLESPACENAME
 Store the data tables (non slim) in the given tablespace.
 .RS
 .RE
 .TP
-.B \-\-tablespace\-main\-index tablespacename
+.B \-\-tablespace\-main\-index=TABLESPACENAME
 Store the indices of the main tables (non slim) in the given tablespace.
 .RS
 .RE
 .TP
-.B \-\-tablespace\-slim\-data tablespacename
+.B \-\-tablespace\-slim\-data=TABLESPACENAME
 Store the slim mode tables in the given tablespace.
 .RS
 .RE
 .TP
-.B \-\-tablespace\-slim\-index tablespacename
+.B \-\-tablespace\-slim\-index=TABLESPACENAME
 Store the indices of the slim mode tables in the given tablespace.
 .RS
 .RE
@@ -90,17 +91,17 @@ default).
 .RS
 .RE
 .TP
-.B \-E, \-\-proj num
-Use projection EPSG:num.
+.B \-E, \-\-proj=SRID
+Use projection EPSG:SRID.
 .RS
 .RE
 .TP
-.B \-p, \-\-prefix prefix_string
-Prefix for table names (default: planet_osm).
+.B \-p, \-\-prefix=PREFIX
+Prefix for table names (default: \f[C]planet_osm\f[]).
 .RS
 .RE
 .TP
-.B \-r, \-\-input\-reader format
+.B \-r, \-\-input\-reader=FORMAT
 Select format of the input file.
 Available choices are \f[B]auto\f[] (default) for autodetecting the
 format, \f[B]xml\f[] for OSM XML format files, \f[B]o5m\f[] for o5m
@@ -134,16 +135,26 @@ update your database, as these tables are needed for diff processing.
 .RS
 .RE
 .TP
-.B \-S, \-\-style /path/to/style
-Location of the osm2pgsql style file.
+.B \-S, \-\-style=FILE
+The osm2pgsql style file.
 This specifies which tags from the data get imported into database
 columns and which tags get dropped.
-Defaults to /usr/share/osm2pgsql/default.style.
+(For the \f[B]pgsql\f[] output, the default is
+\f[C]/usr/share/osm2pgsql/default.style\f[], for other outputs there is
+no default.)
 .RS
 .RE
 .TP
-.B \-C, \-\-cache num
-Only for slim mode: Use up to num many MB of RAM for caching nodes.
+.B \-\-tag\-transform\-script=SCRIPT
+Specify a lua script to handle tag filtering and normalisation.
+The script contains callback functions for nodes, ways and relations,
+which each take a set of tags and returns a transformed, filtered set of
+tags which are then written to the database.
+.RS
+.RE
+.TP
+.B \-C, \-\-cache=NUM
+Only for slim mode: Use up to \f[B]NUM\f[] MB of RAM for caching nodes.
 Giving osm2pgsql sufficient cache to store all imported nodes typically
 greatly increases the speed of the import.
 Each cached node requires 8 bytes of cache, plus about 10% \- 30%
@@ -158,7 +169,7 @@ Defaults to 800.
 .RS
 .RE
 .TP
-.B \-\-cache\-strategy strategy
+.B \-\-cache\-strategy=STRATEGY
 There are a number of different modes in which osm2pgsql can organize
 its node cache in RAM.
 These are optimized for different assumptions of the data and the
@@ -181,7 +192,7 @@ This is the default and should be typically used.
 .RS
 .RE
 .TP
-.B \-U, \-\-username name
+.B \-U, \-\-username=NAME
 Postgresql user name.
 .RS
 .RE
@@ -191,38 +202,43 @@ Force password prompt.
 .RS
 .RE
 .TP
-.B \-H, \-\-host hostname
+.B \-H, \-\-host=HOSTNAME
 Database server hostname or socket location.
 .RS
 .RE
 .TP
-.B \-P, \-\-port num
+.B \-P, \-\-port=PORT
 Database server port.
 .RS
 .RE
 .TP
-.B \-e, \-\-expire\-tiles [min_zoom\-]max\-zoom
+.B \-e, \-\-expire\-tiles=[MIN_ZOOM\-]MAX\-ZOOM
 Create a tile expiry list.
 .RS
 .RE
 .TP
-.B \-o, \-\-expire\-output /path/to/expire.list
+.B \-o, \-\-expire\-output=FILENAME
 Output file name for expired tiles list.
 .RS
 .RE
 .TP
-.B \-O, \-\-output
-Specifies the output back\-end or database schema to use.
+.B \-\-expire\-bbox\-size=SIZE
+Max size for a polygon to expire the whole polygon, not just the
+boundary.
+.RS
+.RE
+.TP
+.B \-O, \-\-output=OUTPUT
+Specifies the output back\-end to use.
 Currently osm2pgsql supports \f[B]pgsql\f[], \f[B]flex\f[],
 \f[B]gazetteer\f[] and \f[B]null\f[].
-\f[B]pgsql\f[] is the default output back\-end / schema and is optimized
-for rendering with Mapnik.
-\f[B]gazetteer\f[] is a db schema optimized for geocoding and is used by
-Nominatim.
+\f[B]pgsql\f[] is the default output back\-end and is optimized for
+rendering with Mapnik.
+\f[B]gazetteer\f[] is intended for geocoding with Nominatim.
 The experimental \f[B]flex\f[] backend allows more flexible
 configuration.
 \f[B]null\f[] does not write any output and is only useful for testing
-or with \[en]slim for creating slim tables.
+or with \f[B]\-\-slim\f[] for creating slim tables.
 There is also a \f[B]multi\f[] backend.
 This is now deprecated and will be removed in future versions of
 osm2pgsql.
@@ -248,10 +264,11 @@ tables.
 .RS
 .RE
 .TP
-.B \-z, \-\-hstore\-column key_name
+.B \-z, \-\-hstore\-column=KEY_PREFIX
 Add an additional hstore (key/value) column containing all tags that
 start with the specified string, eg \-\-hstore\-column \[lq]name:\[rq]
-will produce an extra hstore column that contains all name:xx tags
+will produce an extra hstore column that contains all \f[C]name:xx\f[]
+tags
 .RS
 .RE
 .TP
@@ -270,21 +287,26 @@ Create indices for the hstore columns during import.
 Normally osm2pgsql splits multi\-part geometries into separate database
 rows per part.
 A single OSM id can therefore have several rows.
-With this option, PostgreSQL instead generates multi\-geometry features
+With this option, osm2pgsql instead generates multi\-geometry features
 in the PostgreSQL tables.
 .RS
 .RE
 .TP
 .B \-K, \-\-keep\-coastlines
 Keep coastline data rather than filtering it out.
-By default natural=coastline tagged data will be discarded based on the
-assumption that Shapefiles generated by OSMCoastline
-(https://osmdata.openstreetmap.de/) will be used.
+By default objects tagged \f[C]natural=coastline\f[] will be discarded
+based on the assumption that Shapefiles generated by OSMCoastline
+(https://osmdata.openstreetmap.de/) will be used for the coastline data.
 .RS
 .RE
 .TP
-.B \-\-number\-processes num
-Specifies the number of parallel processes used for certain operations.
+.B \-\-reproject\-area
+Compute area column using spherical mercator coordinates.
+.RS
+.RE
+.TP
+.B \-\-number\-processes=THREADS
+Specifies the number of parallel threads used for certain operations.
 If disks are fast enough e.g.\ if you have an SSD, then this can greatly
 increase speed of the \[lq]going over pending ways\[rq] and \[lq]going
 over pending relations\[rq] stages on a multi\-core server.
@@ -294,13 +316,13 @@ over pending relations\[rq] stages on a multi\-core server.
 .B \-I, \-\-disable\-parallel\-indexing
 By default osm2pgsql initiates the index building on all tables in
 parallel to increase performance.
-This can be disadvantages on slow disks, or if you don't have enough RAM
-for PostgreSQL to perform up to 7 parallel index building processes
-(e.g.\ because maintenance_work_mem is set high).
+This can be a disadvantage on slow disks, or if you don't have enough
+RAM for PostgreSQL to perform up to 7 parallel index building processes
+(e.g.\ because \f[C]maintenance_work_mem\f[] is set high).
 .RS
 .RE
 .TP
-.B \-\-flat\-nodes /path/to/nodes.cache
+.B \-\-flat\-nodes=FILENAME
 The flat\-nodes mode is a separate method to store slim mode node
 information on disk.
 Instead of storing this information in the main PostgreSQL database,
@@ -323,13 +345,20 @@ The default is disabled.
 .RE
 .TP
 .B \-h, \-\-help
-Help information.
-Add \f[B]\-v\f[] to display supported projections.
+Show usage information.
+Add \f[B]\-v\f[] to display more verbose help.
 .RS
 .RE
 .TP
 .B \-v, \-\-verbose
 Verbose output.
+.RS
+.RE
+.TP
+.B \[en]middle\-way\-node\-index\-id\-shift shift
+Set ID shift for way node bucket index in middle.
+Experts only.
+See documentation for details.
 .RS
 .RE
 .SH SUPPORTED PROJECTIONS

--- a/docs/osm2pgsql.md
+++ b/docs/osm2pgsql.md
@@ -8,17 +8,13 @@ osm2pgsql - Openstreetmap data to PostgreSQL converter
 
 # DESCRIPTION
 
-This manual page documents briefly the **osm2pgsql** command.
+**osm2pgsql** imports OpenStreetMap data into a PostgreSQL/PostGIS database. It
+is an essential part of many rendering toolchains, the Nominatim geocoder and
+other applications processing OSM data.
 
-**osm2pgsql** imports data from OSM file(s) into a PostgreSQL database
-suitable for use by the Mapnik renderer or the Nominatim geocoder.
-OSM planet snapshots can be downloaded from
-https://planet.openstreetmap.org/. Partial planet files
-("extracts") for various countries are available, see
+OSM planet snapshots can be downloaded from https://planet.openstreetmap.org/.
+Data extracts for various countries or other areas are also available, see
 https://wiki.openstreetmap.org/wiki/Planet.osm.
-
-Extracts in PBF (ProtoBufBinary) format are also available from
-https://download.geofabrik.de/.
 
 When operating in "slim" mode (and on a database created in "slim" mode!),
 **osm2pgsql** can also process OSM change files (osc files), thereby bringing
@@ -28,41 +24,41 @@ an existing database up to date.
 # OPTIONS
 
 This program follows the usual GNU command line syntax, with long options
-starting with two dashes (`--`). A summary of options is included below.
+starting with two dashes (`--`).
+
+Mandatory arguments to long options are mandatory for short options too.
 
 -a, \--append
-:   Add the OSM file into the database without removing
-    existing data.
+:   Add the OSM file into the database without removing existing data.
 
--b, \--bbox
-:   Apply a bounding box filter on the imported data.
-    Must be specified as: minlon,minlat,maxlon,maxlat
-    e.g. **\--bbox** **-0.5,51.25,0.5,51.75**
+-b, \--bbox=MINLON,MINLAT,MAXLON,MAXLAT
+:   Apply a bounding box filter on the imported data. Example:
+    **\--bbox** **-0.5,51.25,0.5,51.75**
 
 -c, \--create
-:   Remove existing data from the database. This is the
-    default if **\--append** is not specified.
+:   Remove existing data from the database. This is the default if
+    **\--append** is not specified.
 
--d, \--database name
+-d, \--database=NAME
 :   The name of the PostgreSQL database to connect to. If this parameter
     contains an `=` sign or starts with a valid URI prefix (`postgresql://` or
     `postgres://`), it is treated as a conninfo string. See the PostgreSQL
     manual for details.
 
--i, \--tablespace-index tablespacename
+-i, \--tablespace-index=TABLESPACENAME
 :   Store all indices in a separate PostgreSQL tablespace named by this parameter.
     This allows one to e.g. store the indices on faster storage like SSDs.
 
-\--tablespace-main-data tablespacename
+\--tablespace-main-data=TABLESPACENAME
 :   Store the data tables (non slim) in the given tablespace.
 
-\--tablespace-main-index tablespacename
+\--tablespace-main-index=TABLESPACENAME
 :   Store the indices of the main tables (non slim) in the given tablespace.
 
-\--tablespace-slim-data tablespacename
+\--tablespace-slim-data=TABLESPACENAME
 :   Store the slim mode tables in the given tablespace.
 
-\--tablespace-slim-index tablespacename
+\--tablespace-slim-index=TABLESPACENAME
 :   Store the indices of the slim mode tables in the given tablespace.
 
 \--latlong
@@ -71,13 +67,13 @@ starting with two dashes (`--`). A summary of options is included below.
 -m, \--merc
 :   Store data in Spherical Mercator (Web Mercator, EPSG:3857) (the default).
 
--E, \--proj num
-:   Use projection EPSG:num.
+-E, \--proj=SRID
+:   Use projection EPSG:SRID.
 
--p, \--prefix prefix_string
-:   Prefix for table names (default: planet_osm).
+-p, \--prefix=PREFIX
+:   Prefix for table names (default: `planet_osm`).
 
--r, \--input-reader format
+-r, \--input-reader=FORMAT
 :   Select format of the input file. Available choices are **auto**
     (default) for autodetecting the format,
     **xml** for OSM XML format files, **o5m** for o5m formatted files
@@ -99,12 +95,20 @@ starting with two dashes (`--`). A summary of options is included below.
     can nearly halve import time. Slim mode tables however have to be persistent if you want
     to be able to update your database, as these tables are needed for diff processing.
 
--S, \--style /path/to/style
-:   Location of the osm2pgsql style file. This specifies which tags from the data get
-    imported into database columns and which tags get dropped. Defaults to /usr/share/osm2pgsql/default.style.
+-S, \--style=FILE
+:   The osm2pgsql style file. This specifies which tags from the data get
+    imported into database columns and which tags get dropped. (For the
+    **pgsql** output, the default is `/usr/share/osm2pgsql/default.style`,
+    for other outputs there is no default.)
 
--C, \--cache num
-:   Only for slim mode: Use up to num many MB of RAM for caching nodes. Giving osm2pgsql sufficient cache
+\--tag-transform-script=SCRIPT
+:   Specify a lua script to handle tag filtering and normalisation. The script
+    contains callback functions for nodes, ways and relations, which each take
+    a set of tags and returns a transformed, filtered set of tags which are
+    then written to the database.
+
+-C, \--cache=NUM
+:   Only for slim mode: Use up to **NUM** MB of RAM for caching nodes. Giving osm2pgsql sufficient cache
     to store all imported nodes typically greatly increases the speed of the import. Each cached node
     requires 8 bytes of cache, plus about 10% - 30% overhead. As a rule of thumb,
     give a bit more than the size of the import file in PBF format. If the RAM is not
@@ -112,7 +116,7 @@ starting with two dashes (`--`). A summary of options is included below.
     It needs at least the amount of `shared_buffers` given in its configuration.
     Defaults to 800.
 
-\--cache-strategy strategy
+\--cache-strategy=STRATEGY
 :   There are a number of different modes in which osm2pgsql can organize its
     node cache in RAM. These are optimized for different assumptions of the data
     and the hardware resources available. Currently available strategies are
@@ -127,32 +131,35 @@ starting with two dashes (`--`). A summary of options is included below.
     if it is more effective to store the block of IDs in sparse or dense mode. This is the
     default and should be typically used.
 
--U, \--username name
+-U, \--username=NAME
 :   Postgresql user name.
 
 -W, \--password
 :   Force password prompt.
 
--H, \--host hostname
+-H, \--host=HOSTNAME
 :   Database server hostname or socket location.
 
--P, \--port num
+-P, \--port=PORT
 :   Database server port.
 
--e, \--expire-tiles [min_zoom-]max-zoom
+-e, \--expire-tiles=[MIN_ZOOM-]MAX-ZOOM
 :   Create a tile expiry list.
 
--o, \--expire-output /path/to/expire.list
+-o, \--expire-output=FILENAME
 :   Output file name for expired tiles list.
 
--O, \--output
-:   Specifies the output back-end or database schema to use. Currently osm2pgsql
+\--expire-bbox-size=SIZE
+:   Max size for a polygon to expire the whole polygon, not just the boundary.
+
+-O, \--output=OUTPUT
+:   Specifies the output back-end to use. Currently osm2pgsql
     supports **pgsql**, **flex**, **gazetteer** and **null**. **pgsql** is
-    the default output back-end / schema and is optimized for rendering with Mapnik.
-    **gazetteer** is a db schema optimized for geocoding and is used by Nominatim.
+    the default output back-end and is optimized for rendering with Mapnik.
+    **gazetteer** is intended for geocoding with Nominatim.
     The experimental **flex** backend allows more flexible configuration.
     **null** does not write any output and is only useful for testing or with
-    --slim for creating slim tables. There is also a **multi** backend. This is
+    **\--slim** for creating slim tables. There is also a **multi** backend. This is
     now deprecated and will be removed in future versions of osm2pgsql.
 
 -x, \--extra-attributes
@@ -166,10 +173,10 @@ starting with two dashes (`--`). A summary of options is included below.
 -j, \--hstore-all
 :   Add all tags to an additional hstore (key/value) column in PostgreSQL tables.
 
--z, \--hstore-column key_name
+-z, \--hstore-column=KEY_PREFIX
 :   Add an additional hstore (key/value) column containing all tags
     that start with the specified string, eg \--hstore-column "name:" will
-    produce an extra hstore column that contains all name:xx tags
+    produce an extra hstore column that contains all `name:xx` tags
 
 \--hstore-match-only
 :   Only keep objects that have a value in one of the columns
@@ -180,28 +187,31 @@ starting with two dashes (`--`). A summary of options is included below.
 
 -G, \--multi-geometry
 :   Normally osm2pgsql splits multi-part geometries into separate database rows per part.
-    A single OSM id can therefore have several rows. With this option, PostgreSQL instead
+    A single OSM id can therefore have several rows. With this option, osm2pgsql instead
     generates multi-geometry features in the PostgreSQL tables.
 
 -K, \--keep-coastlines
-:   Keep coastline data rather than filtering it out.
-    By default natural=coastline tagged data will be discarded based on the
-    assumption that Shapefiles generated by OSMCoastline (https://osmdata.openstreetmap.de/)
-    will be used.
+:   Keep coastline data rather than filtering it out. By default objects
+    tagged `natural=coastline` will be discarded based on the assumption that
+    Shapefiles generated by OSMCoastline (https://osmdata.openstreetmap.de/)
+    will be used for the coastline data.
 
-\--number-processes num
-:   Specifies the number of parallel processes used for certain operations. If disks are
+\--reproject-area
+:   Compute area column using spherical mercator coordinates.
+
+\--number-processes=THREADS
+:   Specifies the number of parallel threads used for certain operations. If disks are
     fast enough e.g. if you have an SSD, then this can greatly increase speed of
     the "going over pending ways" and "going over pending relations" stages on a multi-core
     server.
 
 -I, \--disable-parallel-indexing
 :   By default osm2pgsql initiates the index building on all tables in parallel to increase
-    performance. This can be disadvantages on slow disks, or if you don't have
+    performance. This can be a disadvantage on slow disks, or if you don't have
     enough RAM for PostgreSQL to perform up to 7 parallel index building processes
-    (e.g. because maintenance_work_mem is set high).
+    (e.g. because `maintenance_work_mem` is set high).
 
-\--flat-nodes /path/to/nodes.cache
+\--flat-nodes=FILENAME
 :   The flat-nodes mode is a separate method to store slim mode node information on disk.
     Instead of storing this information in the main PostgreSQL database, this mode creates
     its own separate custom database to store the information. As this custom database
@@ -214,8 +224,7 @@ starting with two dashes (`--`). A summary of options is included below.
     as it doesn't work well with small imports. The default is disabled.
 
 -h, \--help
-:   Help information.
-    Add **-v** to display supported projections.
+:   Show usage information. Add **-v** to display more verbose help.
 
 -v, \--verbose
 :   Verbose output.


### PR DESCRIPTION
Add missing options to man page and do some light editing/formatting. This is only a step in bringing the man page more up to date.

In a future PR I want to split the options into several sections, so I haven't taken that into account much when adding the three missing options.

