### PR TITLE
Move output of projection used from main to pgsql output

### DIFF
--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -79,10 +79,6 @@ int main(int argc, char *argv[])
         osmdata_t osmdata{std::move(dependency_manager), middle, outputs,
                           options};
 
-        fmt::print(stderr, "Using projection SRS {} ({})\n",
-                   options.projection->target_srs(),
-                   options.projection->target_desc());
-
         util::timer_t timer_overall;
         osmdata.start();
 

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -343,6 +343,9 @@ output_pgsql_t::output_pgsql_t(
   buffer(32768, osmium::memory::Buffer::auto_grow::yes),
   rels_buffer(1024, osmium::memory::Buffer::auto_grow::yes)
 {
+    fmt::print(stderr, "Using projection SRS {} ({})\n",
+               o.projection->target_srs(), o.projection->target_desc());
+
     export_list exlist;
 
     m_enable_way_area = read_style_file(m_options.style, &exlist);


### PR DESCRIPTION
Other outputs don't use the projection from the command line any more,
so it might be confusing to print that in main.