### PR TITLE
Make the Lua add_row() functions 2nd parameter optional

### DIFF
--- a/tests/data/test_output_flex_types.lua
+++ b/tests/data/test_output_flex_types.lua
@@ -15,7 +15,7 @@ function osm2pgsql.process_node(object)
     local test_type = object.tags.type
 
     if test_type == 'nil' then
-        test_table:add_row{}
+        test_table:add_row()
         return
     end
     if test_type == 'boolean' then


### PR DESCRIPTION
For tables without geometry column, this allows writing
some_table:add_row() in addtion to some_table:add_row({}) or
some_table:add_row{} which makes it a tiny bit more usable.