### PR TITLE
Do not create planet_osm_nodes table if flat nodes are used

### DIFF
--- a/src/db-check.cpp
+++ b/src/db-check.cpp
@@ -5,6 +5,22 @@
 
 #include <stdexcept>
 
+/**
+ * Check whether the table with the specified name exists in the specified
+ * schema in the database. Leave schema empty to check in the 'public' schema.
+ */
+static bool has_table(pg_conn_t &db_connection, std::string const &schema,
+                      std::string const &table)
+{
+    auto const sql = "SELECT count(*) FROM pg_tables"
+                     "  WHERE schemaname='{}' AND tablename='{}'"_format(
+                         schema.empty() ? "public" : schema, table);
+    auto const res = db_connection.query(PGRES_TUPLES_OK, sql);
+    auto const num = res.get_value(0, 0);
+
+    return num[0] == '1' && num[1] == '\0';
+}
+
 void check_db(options_t const &options)
 {
     pg_conn_t db_connection{options.database_options.conninfo()};
@@ -20,6 +36,19 @@ void check_db(options_t const &options)
             throw std::runtime_error{
                 "Your database version is too old (need at least {})."_format(
                     get_minimum_postgresql_server_version())};
+        }
+
+        // If we are in append mode and the middle nodes table isn't there,
+        // it probably means we used a flat node store when we created this
+        // database. Check for that and stop if it looks like we are missing
+        // the node location store option.
+        if (options.append && !options.flat_node_cache_enabled) {
+            if (!has_table(db_connection, options.middle_dbschema,
+                           options.prefix + "_nodes")) {
+                throw std::runtime_error{
+                    "You seem to not have a nodes table. Did "
+                    "you forget the --flat-nodes option?"};
+            }
         }
 
     } catch (std::out_of_range const &) {

--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -578,14 +578,12 @@ void middle_pgsql_t::start()
         // (Re)create tables.
         m_db_connection.exec("SET client_min_messages = WARNING");
         for (auto const &table : m_tables) {
-            if (!table.m_create.empty()) {
-                fmt::print(stderr, "Setting up table: {}\n", table.name());
-                auto const qual_name = qualified_name(
-                    table.m_copy_target->schema, table.m_copy_target->name);
-                m_db_connection.exec(
-                    "DROP TABLE IF EXISTS {} CASCADE"_format(qual_name));
-                m_db_connection.exec(table.m_create);
-            }
+            fmt::print(stderr, "Setting up table: {}\n", table.name());
+            auto const qual_name = qualified_name(
+                table.m_copy_target->schema, table.m_copy_target->name);
+            m_db_connection.exec(
+                "DROP TABLE IF EXISTS {} CASCADE"_format(qual_name));
+            m_db_connection.exec(table.m_create);
         }
 
         // The extra query connection is only needed in append mode, so close.

--- a/src/pgsql.cpp
+++ b/src/pgsql.cpp
@@ -55,11 +55,18 @@ void pg_conn_t::set_config(char const *setting, char const *value) const
     query(PGRES_TUPLES_OK, sql);
 }
 
-void pg_conn_t::exec(char const *sql) const { query(PGRES_COMMAND_OK, sql); }
+void pg_conn_t::exec(char const *sql) const
+{
+    if (sql && sql[0] != '\0') {
+        query(PGRES_COMMAND_OK, sql);
+    }
+}
 
 void pg_conn_t::exec(std::string const &sql) const
 {
-    query(PGRES_COMMAND_OK, sql.c_str());
+    if (!sql.empty()) {
+        query(PGRES_COMMAND_OK, sql.c_str());
+    }
 }
 
 void pg_conn_t::copy_data(std::string const &sql,

--- a/tests/regression.py
+++ b/tests/regression.py
@@ -19,6 +19,7 @@
 from collections import namedtuple
 import logging
 from os import path as op
+import os
 import subprocess
 import sys
 import psycopg2
@@ -102,6 +103,11 @@ class BaseRunner(object):
 
     @classmethod
     def setUpClass(cls):
+        try:
+            # In case one is left over from a previous test
+            os.remove('flat.nodes')
+        except (FileNotFoundError):
+            pass
         if cls.use_lua_tagtransform and not CONFIG['have_lua']:
             cls.skipTest(None, "No Lua configured.")
         if 'tablespacetest' in cls.extra_params and not CONFIG['have_lua']:
@@ -131,6 +137,10 @@ class BaseRunner(object):
         if cls.schema:
             with psycopg2.connect("dbname='{}'".format(CONFIG['test_database'])) as conn:
                 conn.cursor().execute("DROP SCHEMA IF EXISTS {} CASCADE".format(cls.schema))
+        try:
+            os.remove('flat.nodes')
+        except (FileNotFoundError):
+            pass
 
     @classmethod
     def get_def_params(cls):

--- a/tests/regression.py
+++ b/tests/regression.py
@@ -506,6 +506,9 @@ class MultipolygonTests(object):
     def test_different_tags_on_relation_and_way_way_presence(self):
         self.assert_count(1, 'planet_osm_polygon', where='osm_id = 140')
 
+    def test_planet_osm_nodes(self):
+        self.assert_count(1, 'pg_tables',
+                          where="tablename = 'planet_osm_nodes'")
 
 
 ########################################################################
@@ -748,6 +751,14 @@ class TestMPUpdateSlimLuaHstore(MultipolygonUpdateRunner, unittest.TestCase,
                                 MultipolygonTests):
     extra_params = ['--slim', '-k']
     use_lua_tagtransform = True
+
+class TestMPUpdateSlimWithFlatNodes(MultipolygonUpdateRunner, unittest.TestCase,
+                                    MultipolygonTests):
+    extra_params = ['--slim', '-F', 'flat.nodes']
+
+    def test_planet_osm_nodes(self):
+        self.assert_count(0, 'pg_tables',
+                          where="tablename = 'planet_osm_nodes'")
 
 # Database access tests
 


### PR DESCRIPTION
Also checks in append mode whether the table is there. If not and there
is no --flat-nodes option specified, osm2pgsql will stop with an error.

Fixes #39