### PR TITLE
Fix order of parameters in set_config()

### DIFF
--- a/src/pgsql.cpp
+++ b/src/pgsql.cpp
@@ -51,7 +51,7 @@ void pg_conn_t::set_config(char const *setting, char const *value) const
     // implemented.
     auto const sql =
         "UPDATE pg_settings SET setting = '{}' WHERE name = '{}'"_format(
-            setting, value);
+            value, setting);
     query(PGRES_TUPLES_OK, sql);
 }
 


### PR DESCRIPTION
When using the UPDATE notation then the value of the setting comes before the name.