### PR TITLE
Bugfix: Setting of type_column in flex backend did not work

### DIFF
--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -655,7 +655,7 @@ void output_flex_t::setup_id_columns(flex_table_t *table)
         table->set_id_type(osmium::item_type::area);
     } else if (type == "any") {
         std::string type_column_name{"osm_type"};
-        lua_getfield(lua_state(), -1, "type_column");
+        lua_getfield(lua_state(), -2, "type_column");
         if (lua_isstring(lua_state(), -1)) {
             type_column_name = lua_tolstring(lua_state(), -1, nullptr);
             check_name(type_column_name, "column");

--- a/tests/data/test_output_flex_uni.lua
+++ b/tests/data/test_output_flex_uni.lua
@@ -1,7 +1,7 @@
 
 local test_table = osm2pgsql.define_table{
     name = 'osm2pgsql_test_data',
-    ids = { type = 'any', type_column = 'osm_type', id_column = 'osm_id' },
+    ids = { type = 'any', type_column = 'x_type', id_column = 'x_id' },
     columns = {
         { column = 'tags', type = 'hstore' },
         { column = 'geom', type = 'geometry' },

--- a/tests/test-output-flex-uni.cpp
+++ b/tests/test-output-flex-uni.cpp
@@ -35,16 +35,16 @@ TEMPLATE_TEST_CASE("updating a node", "", options_slim_default,
 
     auto conn = db.db().connect();
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
 
     // give the node a tag...
     options.append = true;
     REQUIRE_NOTHROW(
         db.run_import(options, "n10 v2 dV x10 y10 Tamenity=restaurant\n"));
 
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "osm_type = 'N'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
     REQUIRE(1 == conn.get_count("osm2pgsql_test_data",
-                                "osm_type = 'N' AND osm_id = 10 AND "
+                                "x_type = 'N' AND x_id = 10 AND "
                                 "tags->'amenity' = 'restaurant'"));
 
     SECTION("remove the tag from node")
@@ -57,7 +57,7 @@ TEMPLATE_TEST_CASE("updating a node", "", options_slim_default,
         REQUIRE_NOTHROW(db.run_import(options, "n10 v3 dD\n"));
     }
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
 }
 
 TEMPLATE_TEST_CASE("updating a way", "", options_slim_default,
@@ -73,54 +73,53 @@ TEMPLATE_TEST_CASE("updating a way", "", options_slim_default,
 
     auto conn = db.db().connect();
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type = 'N'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "osm_type = 'W'"));
-    REQUIRE(
-        1 ==
-        conn.get_count(
-            "osm2pgsql_test_data",
-            "osm_type = 'W' AND osm_id = 20 AND tags->'highway' = 'primary' "
-            "AND ST_NumPoints(geom) = 2"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "x_type = 'W'"));
+    REQUIRE(1 ==
+            conn.get_count(
+                "osm2pgsql_test_data",
+                "x_type = 'W' AND x_id = 20 AND tags->'highway' = 'primary' "
+                "AND ST_NumPoints(geom) = 2"));
 
     // now change the way itself...
     options.append = true;
     REQUIRE_NOTHROW(
         db.run_import(options, "w20 v2 dV Thighway=secondary Nn10,n11\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type = 'N'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "osm_type = 'W'"));
-    REQUIRE(1 == conn.get_count(
-                     "osm2pgsql_test_data",
-                     "osm_type = 'W' AND osm_id = 20 AND tags->'highway' = "
-                     "'secondary' AND ST_NumPoints(geom) = 2"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "x_type = 'W'"));
+    REQUIRE(1 ==
+            conn.get_count("osm2pgsql_test_data",
+                           "x_type = 'W' AND x_id = 20 AND tags->'highway' = "
+                           "'secondary' AND ST_NumPoints(geom) = 2"));
 
     // now change a node in the way...
     REQUIRE_NOTHROW(db.run_import(options, "n10 v2 dV x10.0 y10.3\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type = 'N'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "osm_type = 'W'"));
-    REQUIRE(1 == conn.get_count(
-                     "osm2pgsql_test_data",
-                     "osm_type = 'W' AND osm_id = 20 AND tags->'highway' = "
-                     "'secondary' AND ST_NumPoints(geom) = 2"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "x_type = 'W'"));
+    REQUIRE(1 ==
+            conn.get_count("osm2pgsql_test_data",
+                           "x_type = 'W' AND x_id = 20 AND tags->'highway' = "
+                           "'secondary' AND ST_NumPoints(geom) = 2"));
 
     // now add a node to the way...
     REQUIRE_NOTHROW(db.run_import(
         options, "n12 v1 dV x10.2 y10.1\n"
                  "w20 v3 dV Thighway=residential Nn10,n11,n12\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type = 'N'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "osm_type = 'W'"));
-    REQUIRE(1 == conn.get_count(
-                     "osm2pgsql_test_data",
-                     "osm_type = 'W' AND osm_id = 20 AND tags->'highway' = "
-                     "'residential' AND ST_NumPoints(geom) = 3"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "x_type = 'W'"));
+    REQUIRE(1 ==
+            conn.get_count("osm2pgsql_test_data",
+                           "x_type = 'W' AND x_id = 20 AND tags->'highway' = "
+                           "'residential' AND ST_NumPoints(geom) = 3"));
 
     // now delete the way...
     REQUIRE_NOTHROW(db.run_import(options, "w20 v4 dD\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type = 'N'"));
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type = 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'W'"));
 }
 
 TEMPLATE_TEST_CASE("ways as linestrings and polygons", "", options_slim_default,
@@ -138,15 +137,14 @@ TEMPLATE_TEST_CASE("ways as linestrings and polygons", "", options_slim_default,
 
     auto conn = db.db().connect();
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type != 'W'"));
-    REQUIRE(
-        1 ==
-        conn.get_count(
-            "osm2pgsql_test_data",
-            "osm_type = 'W' AND osm_id = 20 AND tags->'building' = 'yes' AND "
-            "ST_GeometryType(geom) = 'ST_Polygon'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type != 'W'"));
+    REQUIRE(1 ==
+            conn.get_count(
+                "osm2pgsql_test_data",
+                "x_type = 'W' AND x_id = 20 AND tags->'building' = 'yes' AND "
+                "ST_GeometryType(geom) = 'ST_Polygon'"));
     REQUIRE(0 == conn.get_count("osm2pgsql_test_data",
-                                "osm_type = 'W' AND osm_id = 20 AND "
+                                "x_type = 'W' AND x_id = 20 AND "
                                 "tags->'highway' = 'secondary' AND "
                                 "ST_GeometryType(geom) = 'ST_LineString'"));
 
@@ -155,15 +153,14 @@ TEMPLATE_TEST_CASE("ways as linestrings and polygons", "", options_slim_default,
     REQUIRE_NOTHROW(db.run_import(
         options, "w20 v2 dV Thighway=secondary Nn10,n11,n12,n13,n10\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type != 'W'"));
-    REQUIRE(
-        0 ==
-        conn.get_count(
-            "osm2pgsql_test_data",
-            "osm_type = 'W' AND osm_id = 20 AND tags->'building' = 'yes' AND "
-            "ST_GeometryType(geom) = 'ST_Polygon'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type != 'W'"));
+    REQUIRE(0 ==
+            conn.get_count(
+                "osm2pgsql_test_data",
+                "x_type = 'W' AND x_id = 20 AND tags->'building' = 'yes' AND "
+                "ST_GeometryType(geom) = 'ST_Polygon'"));
     REQUIRE(1 == conn.get_count("osm2pgsql_test_data",
-                                "osm_type = 'W' AND osm_id = 20 AND "
+                                "x_type = 'W' AND x_id = 20 AND "
                                 "tags->'highway' = 'secondary' AND "
                                 "ST_GeometryType(geom) = 'ST_LineString'"));
 
@@ -171,15 +168,14 @@ TEMPLATE_TEST_CASE("ways as linestrings and polygons", "", options_slim_default,
     REQUIRE_NOTHROW(db.run_import(
         options, "w20 v3 dV Thighway=secondary Nn10,n11,n12,n13\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type != 'W'"));
-    REQUIRE(
-        0 ==
-        conn.get_count(
-            "osm2pgsql_test_data",
-            "osm_type = 'W' AND osm_id = 20 AND tags->'building' = 'yes' AND "
-            "ST_GeometryType(geom) = 'ST_Polygon'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type != 'W'"));
+    REQUIRE(0 ==
+            conn.get_count(
+                "osm2pgsql_test_data",
+                "x_type = 'W' AND x_id = 20 AND tags->'building' = 'yes' AND "
+                "ST_GeometryType(geom) = 'ST_Polygon'"));
     REQUIRE(1 == conn.get_count("osm2pgsql_test_data",
-                                "osm_type = 'W' AND osm_id = 20 AND "
+                                "x_type = 'W' AND x_id = 20 AND "
                                 "tags->'highway' = 'secondary' AND "
                                 "ST_GeometryType(geom) = 'ST_LineString'"));
 
@@ -193,13 +189,12 @@ TEMPLATE_TEST_CASE("ways as linestrings and polygons", "", options_slim_default,
     REQUIRE_NOTHROW(db.run_import(
         options, "w20 v5 dV Tbuilding=yes Nn10,n11,n12,n13,n10\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type != 'W'"));
-    REQUIRE(
-        1 ==
-        conn.get_count(
-            "osm2pgsql_test_data",
-            "osm_type = 'W' AND osm_id = 20 AND tags->'building' = 'yes' AND "
-            "ST_GeometryType(geom) = 'ST_Polygon'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type != 'W'"));
+    REQUIRE(1 ==
+            conn.get_count(
+                "osm2pgsql_test_data",
+                "x_type = 'W' AND x_id = 20 AND tags->'building' = 'yes' AND "
+                "ST_GeometryType(geom) = 'ST_Polygon'"));
 }
 
 TEMPLATE_TEST_CASE("multipolygons", "", options_slim_default,
@@ -218,15 +213,14 @@ TEMPLATE_TEST_CASE("multipolygons", "", options_slim_default,
 
     auto conn = db.db().connect();
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type = 'N'"));
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type = 'W'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "osm_type = 'R'"));
-    REQUIRE(
-        1 ==
-        conn.get_count(
-            "osm2pgsql_test_data",
-            "osm_type = 'R' AND osm_id = 30 AND tags->'building' = 'yes' AND "
-            "ST_GeometryType(geom) = 'ST_Polygon'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'W'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "x_type = 'R'"));
+    REQUIRE(1 ==
+            conn.get_count(
+                "osm2pgsql_test_data",
+                "x_type = 'R' AND x_id = 30 AND tags->'building' = 'yes' AND "
+                "ST_GeometryType(geom) = 'ST_Polygon'"));
 
     // change tags on that relation...
     options.append = true;
@@ -234,15 +228,14 @@ TEMPLATE_TEST_CASE("multipolygons", "", options_slim_default,
         options,
         "r30 v2 dV Ttype=multipolygon,building=yes,name=Shed Mw20@\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type = 'N'"));
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "osm_type = 'W'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "osm_type = 'R'"));
-    REQUIRE(
-        1 ==
-        conn.get_count(
-            "osm2pgsql_test_data",
-            "osm_type = 'R' AND osm_id = 30 AND tags->'building' = 'yes' AND "
-            "ST_GeometryType(geom) = 'ST_Polygon'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'W'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "x_type = 'R'"));
+    REQUIRE(1 ==
+            conn.get_count(
+                "osm2pgsql_test_data",
+                "x_type = 'R' AND x_id = 30 AND tags->'building' = 'yes' AND "
+                "ST_GeometryType(geom) = 'ST_Polygon'"));
 
     SECTION("remove relation")
     {


### PR DESCRIPTION
When using a table in the flex output which can take any type of OSM
object, the setting of the type_column name did not work. It always used
the default. The test only checked setting this to the default value, so
it didn't fail.