### PR TITLE
Add option to how flex output handles ids in output tables

### DIFF
--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -308,9 +308,7 @@ void table_connection_t::delete_rows_with(osmium::item_type type, osmid_t id)
 {
     m_copy_mgr.new_line(m_target);
 
-    // If the table id type is some specific type, we don't care about the
-    // type of the individual object, because they all will be the same.
-    if (table().id_type() != osmium::item_type::undefined) {
+    if (!table().has_multicolumn_id_index()) {
         type = osmium::item_type::undefined;
     }
     m_copy_mgr.delete_object(type_to_char(type)[0], id);

--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -139,7 +139,20 @@ public:
     osmid_t map_id(osmium::item_type type, osmid_t id) const noexcept
     {
         if (m_id_type == osmium::item_type::undefined) {
-            return id;
+            if (has_multicolumn_id_index()) {
+                return id;
+            }
+
+            switch (type) {
+            case osmium::item_type::node:
+                return id;
+            case osmium::item_type::way:
+                return -id;
+            case osmium::item_type::relation:
+                return -id - 100000000000000000LL;
+            default:
+                assert(false);
+            }
         }
 
         if (m_id_type != osmium::item_type::relation &&

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -654,16 +654,17 @@ void output_flex_t::setup_id_columns(flex_table_t *table)
     } else if (type == "area") {
         table->set_id_type(osmium::item_type::area);
     } else if (type == "any") {
-        std::string type_column_name{"osm_type"};
+        table->set_id_type(osmium::item_type::undefined);
         lua_getfield(lua_state(), -2, "type_column");
         if (lua_isstring(lua_state(), -1)) {
-            type_column_name = lua_tolstring(lua_state(), -1, nullptr);
-            check_name(type_column_name, "column");
+            auto const column_name = lua_tolstring(lua_state(), -1, nullptr);
+            check_name(column_name, "column");
+            auto &column = table->add_column(column_name, "id_type");
+            column.set_not_null();
+        } else if (!lua_isnil(lua_state(), -1)) {
+            throw std::runtime_error{"type_column must be a string or nil"};
         }
         lua_pop(lua_state(), 1); // type_column
-        auto &column = table->add_column(type_column_name, "id_type");
-        column.set_not_null();
-        table->set_id_type(osmium::item_type::undefined);
     } else {
         throw std::runtime_error{"Unknown ids type: " + type};
     }

--- a/tests/data/test_output_flex_uni.lua
+++ b/tests/data/test_output_flex_uni.lua
@@ -1,6 +1,18 @@
 
-local test_table = osm2pgsql.define_table{
-    name = 'osm2pgsql_test_data',
+-- Table with a single id column
+local table1idcol = osm2pgsql.define_table{
+    name = 'osm2pgsql_test_data1',
+    ids = { type = 'any', id_column = 'the_id' },
+    columns = {
+        { column = 'orig_id', type = 'int8' },
+        { column = 'tags', type = 'hstore' },
+        { column = 'geom', type = 'geometry' },
+    }
+}
+
+-- Table with two id columns: type and id
+local table2idcol = osm2pgsql.define_table{
+    name = 'osm2pgsql_test_data2',
     ids = { type = 'any', type_column = 'x_type', id_column = 'x_id' },
     columns = {
         { column = 'tags', type = 'hstore' },
@@ -17,7 +29,12 @@ function osm2pgsql.process_node(object)
         return
     end
 
-    test_table:add_row({
+    table1idcol:add_row({
+        orig_id = object.id,
+        tags = object.tags,
+        geom = { create = 'point' }
+    })
+    table2idcol:add_row({
         tags = object.tags,
         geom = { create = 'point' }
     })
@@ -29,12 +46,22 @@ function osm2pgsql.process_way(object)
     end
 
     if object.tags.building then
-        test_table:add_row({
+        table1idcol:add_row({
+            orig_id = object.id,
+            tags = object.tags,
+            geom = { create = 'area' }
+        })
+        table2idcol:add_row({
             tags = object.tags,
             geom = { create = 'area' }
         })
     else
-        test_table:add_row({
+        table1idcol:add_row({
+            orig_id = object.id,
+            tags = object.tags,
+            geom = { create = 'line' }
+        })
+        table2idcol:add_row({
             tags = object.tags,
             geom = { create = 'line' }
         })
@@ -43,7 +70,12 @@ end
 
 function osm2pgsql.process_relation(object)
     if object.tags.type == 'multipolygon' then
-        test_table:add_row({
+        table1idcol:add_row({
+            orig_id = object.id,
+            tags = object.tags,
+            geom = { create = 'area', multi = false }
+        })
+        table2idcol:add_row({
             tags = object.tags,
             geom = { create = 'area', multi = false }
         })

--- a/tests/test-output-flex-uni.cpp
+++ b/tests/test-output-flex-uni.cpp
@@ -35,16 +35,21 @@ TEMPLATE_TEST_CASE("updating a node", "", options_slim_default,
 
     auto conn = db.db().connect();
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1", "the_id > 0"));
 
     // give the node a tag...
     options.append = true;
     REQUIRE_NOTHROW(
         db.run_import(options, "n10 v2 dV x10 y10 Tamenity=restaurant\n"));
 
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data",
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data2", "x_type = 'N'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1", "the_id > 0"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data2",
                                 "x_type = 'N' AND x_id = 10 AND "
+                                "tags->'amenity' = 'restaurant'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id = 10 AND "
                                 "tags->'amenity' = 'restaurant'"));
 
     SECTION("remove the tag from node")
@@ -57,7 +62,8 @@ TEMPLATE_TEST_CASE("updating a node", "", options_slim_default,
         REQUIRE_NOTHROW(db.run_import(options, "n10 v3 dD\n"));
     }
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1", "the_id > 0"));
 }
 
 TEMPLATE_TEST_CASE("updating a way", "", options_slim_default,
@@ -73,53 +79,80 @@ TEMPLATE_TEST_CASE("updating a way", "", options_slim_default,
 
     auto conn = db.db().connect();
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "x_type = 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1", "the_id > 0"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data2", "x_type = 'W'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id < 0 AND the_id > -1e17"));
     REQUIRE(1 ==
             conn.get_count(
-                "osm2pgsql_test_data",
+                "osm2pgsql_test_data2",
                 "x_type = 'W' AND x_id = 20 AND tags->'highway' = 'primary' "
                 "AND ST_NumPoints(geom) = 2"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id = -20 AND tags->'highway' = 'primary' "
+                                "AND ST_NumPoints(geom) = 2"));
 
     // now change the way itself...
     options.append = true;
     REQUIRE_NOTHROW(
         db.run_import(options, "w20 v2 dV Thighway=secondary Nn10,n11\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "x_type = 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1", "the_id > 0"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data2", "x_type = 'W'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id < 0 AND the_id > -1e17"));
     REQUIRE(1 ==
-            conn.get_count("osm2pgsql_test_data",
+            conn.get_count("osm2pgsql_test_data2",
                            "x_type = 'W' AND x_id = 20 AND tags->'highway' = "
                            "'secondary' AND ST_NumPoints(geom) = 2"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id = -20 AND tags->'highway' = "
+                                "'secondary' AND ST_NumPoints(geom) = 2"));
 
     // now change a node in the way...
     REQUIRE_NOTHROW(db.run_import(options, "n10 v2 dV x10.0 y10.3\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "x_type = 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1", "the_id > 0"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data2", "x_type = 'W'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id < 0 AND the_id > -1e17"));
     REQUIRE(1 ==
-            conn.get_count("osm2pgsql_test_data",
+            conn.get_count("osm2pgsql_test_data2",
                            "x_type = 'W' AND x_id = 20 AND tags->'highway' = "
                            "'secondary' AND ST_NumPoints(geom) = 2"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id = -20 AND tags->'highway' = "
+                                "'secondary' AND ST_NumPoints(geom) = 2"));
 
     // now add a node to the way...
     REQUIRE_NOTHROW(db.run_import(
         options, "n12 v1 dV x10.2 y10.1\n"
                  "w20 v3 dV Thighway=residential Nn10,n11,n12\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "x_type = 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1", "the_id > 0"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data2", "x_type = 'W'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id < 0 AND the_id > -1e17"));
     REQUIRE(1 ==
-            conn.get_count("osm2pgsql_test_data",
+            conn.get_count("osm2pgsql_test_data2",
                            "x_type = 'W' AND x_id = 20 AND tags->'highway' = "
                            "'residential' AND ST_NumPoints(geom) = 3"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id = -20 AND tags->'highway' = "
+                                "'residential' AND ST_NumPoints(geom) = 3"));
 
     // now delete the way...
     REQUIRE_NOTHROW(db.run_import(options, "w20 v4 dD\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1", "the_id > 0"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type = 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id < 0 AND the_id > -1e17"));
 }
 
 TEMPLATE_TEST_CASE("ways as linestrings and polygons", "", options_slim_default,
@@ -137,14 +170,23 @@ TEMPLATE_TEST_CASE("ways as linestrings and polygons", "", options_slim_default,
 
     auto conn = db.db().connect();
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type != 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type != 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id > 0 AND the_id < -1e17"));
     REQUIRE(1 ==
             conn.get_count(
-                "osm2pgsql_test_data",
+                "osm2pgsql_test_data2",
                 "x_type = 'W' AND x_id = 20 AND tags->'building' = 'yes' AND "
                 "ST_GeometryType(geom) = 'ST_Polygon'"));
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data",
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id = -20 AND tags->'building' = 'yes' AND "
+                                "ST_GeometryType(geom) = 'ST_Polygon'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2",
                                 "x_type = 'W' AND x_id = 20 AND "
+                                "tags->'highway' = 'secondary' AND "
+                                "ST_GeometryType(geom) = 'ST_LineString'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id = -20 AND "
                                 "tags->'highway' = 'secondary' AND "
                                 "ST_GeometryType(geom) = 'ST_LineString'"));
 
@@ -153,14 +195,23 @@ TEMPLATE_TEST_CASE("ways as linestrings and polygons", "", options_slim_default,
     REQUIRE_NOTHROW(db.run_import(
         options, "w20 v2 dV Thighway=secondary Nn10,n11,n12,n13,n10\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type != 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type != 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id > 0 AND the_id < -1e17"));
     REQUIRE(0 ==
             conn.get_count(
-                "osm2pgsql_test_data",
+                "osm2pgsql_test_data2",
                 "x_type = 'W' AND x_id = 20 AND tags->'building' = 'yes' AND "
                 "ST_GeometryType(geom) = 'ST_Polygon'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data",
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id = -20 AND tags->'building' = 'yes' AND "
+                                "ST_GeometryType(geom) = 'ST_Polygon'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data2",
                                 "x_type = 'W' AND x_id = 20 AND "
+                                "tags->'highway' = 'secondary' AND "
+                                "ST_GeometryType(geom) = 'ST_LineString'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id = -20 AND "
                                 "tags->'highway' = 'secondary' AND "
                                 "ST_GeometryType(geom) = 'ST_LineString'"));
 
@@ -168,14 +219,23 @@ TEMPLATE_TEST_CASE("ways as linestrings and polygons", "", options_slim_default,
     REQUIRE_NOTHROW(db.run_import(
         options, "w20 v3 dV Thighway=secondary Nn10,n11,n12,n13\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type != 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type != 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id > 0 AND the_id < -1e17"));
     REQUIRE(0 ==
             conn.get_count(
-                "osm2pgsql_test_data",
+                "osm2pgsql_test_data2",
                 "x_type = 'W' AND x_id = 20 AND tags->'building' = 'yes' AND "
                 "ST_GeometryType(geom) = 'ST_Polygon'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data",
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id = -20 AND tags->'building' = 'yes' AND "
+                                "ST_GeometryType(geom) = 'ST_Polygon'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data2",
                                 "x_type = 'W' AND x_id = 20 AND "
+                                "tags->'highway' = 'secondary' AND "
+                                "ST_GeometryType(geom) = 'ST_LineString'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id = -20 AND "
                                 "tags->'highway' = 'secondary' AND "
                                 "ST_GeometryType(geom) = 'ST_LineString'"));
 
@@ -183,18 +243,24 @@ TEMPLATE_TEST_CASE("ways as linestrings and polygons", "", options_slim_default,
     REQUIRE_NOTHROW(
         db.run_import(options, "w20 v4 dV Tbuilding=yes Nn10,n11,n12,n13\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1"));
 
     // now close the way again
     REQUIRE_NOTHROW(db.run_import(
         options, "w20 v5 dV Tbuilding=yes Nn10,n11,n12,n13,n10\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type != 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type != 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id > 0 AND the_id < -1e17"));
     REQUIRE(1 ==
             conn.get_count(
-                "osm2pgsql_test_data",
+                "osm2pgsql_test_data2",
                 "x_type = 'W' AND x_id = 20 AND tags->'building' = 'yes' AND "
                 "ST_GeometryType(geom) = 'ST_Polygon'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id = -20 AND tags->'building' = 'yes' AND "
+                                "ST_GeometryType(geom) = 'ST_Polygon'"));
 }
 
 TEMPLATE_TEST_CASE("multipolygons", "", options_slim_default,
@@ -213,14 +279,22 @@ TEMPLATE_TEST_CASE("multipolygons", "", options_slim_default,
 
     auto conn = db.db().connect();
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'W'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "x_type = 'R'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1", "the_id > 0"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type = 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id < 0 AND the_id > -1e17"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data2", "x_type = 'R'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1", "the_id < -1e17"));
     REQUIRE(1 ==
             conn.get_count(
-                "osm2pgsql_test_data",
+                "osm2pgsql_test_data2",
                 "x_type = 'R' AND x_id = 30 AND tags->'building' = 'yes' AND "
                 "ST_GeometryType(geom) = 'ST_Polygon'"));
+    REQUIRE(1 == conn.get_count(
+                     "osm2pgsql_test_data1",
+                     "the_id = (-30 - 1e17) AND tags->'building' = 'yes' AND "
+                     "ST_GeometryType(geom) = 'ST_Polygon'"));
 
     // change tags on that relation...
     options.append = true;
@@ -228,14 +302,22 @@ TEMPLATE_TEST_CASE("multipolygons", "", options_slim_default,
         options,
         "r30 v2 dV Ttype=multipolygon,building=yes,name=Shed Mw20@\n"));
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'N'"));
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data", "x_type = 'W'"));
-    REQUIRE(1 == conn.get_count("osm2pgsql_test_data", "x_type = 'R'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type = 'N'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1", "the_id > 0"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2", "x_type = 'W'"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1",
+                                "the_id < 0 AND the_id > -1e17"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data2", "x_type = 'R'"));
+    REQUIRE(1 == conn.get_count("osm2pgsql_test_data1", "the_id < -1e17"));
     REQUIRE(1 ==
             conn.get_count(
-                "osm2pgsql_test_data",
+                "osm2pgsql_test_data2",
                 "x_type = 'R' AND x_id = 30 AND tags->'building' = 'yes' AND "
                 "ST_GeometryType(geom) = 'ST_Polygon'"));
+    REQUIRE(1 == conn.get_count(
+                     "osm2pgsql_test_data1",
+                     "the_id = (-30 - 1e17) AND tags->'building' = 'yes' AND "
+                     "ST_GeometryType(geom) = 'ST_Polygon'"));
 
     SECTION("remove relation")
     {
@@ -248,5 +330,6 @@ TEMPLATE_TEST_CASE("multipolygons", "", options_slim_default,
             options, "r30 v3 dV Tbuilding=yes,name=Shed Mw20@\n"));
     }
 
-    REQUIRE(0 == conn.get_count("osm2pgsql_test_data"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data2"));
+    REQUIRE(0 == conn.get_count("osm2pgsql_test_data1"));
 }


### PR DESCRIPTION
Osm2pgsql needs to keep track of all objects it writes into the output
tables by their id, so it can remove/update them when the database is
updated. In the flex output there were two options:

* Use tables with nodes, ways, or relations only. Then we can write
  the id of those objects "as is" into those tables.
* For area tables, ways can use positive ids and relations negative
  ids.
* For tables which can take more than one type of object, we use
  two columns, one for the object type ("N", "W", or "R"), one for
  the id.

The second option has the drawback that we need to have two columns
which might take more space and also makes some operations more
difficult. Some programs might also need a single unique id column.
So we added a new option here: Just have a single id column and,
similarly to how this is done for area tables, convert the ids.

Rather then inventing a new scheme, we use the same scheme that imposm
uses in this case: node ids stay the same (so they are positive), way
ids are negative and relation ids are negative and 1e17 is subtracted
from them. This gives distinct ranges for all ids.

To tell osm2pgsql that you want the type scheme, do not set the
"type_column" option on the ids setting in your flex Lua config.
(Before this, not setting this option meant you get the default
column name "osm_type".)