### PR TITLE
Add starts_with()/ends_with() and suffix check in make_clean_tags_func

### DIFF
--- a/tests/lua/tests.lua
+++ b/tests/lua/tests.lua
@@ -12,6 +12,26 @@ local o = osm2pgsql
 
 -- ---------------------------------------------------------------------------
 
+-- has_prefix()
+
+assert(o.has_prefix('addr:city', 'addr:'))
+assert(not o.has_prefix('addr:city', 'foo'))
+assert(o.has_prefix('addr:city', ''))
+assert(not o.has_prefix('name', 'addr:'))
+assert(o.has_prefix('a', 'a'))
+assert(not o.has_prefix('a', 'ab'))
+
+-- has_suffix()
+
+assert(o.has_suffix('tiger:source', ':source'))
+assert(not o.has_suffix('tiger:source', 'foo'))
+assert(o.has_suffix('tiger:source', ''))
+assert(not o.has_suffix('name', ':source'))
+assert(o.has_suffix('a', 'a'))
+assert(not o.has_suffix('a', 'ba'))
+
+-- ---------------------------------------------------------------------------
+
 -- clamp
 do
     assert(o.clamp(1, 2, 3) == 2)
@@ -45,12 +65,18 @@ end
 
 -- make_clean_tags_func
 do
-    local clean_tags = o.make_clean_tags_func{'source', 'source:*', 'note'}
+    local clean_tags = o.make_clean_tags_func{'source',
+                                              'source:*',
+                                              '*:source',
+                                              'note'}
 
     local tags = {
         source = 'foo',
         highway = 'residential',
         ['source:url'] = 'bar',
+        ['tiger:source'] = 'value',
+        ['source:vs:source'] = 'removeme',
+        ['with:source:infix'] = 'keepme',
         NOTE = 'x'
     }
 
@@ -60,13 +86,16 @@ do
     assert(tags.NOTE == 'x')
     assert(tags.source == nil)
     assert(tags['source:url'] == nil)
+    assert(tags['tiger:source'] == nil)
+    assert(tags['source:vs:source'] == nil)
+    assert(tags['with:source:infix'] == 'keepme')
 
     num = 0
     for k, v in pairs(tags) do
         num = num + 1
     end
 
-    assert(num == 2)
+    assert(num == 3)
 end
 
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds Lua helper functions has_prefix() and has_suffix(). This is useful
for checks like osm2pgsql.has_prefix(some_tag, 'addr:').

Also add functionality to the osm2pgsql.make_clean_tags_func() function
to also check for suffixes, so '*:sources' will check for all tags
with suffix ':sources'.