### PR TITLE
Fix: Flex output could create two id indexes on the same table

### DIFF
--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -229,10 +229,7 @@ public:
 
     void prepare();
 
-    void create_id_index()
-    {
-        m_db_connection->exec(table().build_sql_create_id_index());
-    }
+    void create_id_index();
 
     pg_result_t get_geom_by_id(osmium::item_type type, osmid_t id) const;
 
@@ -264,6 +261,9 @@ private:
 
     /// The connection to the database server.
     std::unique_ptr<pg_conn_t> m_db_connection;
+
+    /// Has the Id index already been created?
+    bool m_id_index_created = false;
 
 }; // class table_connection_t
 

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1507,8 +1507,6 @@ void output_flex_t::reprocess_marked()
 
         for (auto &table : m_table_connections) {
             if (table.table().matches_type(osmium::item_type::way)) {
-                fmt::print(stderr, "  Creating id index on table '{}'...\n",
-                           table.table().name());
                 table.create_id_index();
             }
         }


### PR DESCRIPTION
The flex output could create two id indexes on the same table. This
happened for tables without geometry when 2-stage processing was used.
This fix keeps track of the id indexes on tables and never creates
an index if it already has one.

Fixes #1312