### PR TITLE
Output durations in more human readable form

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(osm2pgsql_lib_SOURCES
   taginfo.cpp
   tagtransform-c.cpp
   tagtransform.cpp
+  util.cpp
   wildcmp.cpp
 )
 

--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -276,8 +276,8 @@ void table_connection_t::stop(bool updateable, bool append)
     fmt::print(stderr, "Analyzing table '{}'...\n", table().name());
     m_db_connection->exec("ANALYZE " + table().full_name());
 
-    fmt::print(stderr, "All postprocessing on table '{}' done in {}s.\n",
-               table().name(), timer.stop());
+    fmt::print(stderr, "All postprocessing on table '{}' done in {}.\n",
+               table().name(), util::human_readable_duration(timer.stop()));
 
     teardown();
 }

--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -108,7 +108,8 @@ void middle_pgsql_t::table_desc::stop(std::string const &conninfo,
         sql_conn.exec(m_array_indexes);
     }
 
-    fmt::print(stderr, "Stopped table: {} in {}s\n", name(), timer.stop());
+    fmt::print(stderr, "Stopped table: {} in {}\n", name(),
+               util::human_readable_duration(timer.stop()));
 }
 
 namespace {

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -102,7 +102,8 @@ int main(int argc, char *argv[])
             progress.update(osmdata.process_file(file, options.bbox));
 
             progress.print_status(std::time(nullptr));
-            fmt::print(stderr, "  parse time: {}s\n", timer_parse.stop());
+            fmt::print(stderr, "  parse time: {}\n",
+                       util::human_readable_duration(timer_parse.stop()));
         }
 
         progress.print_summary();
@@ -111,8 +112,8 @@ int main(int argc, char *argv[])
         // create indexes.
         osmdata.stop();
 
-        fmt::print(stderr, "\nOsm2pgsql took {}s overall\n",
-                   timer_overall.stop());
+        fmt::print(stderr, "\nOsm2pgsql took {} overall\n",
+                   util::human_readable_duration(timer_overall.stop()));
     } catch (std::exception const &e) {
         fmt::print(stderr, "Osm2pgsql failed due to ERROR: {}\n", e.what());
         return 1;

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -342,8 +342,8 @@ private:
 
         timer.stop();
 
-        fmt::print(stderr, "\rFinished processing {} {}s in {} s\n\n",
-                   ids_queued, type, timer.elapsed());
+        fmt::print(stderr, "\rFinished processing {} {}s in {}\n\n", ids_queued,
+                   type, util::human_readable_duration(timer.elapsed()));
 
         if (timer.elapsed() > 0) {
             fmt::print(stderr,

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1511,8 +1511,8 @@ void output_flex_t::reprocess_marked()
             }
         }
 
-        fmt::print(stderr, "  Creating id indexes took {} seconds\n"_format(
-                               timer.stop()));
+        fmt::print(stderr, "  Creating id indexes took {}\n"_format(
+                               util::human_readable_duration(timer.stop())));
     }
 
     lua_gc(lua_state(), LUA_GCCOLLECT, 0);

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -272,8 +272,8 @@ void table_t::stop(bool updateable, bool enable_hstore_index,
         }
         fmt::print(stderr, "Creating indexes on {} finished\n", m_target->name);
         m_sql_conn->exec("ANALYZE {}"_format(qual_name));
-        fmt::print(stderr, "All indexes on {} created in {}s\n", m_target->name,
-                   timer.stop());
+        fmt::print(stderr, "All indexes on {} created in {}\n", m_target->name,
+                   util::human_readable_duration(timer.stop()));
     }
     teardown();
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,0 +1,19 @@
+
+#include "util.hpp"
+
+namespace util {
+
+std::string human_readable_duration(uint64_t seconds)
+{
+    if (seconds < 60) {
+        return "{}s"_format(seconds);
+    } else if (seconds < (60 * 60)) {
+        return "{}s ({}m {}s)"_format(seconds, seconds / 60, seconds % 60);
+    }
+
+    auto const secs = seconds % 60;
+    auto const mins = seconds / 60;
+    return "{}s ({}h {}m {}s)"_format(seconds, mins / 60, mins % 60, secs);
+}
+
+} // namespace util

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <ctime>
+#include <string>
 
 namespace util {
 
@@ -89,6 +90,8 @@ private:
     std::time_t m_stop = 0;
 
 }; // class timer_t
+
+std::string human_readable_duration(uint64_t seconds);
 
 } // namespace util
 

--- a/tests/test-util.cpp
+++ b/tests/test-util.cpp
@@ -34,3 +34,18 @@ TEST_CASE("double_to_buffer 3.141")
     util::double_to_buffer buffer{3.141};
     REQUIRE(std::strcmp(buffer.c_str(), "3.141") == 0);
 }
+
+TEST_CASE("human readable time durations")
+{
+    REQUIRE(util::human_readable_duration(0) == "0s");
+    REQUIRE(util::human_readable_duration(17) == "17s");
+    REQUIRE(util::human_readable_duration(59) == "59s");
+    REQUIRE(util::human_readable_duration(60) == "60s (1m 0s)");
+    REQUIRE(util::human_readable_duration(66) == "66s (1m 6s)");
+    REQUIRE(util::human_readable_duration(247) == "247s (4m 7s)");
+    REQUIRE(util::human_readable_duration(3599) == "3599s (59m 59s)");
+    REQUIRE(util::human_readable_duration(3600) == "3600s (1h 0m 0s)");
+    REQUIRE(util::human_readable_duration(3723) == "3723s (1h 2m 3s)");
+    REQUIRE(util::human_readable_duration(152592) == "152592s (42h 23m 12s)");
+}
+


### PR DESCRIPTION
osm2pgsql prints the duration of several bits of processing. This used
to be just something like "3723s". For large numbers this is
inconvenient. The new output keeps the seconds, but if the duration is
longer than 59 seconds, adds a better readable duration: "3723s (1h
2m 3s)".