### PR TITLE
Improved logging output with timestamps, level settings and more

### DIFF
--- a/docs/osm2pgsql.1
+++ b/docs/osm2pgsql.1
@@ -56,6 +56,23 @@ Add \f[B]\-v, \-\-verbose\f[] to display more verbose help.
 Print osm2pgsql version.
 .RS
 .RE
+.SH LOGGING OPTIONS
+.TP
+.B \-\-log\-level=LEVEL
+Set log level (`debug', `info' (default), `warn', or `error').
+.RS
+.RE
+.TP
+.B \-\-log\-sql
+Enable logging of SQL commands for debugging.
+.RS
+.RE
+.TP
+.B \-\-log\-sql\-data
+Enable logging of all data added to the database.
+This will write out a huge amount of data! For debugging.
+.RS
+.RE
 .SH DATABASE OPTIONS
 .TP
 .B \-d, \-\-database=NAME

--- a/docs/osm2pgsql.md
+++ b/docs/osm2pgsql.md
@@ -47,6 +47,26 @@ Mandatory arguments to long options are mandatory for short options too.
 -V, \--version
 :   Print osm2pgsql version.
 
+# LOGGING OPTIONS
+
+\--log-level=LEVEL
+:   Set log level ('debug', 'info' (default), 'warn', or 'error').
+
+\--log-progress=VALUE
+:   Enable (`true`) or disable (`false`) progress logging. The default is
+    `auto` which will enable progress logging on the console and disable it
+    if the output is redirected to a file.
+
+\--log-sql
+:   Enable logging of SQL commands for debugging.
+
+\--log-sql-data
+:   Enable logging of all data added to the database. This will write out
+    a huge amount of data! For debugging.
+
+-v, \--verbose
+:   Same as `--log-level=debug`.
+
 # DATABASE OPTIONS
 
 -d, \--database=NAME

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ set(osm2pgsql_lib_SOURCES
   geometry-processor.cpp
   id-tracker.cpp
   input-handler.cpp
+  logging.cpp
   middle-pgsql.cpp
   middle-ram.cpp
   node-persistent-cache.cpp

--- a/src/db-check.cpp
+++ b/src/db-check.cpp
@@ -1,5 +1,5 @@
 #include "db-check.hpp"
-#include "format.hpp"
+#include "logging.hpp"
 #include "pgsql.hpp"
 #include "version.hpp"
 
@@ -28,7 +28,7 @@ void check_db(options_t const &options)
     auto const settings = get_postgresql_settings(db_connection);
 
     try {
-        fmt::print("Database version: {}\n", settings.at("server_version"));
+        log_info("Database version: {}", settings.at("server_version"));
 
         auto const version_str = settings.at("server_version_num");
         auto const version = std::strtoul(version_str.c_str(), nullptr, 10);

--- a/src/db-copy.cpp
+++ b/src/db-copy.cpp
@@ -2,6 +2,7 @@
 
 #include "db-copy.hpp"
 #include "format.hpp"
+#include "logging.hpp"
 #include "pgsql.hpp"
 
 void db_deleter_by_id_t::delete_rows(std::string const &table,
@@ -151,7 +152,7 @@ void db_copy_thread_t::thread_t::operator()()
 
         m_conn.reset();
     } catch (std::runtime_error const &e) {
-        fmt::print(stderr, "DB copy thread failed: {}\n", e.what());
+        log_error("DB copy thread failed: {}", e.what());
         exit(2);
     }
 }

--- a/src/expire-tiles.hpp
+++ b/src/expire-tiles.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <unordered_set>
 
+#include "logging.hpp"
 #include "osmtypes.hpp"
 #include "pgsql.hpp"
 
@@ -30,7 +31,6 @@ struct xy_coord_t
 class tile_output_t
 {
     FILE *outfile;
-    uint32_t outcount = 0;
 
 public:
     tile_output_t(char const *filename);
@@ -93,6 +93,7 @@ struct expire_tiles
          * last_quadkey is initialized with a value which is not expected to exist
          * (larger than largest possible quadkey). */
         uint64_t last_quadkey = 1ULL << (2 * maxzoom);
+        std::size_t count = 0;
         for (std::vector<uint64_t>::const_iterator it = tiles_maxzoom.cbegin();
              it != tiles_maxzoom.cend(); ++it) {
             for (uint32_t dz = 0; dz <= maxzoom - minzoom; ++dz) {
@@ -107,9 +108,11 @@ struct expire_tiles
                 }
                 xy_coord_t xy = quadkey_to_xy(qt_current, maxzoom - dz);
                 output_writer.output_dirty_tile(xy.x, xy.y, maxzoom - dz);
+                ++count;
             }
             last_quadkey = *it;
         }
+        log_info("Wrote {} entries to expired tiles list", count);
     }
 
     /**

--- a/src/gazetteer-style.cpp
+++ b/src/gazetteer-style.cpp
@@ -8,6 +8,7 @@
 #include "domain-matcher.hpp"
 #include "format.hpp"
 #include "gazetteer-style.hpp"
+#include "logging.hpp"
 #include "pgsql.hpp"
 #include "wkb.hpp"
 
@@ -81,7 +82,7 @@ std::string gazetteer_style_t::class_list() const
 
 void gazetteer_style_t::load_style(std::string const &filename)
 {
-    fmt::print(stderr, "Parsing gazetteer style file '{}'.\n", filename);
+    log_info("Parsing gazetteer style file '{}'.", filename);
     pt::ptree root;
 
     pt::read_json(filename, root);

--- a/src/geom-transform.cpp
+++ b/src/geom-transform.cpp
@@ -1,5 +1,6 @@
 
 #include "geom-transform.hpp"
+#include "logging.hpp"
 
 #include <osmium/osm.hpp>
 
@@ -160,10 +161,9 @@ void init_geom_transform(geom_transform_t *transform, lua_State *lua_state)
 
         if (std::strcmp(field, "create") != 0) {
             if (!transform->set_param(field, lua_state) && show_warning) {
-                fmt::print(stderr,
-                           "\nWarning! Ignoring unknown field '{}' in geometry "
-                           "transformation description.\n",
-                           field);
+                log_warn("Ignoring unknown field '{}' in geometry "
+                         "transformation description.",
+                         field);
                 show_warning = false;
             }
         }

--- a/src/input-handler.cpp
+++ b/src/input-handler.cpp
@@ -2,6 +2,7 @@
 
 #include "format.hpp"
 #include "input-handler.hpp"
+#include "logging.hpp"
 #include "osmdata.hpp"
 
 input_handler_t::input_handler_t(osmium::Box const &bbox, bool append,
@@ -43,13 +44,8 @@ void input_handler_t::node(osmium::Node const &node)
         // we probably ought to treat invalid locations as if they were
         // deleted and ignore them.
         if (!node.location().valid()) {
-            fmt::print(
-                stderr,
-                "WARNING: Node {} (version {}) has an invalid location and has "
-                "been ignored. This is not expected to happen with recent "
-                "planet files, so please check that your input is correct.\n",
-                node.id(), node.version());
-
+            log_warn("Ignored invalid location on node {} (version {})",
+                     node.id(), node.version());
             return;
         }
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -1,0 +1,9 @@
+
+#include "logging.hpp"
+
+/// Global logger singleton
+logger the_logger{};
+
+/// Access the global logger singleton
+logger &get_logger() noexcept { return the_logger; }
+

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -1,0 +1,128 @@
+#ifndef OSM2PGSQL_LOGGING_HPP
+#define OSM2PGSQL_LOGGING_HPP
+
+#include "format.hpp"
+
+#include <osmium/util/file.hpp>
+
+#include <fmt/chrono.h>
+#include <fmt/color.h>
+
+#include <cstdio>
+#include <utility>
+
+enum class log_level
+{
+    debug = 1,
+    info = 2,
+    warn = 3,
+    error = 4
+};
+
+/**
+ * This class contains the logging state and code. It is intended as a
+ * singleton class. Its use is mostly wrapped in the log_*() free functions.
+ */
+class logger
+{
+public:
+    template <typename S, typename... TArgs>
+    void log(log_level with_level, char const *prefix,
+             fmt::text_style const &style, S const &format_str,
+             TArgs &&... tags) const
+    {
+        if (with_level < m_current_level) {
+            return;
+        }
+
+        auto const &ts = m_show_progress ? style : fmt::text_style{};
+
+        std::string str =
+            "{:%Y-%m-%d %H:%M:%S}  "_format(fmt::localtime(std::time(nullptr)));
+
+        if (prefix) {
+            str += fmt::format(ts, "{}: ", prefix);
+        }
+
+        str += fmt::format(ts, format_str, std::forward<TArgs>(tags)...);
+        str += '\n';
+
+        std::fputs(str.c_str(), stderr);
+    }
+
+    bool log_sql() const noexcept { return m_log_sql; }
+
+    bool log_sql_data() const noexcept { return m_log_sql_data; }
+
+    void set_level(log_level level) noexcept { m_current_level = level; }
+
+    void enable_sql() noexcept { m_log_sql = true; }
+
+    void enable_sql_data() noexcept { m_log_sql_data = true; }
+
+    bool show_progress() const noexcept { return m_show_progress; }
+
+    void enable_progress() noexcept { m_show_progress = true; }
+
+    void disable_progress() noexcept { m_show_progress = false; }
+
+private:
+    log_level m_current_level = log_level::info;
+    bool m_log_sql = false;
+    bool m_log_sql_data = false;
+    bool m_show_progress = osmium::util::isatty(2);
+
+}; // class logger
+
+logger &get_logger() noexcept;
+
+template <typename S, typename... TArgs>
+void log_debug(S const &format_str, TArgs &&... tags)
+{
+    get_logger().log(log_level::debug, nullptr, {}, format_str,
+                     std::forward<TArgs>(tags)...);
+}
+
+template <typename S, typename... TArgs>
+void log_info(S const &format_str, TArgs &&... tags)
+{
+    get_logger().log(log_level::info, nullptr, {}, format_str,
+                     std::forward<TArgs>(tags)...);
+}
+
+template <typename S, typename... TArgs>
+void log_warn(S const &format_str, TArgs &&... tags)
+{
+    get_logger().log(log_level::warn, "WARNING", fg(fmt::color::red),
+                     format_str, std::forward<TArgs>(tags)...);
+}
+
+template <typename S, typename... TArgs>
+void log_error(S const &format_str, TArgs &&... tags)
+{
+    get_logger().log(log_level::error, "ERROR",
+                     fmt::emphasis::bold | fg(fmt::color::red), format_str,
+                     std::forward<TArgs>(tags)...);
+}
+
+template <typename S, typename... TArgs>
+void log_sql(S const &format_str, TArgs &&... tags)
+{
+    auto const &logger = get_logger();
+    if (logger.log_sql()) {
+        logger.log(log_level::error, "SQL", fg(fmt::color::blue), format_str,
+                   std::forward<TArgs>(tags)...);
+    }
+}
+
+template <typename S, typename... TArgs>
+void log_sql_data(S const &format_str, TArgs &&... tags)
+{
+    auto const &logger = get_logger();
+    if (logger.log_sql_data()) {
+        logger.log(log_level::error, "SQL", {}, format_str,
+                   std::forward<TArgs>(tags)...);
+    }
+}
+
+#endif // OSM2PGSQL_LOGGING_HPP

--- a/src/node-persistent-cache.cpp
+++ b/src/node-persistent-cache.cpp
@@ -1,6 +1,6 @@
 #define _LARGEFILE64_SOURCE /* See feature_test_macros(7) */
 
-#include "format.hpp"
+#include "logging.hpp"
 #include "node-persistent-cache.hpp"
 #include "options.hpp"
 
@@ -52,13 +52,13 @@ node_persistent_cache::node_persistent_cache(
 
     m_fname = options->flat_node_file->c_str();
     m_remove_file = options->droptemp;
-    fmt::print(stderr, "Mid: loading persistent node cache from {}\n", m_fname);
+    log_info("Mid: loading persistent node cache from {}", m_fname);
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, hicpp-signed-bitwise)
     m_fd = open(m_fname, O_RDWR | O_CREAT, 0644);
     if (m_fd < 0) {
-        fmt::print(stderr, "Cannot open location cache file '{}': {}\n",
-                   m_fname, std::strerror(errno));
+        log_error("Cannot open location cache file '{}': {}", m_fname,
+                  std::strerror(errno));
         throw std::runtime_error{"Unable to open flatnode file."};
     }
 
@@ -74,8 +74,7 @@ node_persistent_cache::~node_persistent_cache() noexcept
 
     if (m_remove_file) {
         try {
-            fmt::print(stderr, "Mid: removing persistent node cache at {}\n",
-                       m_fname);
+            log_info("Mid: removing persistent node cache at {}", m_fname);
         } catch (...) {
         }
         unlink(m_fname);

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -137,6 +137,7 @@ public:
     database_options_t database_options;
     std::string output_backend{"pgsql"};
     std::string input_format; ///< input file format (default: autodetect)
+    std::string log_progress; ///< setting of the --log-progress option
     osmium::Box bbox;
     bool extra_attributes = false;
 

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -21,6 +21,7 @@
 #include <unistd.h>
 
 #include "expire-tiles.hpp"
+#include "logging.hpp"
 #include "middle.hpp"
 #include "node-ram-cache.hpp"
 #include "options.hpp"
@@ -343,8 +344,8 @@ output_pgsql_t::output_pgsql_t(
   buffer(32768, osmium::memory::Buffer::auto_grow::yes),
   rels_buffer(1024, osmium::memory::Buffer::auto_grow::yes)
 {
-    fmt::print(stderr, "Using projection SRS {} ({})\n",
-               o.projection->target_srs(), o.projection->target_desc());
+    log_info("Using projection SRS {} ({})", o.projection->target_srs(),
+             o.projection->target_desc());
 
     export_list exlist;
 

--- a/src/progress-display.cpp
+++ b/src/progress-display.cpp
@@ -1,4 +1,5 @@
 #include "format.hpp"
+#include "logging.hpp"
 #include "progress-display.hpp"
 
 void progress_display_t::update(progress_display_t const &other) noexcept
@@ -12,23 +13,26 @@ void progress_display_t::print_summary() const
 {
     std::time_t const now = std::time(nullptr);
 
-    fmt::print(stderr, "Node stats: total({}), max({}) in {}s\n", m_node.count,
-               m_node.max, nodes_time(now));
-    fmt::print(stderr, "Way stats: total({}), max({}) in {}s\n", m_way.count,
-               m_way.max, ways_time(now));
-    fmt::print(stderr, "Relation stats: total({}), max({}) in {}s\n",
-               m_rel.count, m_rel.max, rels_time(now));
+    log_info("Node stats: total({}), max({}) in {}s", m_node.count, m_node.max,
+             nodes_time(now));
+    log_info("Way stats: total({}), max({}) in {}s", m_way.count, m_way.max,
+             ways_time(now));
+    log_info("Relation stats: total({}), max({}) in {}s", m_rel.count,
+             m_rel.max, rels_time(now));
 }
 
 void progress_display_t::print_status(std::time_t now) const
 {
-    fmt::print(
-        stderr,
-        "\rProcessing: Node({}k {:.1f}k/s) Way({}k {:.2f}k/s)"
-        " Relation({} {:.1f}/s)",
-        m_node.count_k(), count_per_second(m_node.count_k(), nodes_time(now)),
-        m_way.count_k(), count_per_second(m_way.count_k(), ways_time(now)),
-        m_rel.count, count_per_second(m_rel.count, rels_time(now)));
+    if (get_logger().show_progress()) {
+        fmt::print(stderr,
+                   "\rProcessing: Node({}k {:.1f}k/s) Way({}k {:.2f}k/s)"
+                   " Relation({} {:.1f}/s)",
+                   m_node.count_k(),
+                   count_per_second(m_node.count_k(), nodes_time(now)),
+                   m_way.count_k(),
+                   count_per_second(m_way.count_k(), ways_time(now)),
+                   m_rel.count, count_per_second(m_rel.count, rels_time(now)));
+    }
 }
 
 void progress_display_t::possibly_print_status()

--- a/src/taginfo.cpp
+++ b/src/taginfo.cpp
@@ -1,4 +1,5 @@
 #include "format.hpp"
+#include "logging.hpp"
 #include "taginfo-impl.hpp"
 
 #include <cerrno>
@@ -57,8 +58,7 @@ unsigned parse_tag_flags(std::string const &flags, int lineno)
         if (it != tagflags.end()) {
             temp_flags |= it->second;
         } else {
-            fmt::print(stderr, "Unknown flag '{}' line {}, ignored\n",
-                       flag_name, lineno);
+            log_warn("Unknown flag '{}' line {}, ignored", flag_name, lineno);
         }
     }
 

--- a/src/tagtransform.cpp
+++ b/src/tagtransform.cpp
@@ -1,6 +1,6 @@
 #include "tagtransform.hpp"
 #include "config.h"
-#include "format.hpp"
+#include "logging.hpp"
 #include "options.hpp"
 #include "tagtransform-c.hpp"
 
@@ -14,9 +14,8 @@ tagtransform_t::make_tagtransform(options_t const *options,
 {
     if (options->tag_transform_script) {
 #ifdef HAVE_LUA
-        fmt::print(stderr,
-                   "Using lua based tag processing pipeline with script {}\n",
-                   options->tag_transform_script.get());
+        log_info("Using lua based tag transformations with script {}",
+                 options->tag_transform_script.get());
         return std::unique_ptr<tagtransform_t>(new lua_tagtransform_t{options});
 #else
         throw std::runtime_error{"Error: Could not init lua tag transform, as "
@@ -25,7 +24,7 @@ tagtransform_t::make_tagtransform(options_t const *options,
 #endif
     }
 
-    fmt::print(stderr, "Using built-in tag processing pipeline\n");
+    log_info("Using built-in tag transformations");
     return std::unique_ptr<tagtransform_t>(
         new c_tagtransform_t{options, exlist});
 }


### PR DESCRIPTION
This improves the logging output in several ways:

* New logging functions log_debug/info/warn/error(). Almost all
  output now uses one of these functions.
* Log messages start with timestamp.
* Log messages of level warn/error are printed in red when
  logging to console.
* New command line option: --log-level to set log level. Default
  is "info". The option -v, --verbose does the same as
  --log-level=debug.
* New option --log-progress=true/false/auto. The default is `auto`
  which enables progress logging on the console and disables it
  when stderr has been redirected to a file.
* Extra functions to log SQL commands/SQL COPY data. These can
  be activated by command line options --log-sql and --log-sql-data,
  respectively, instead of the compile time setting. Output is
  printed in blue when logging to console.

Most log messages are in level "info" at the moment, so they are shown
as before with the default settings. Many of these probably don't need
to be shown in normal operation and can be downgraded to "debug". I'll
leave this for a later commit.

There are several places in the code where the output is updated on the
screen while some longer process is running:

* The code displaying regular updates of a counter in the expire code
  has been removed. Writing out the expire data doesn't take that long,
  so it isn't important to have this. Instead a log message is now
  generated.
* The output of the objects being processed and the pending ways and
  relations output is now en/disabled by the `--log-progress` option.
  Otherwise it has not been touched. I'll leave cleaning that up
  for a later time.

Some error reporting code has also been changed. Usually errors should
be reported by throwing an exception that is then caught in the main()
function and written out. The exception should contain the whole
error message, sometimes additional logging lines are created before
throwing the error. There is probably some more cleanup needed here.

This introduces a new global object "the_logger". Otherwise we'd have to
add the logger as parameter to a lot of functions!

Fixes #202
Fixes #1246
Fixes #591