### PR TITLE
Check that you have any output tables defined in the flex config

### DIFF
--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1388,6 +1388,11 @@ output_flex_t::output_flex_t(
         init_lua(m_options.style);
     }
 
+    if (m_tables->empty()) {
+        throw std::runtime_error{
+            "No tables defined in Lua config. Nothing to do!"};
+    }
+
     assert(m_table_connections.empty());
     for (auto &table : *m_tables) {
         m_table_connections.emplace_back(&table, m_copy_thread);


### PR DESCRIPTION
Without tables defined there isn't anything to do. So this means
something is wrong with your configuration. Possibly you are using a Lua
transform config for the pgsql output instead of a flex config.

Fixes #1332