### PR TITLE
Log thread id in each log line when debug logging is enabled

### DIFF
--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -9,6 +9,8 @@
 #include <fmt/color.h>
 
 #include <cstdio>
+#include <sstream>
+#include <thread>
 #include <utility>
 
 enum class log_level
@@ -39,6 +41,13 @@ public:
 
         std::string str =
             "{:%Y-%m-%d %H:%M:%S}  "_format(fmt::localtime(std::time(nullptr)));
+
+        if (m_current_level == log_level::debug) {
+            std::stringstream s;
+            s << std::this_thread::get_id();
+            str += s.str();
+            str += ' ';
+        }
 
         if (prefix) {
             str += fmt::format(ts, "{}: ", prefix);


### PR DESCRIPTION
On Linux this looks something like this:

```
...
2020-12-20 16:43:05  140587509511936 Clustering table 'lines' by geometry...
2020-12-20 16:43:05  140587526297344 Clustering table 'points' by geometry...
2020-12-20 16:43:05  140587551475456 Clustering table 'polygons' by geometry...
2020-12-20 16:43:05  140588667282560 node cache: stored: 1439690(100.00%), storage efficiency: 49.89% (dense blocks: 3, sparse nodes: 1430441), hit rate: 100.00%
2020-12-20 16:43:05  140587517904640 Clustering table 'routes' by geometry...
2020-12-20 16:43:05  140587517904640 Using native order for clustering table 'routes'
2020-12-20 16:43:05  140587551475456 Using native order for clustering table 'polygons'
2020-12-20 16:43:05  140587509511936 Using native order for clustering table 'lines'
...
```