### PR TITLE
Simplify build on Alpine

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,22 @@ pkg install devel/cmake devel/boost-libs textproc/expat2 \
   databases/postgresql94-client graphics/proj lang/lua52
 ```
 
+On Alpine, use
+
+```sh
+apk --update-cache add cmake make g++ boost-dev expat-dev \
+  bzip2-dev zlib-dev libpq proj-dev lua5.3-dev
+```
+
+Due to Lua installation details, CMake only detects some of the
+required Lua paths on Alpine, but not the library.
+This can be resolved by setting the `LUA_DIR` environment variable,
+or you can modify `CMAKE_PREFIX_PATH` as mentioned below.
+
+```sh
+export LUA_DIR=<path>  # Defaults to /usr/lib/lua5.3/
+```
+
 Once dependencies are installed, use CMake to build the Makefiles in a separate
 folder:
 

--- a/README.md
+++ b/README.md
@@ -106,15 +106,6 @@ apk --update-cache add cmake make g++ boost-dev expat-dev \
   bzip2-dev zlib-dev libpq proj-dev lua5.3-dev
 ```
 
-Due to Lua installation details, CMake only detects some of the
-required Lua paths on Alpine, but not the library.
-This can be resolved by setting the `LUA_DIR` environment variable,
-or you can modify `CMAKE_PREFIX_PATH` as mentioned below.
-
-```sh
-export LUA_DIR=<path>  # Defaults to /usr/lib/lua5.3/
-```
-
 Once dependencies are installed, use CMake to build the Makefiles in a separate
 folder:
 

--- a/cmake/FindLua.cmake
+++ b/cmake/FindLua.cmake
@@ -114,7 +114,7 @@ find_library(LUA_LIBRARY
   NAMES ${_lua_library_names} lua
   HINTS
     ENV LUA_DIR
-  PATH_SUFFIXES lib
+  PATH_SUFFIXES lib ${_lua_library_names}
   PATHS
   ~/Library/Frameworks
   /Library/Frameworks


### PR DESCRIPTION
Hey,

I was building osm2pgsql in an Alpine container and due to Alpine's popularity I figured it couldn't hurt to add Alpine build instructions while I'm at it.

I may have included a bit too much detail, but I was hoping it could save someone some time of troubleshooting why CMake is only finding part of the Lua "dependencies" (no unversioned symlink to `/usr/lib/lua5.3/liblua-5.3.{so|a}` under `/usr/lib`).

Thanks