### PR TITLE
cmake: add option whether to install osm2pgsql

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(BUILD_TESTS    "Build test suite" OFF)
 option(BUILD_COVERAGE "Build with coverage" OFF)
 option(WITH_LUA       "Build with Lua support" ON)
 option(WITH_LUAJIT    "Build with LuaJIT support" OFF)
+option(INSTALL_OSM2PGSQL "Install osm2pgsql binary and data" ON)
 
 if (PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
     message(FATAL_ERROR "In-source builds are not allowed, please use a separate build directory like `mkdir build && cd build && cmake ..`")
@@ -324,5 +325,7 @@ add_subdirectory(docs)
 # Install
 #############################################################
 
-install(TARGETS osm2pgsql DESTINATION bin)
-install(FILES default.style empty.style DESTINATION share/osm2pgsql)
+if (INSTALL_OSM2PGSQL)
+    install(TARGETS osm2pgsql DESTINATION bin)
+    install(FILES default.style empty.style DESTINATION share/osm2pgsql)
+endif()

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -27,5 +27,7 @@ else()
     message(STATUS "  Manual page can not be built")
 endif()
 
-install(FILES osm2pgsql.1 DESTINATION share/man/man1)
+if (INSTALL_OSM2PGSQL)
+    install(FILES osm2pgsql.1 DESTINATION share/man/man1)
+endif()
 


### PR DESCRIPTION
This option can be useful when osm2pgsql is used as a subproject and the main project wants to offer different installation commands.

In that particular case, I'd like to have it for Nominatim which would install a private copy of the osm2pgsql it needs. I'm aware that this is not an ideal solution but we are not yet at the point where Nominatim can simply use whatever osm2pgsql that is installed in the system.