### PR TITLE
Disable install targets when osm2pgsql is inside a subdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,15 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+# Do not create install targets when run as a subproject.
+# Currently used by Nominatim which cannot yet rely on installed versions
+# of osm2pgsql.
+if (${PROJECT_NAME} STREQUAL ${CMAKE_PROJECT_NAME})
+    set(ENABLE_INSTALL ON)
+else()
+    set(ENABLE_INSTALL OFF)
+endif()
+
 if (WIN32)
     set(DEFAULT_STYLE "default.style" CACHE STRING "Default style used unless one is given on the command line")
 else()
@@ -324,5 +333,7 @@ add_subdirectory(docs)
 # Install
 #############################################################
 
-install(TARGETS osm2pgsql DESTINATION bin)
-install(FILES default.style empty.style DESTINATION share/osm2pgsql)
+if (ENABLE_INSTALL)
+    install(TARGETS osm2pgsql DESTINATION bin)
+    install(FILES default.style empty.style DESTINATION share/osm2pgsql)
+endif()

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -27,5 +27,6 @@ else()
     message(STATUS "  Manual page can not be built")
 endif()
 
-install(FILES osm2pgsql.1 DESTINATION share/man/man1)
-
+if (ENABLE_INSTALL)
+    install(FILES osm2pgsql.1 DESTINATION share/man/man1)
+endif()


### PR DESCRIPTION
@joto suggested a different variant for #1413, where we simply don't add the install target when osm2pgsql is being included as a subproject. I think that's more elegant.