### PR TITLE
Use double quote on all table names etc. in middle

### DIFF
--- a/src/table.cpp
+++ b/src/table.cpp
@@ -225,8 +225,8 @@ void table_t::stop(bool updateable, bool enable_hstore_index,
         m_sql_conn->exec(sql);
 
         m_sql_conn->exec("DROP TABLE {}"_format(qual_name));
-        m_sql_conn->exec(
-            "ALTER TABLE {} RENAME TO {}"_format(qual_tmp_name, m_target->name));
+        m_sql_conn->exec("ALTER TABLE {} RENAME TO \"{}\""_format(
+            qual_tmp_name, m_target->name));
 
         log_info("Creating geometry index on table '{}'...", m_target->name);
 

--- a/tests/test-middle.cpp
+++ b/tests/test-middle.cpp
@@ -44,6 +44,26 @@ struct options_slim_default
     }
 };
 
+struct options_slim_with_lc_prefix
+{
+    static options_t options(testing::pg::tempdb_t const &tmpdb)
+    {
+        options_t o = testing::opt_t().slim(tmpdb);
+        o.prefix = "pre";
+        return o;
+    }
+};
+
+struct options_slim_with_uc_prefix
+{
+    static options_t options(testing::pg::tempdb_t const &tmpdb)
+    {
+        options_t o = testing::opt_t().slim(tmpdb);
+        o.prefix = "PRE";
+        return o;
+    }
+};
+
 struct options_slim_with_schema
 {
     static options_t options(testing::pg::tempdb_t const &tmpdb)
@@ -112,6 +132,7 @@ TEST_CASE("elem_cache_t")
 }
 
 TEMPLATE_TEST_CASE("middle import", "", options_slim_default,
+                   options_slim_with_lc_prefix, options_slim_with_uc_prefix,
                    options_slim_with_schema, options_slim_dense_cache,
                    options_ram_optimized, options_ram_flatnode)
 {


### PR DESCRIPTION
PostgreSQL handles plain tables name differently than it handles quoted
names. So `CREATE TABLE DEU_nodes;` is different than `CREATE TABLE
"DEU_nodes";`. In the first case the name is canonilcalized to lower
case. This quotes names in all places so we get exactly the name we ask
for.

Fixes #1420