### PR TITLE
cmake: use PROJECT_SOURCE_DIR when getting git version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ find_package(Git)
 
 if (GIT_FOUND)
     execute_process(COMMAND "${GIT_EXECUTABLE}" describe --tags --dirty=-changed
-                    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
                     OUTPUT_VARIABLE VERSION_FROM_GIT
                     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
     if (VERSION_FROM_GIT)


### PR DESCRIPTION
This only makes a difference when osm2pgsql is used as a subproject (i.e. in Nominatim). PROJECT_SOURCE_DIR refers to the subproject while CMAKE_SOURCE_DIR refers to the overall one.