### PR TITLE
Remove possible dangling pointer from node_persistent_cache

### DIFF
--- a/src/node-persistent-cache.hpp
+++ b/src/node-persistent-cache.hpp
@@ -11,6 +11,7 @@
  */
 
 #include <memory>
+#include <string>
 
 #include <osmium/index/map/dense_file_array.hpp>
 #include <osmium/osm/location.hpp>
@@ -20,7 +21,7 @@
 class node_persistent_cache
 {
 public:
-    node_persistent_cache(std::string const &file_name, bool remove_file);
+    node_persistent_cache(std::string file_name, bool remove_file);
     ~node_persistent_cache() noexcept;
 
     void set(osmid_t id, osmium::Location location);
@@ -31,10 +32,10 @@ private:
         osmium::index::map::DenseFileArray<osmium::unsigned_object_id_type,
                                            osmium::Location>;
 
+    std::string m_file_name;
     int m_fd = -1;
     std::unique_ptr<index_t> m_index;
-    bool m_remove_file = false;
-    char const *m_fname = nullptr;
+    bool m_remove_file;
 };
 
 #endif // OSM2PGSQL_NODE_PERSISTENT_CACHE_HPP


### PR DESCRIPTION
Storing a pointer to a string that might go away isn't a good idea.
Using std::string instead. Also slightly improved logging.