### PR TITLE
Remove unnecessary define (already set in CMake config)

### DIFF
--- a/src/node-persistent-cache.cpp
+++ b/src/node-persistent-cache.cpp
@@ -7,8 +7,6 @@
  * For a full list of authors see the git log.
  */
 
-#define _LARGEFILE64_SOURCE /* See feature_test_macros(7) */
-
 #include "logging.hpp"
 #include "node-persistent-cache.hpp"
 


### PR DESCRIPTION
This is already set from cmake/FindOsmium.cmake .

Superseeds PR #1452