### PR TITLE
Disable more clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -56,4 +56,6 @@ HeaderFilterRegex: '\/src\/'
 CheckOptions:
     - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
       value: true
+    - key: hicpp-special-member-functions.AllowSoleDefaultDtor
+      value: true
 ...


### PR DESCRIPTION
hicpp-special-member-functions is an alias for
cppcoreguidelines-special-member-functions, so we need both in the
config file.