### PR TITLE
Directly use std::string reference instead of calling c_str()

### DIFF
--- a/src/expire-tiles.cpp
+++ b/src/expire-tiles.cpp
@@ -265,13 +265,13 @@ int expire_tiles::from_bbox(double min_lon, double min_lat, double max_lon,
     return 0;
 }
 
-void expire_tiles::from_wkb(char const *wkb, osmid_t osm_id)
+void expire_tiles::from_wkb(std::string const &wkb, osmid_t osm_id)
 {
     if (maxzoom == 0) {
         return;
     }
 
-    auto parse = ewkb::parser_t(wkb);
+    ewkb::parser_t parse{wkb};
 
     switch (parse.read_header()) {
     case ewkb::wkb_point:
@@ -401,7 +401,7 @@ int expire_tiles::from_db(table_t *table, osmid_t osm_id)
     char const *wkb = nullptr;
     while ((wkb = wkbs.get_next())) {
         auto const binwkb = ewkb::parser_t::wkb_from_hex(wkb);
-        from_wkb(binwkb.c_str(), osm_id);
+        from_wkb(binwkb, osm_id);
     }
 
     //return how many rows were affected
@@ -420,7 +420,7 @@ int expire_tiles::from_result(pg_result_t const &result, osmid_t osm_id)
     for (int i = 0; i < num_tuples; ++i) {
         char const *const wkb = result.get_value(i, 0);
         auto const binwkb = ewkb::parser_t::wkb_from_hex(wkb);
-        from_wkb(binwkb.c_str(), osm_id);
+        from_wkb(binwkb, osm_id);
     }
 
     //return how many rows were affected

--- a/src/expire-tiles.hpp
+++ b/src/expire-tiles.hpp
@@ -64,7 +64,7 @@ struct expire_tiles
 
     int from_bbox(double min_lon, double min_lat, double max_lon,
                   double max_lat);
-    void from_wkb(char const *wkb, osmid_t osm_id);
+    void from_wkb(std::string const &wkb, osmid_t osm_id);
     int from_db(table_t *table, osmid_t osm_id);
     int from_result(pg_result_t const &result, osmid_t osm_id);
 

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1053,7 +1053,7 @@ void output_flex_t::add_row(table_connection_t *table_connection,
     auto const wkbs =
         run_transform(builder, transform, table.geom_column().type(), object);
     for (auto const &wkb : wkbs) {
-        m_expire.from_wkb(wkb.c_str(), id);
+        m_expire.from_wkb(wkb, id);
         write_row(table_connection, object.type(), id, wkb,
                   table.geom_column().srid());
     }

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -50,7 +50,7 @@ void output_pgsql_t::pgsql_out_way(osmium::Way const &way, taglist_t *tags,
     if (polygon && way.is_closed()) {
         auto wkb = m_builder.get_wkb_polygon(way);
         if (!wkb.empty()) {
-            expire.from_wkb(wkb.c_str(), way.id());
+            expire.from_wkb(wkb, way.id());
             if (m_enable_way_area) {
                 auto const area =
                     m_options.reproject_area
@@ -67,7 +67,7 @@ void output_pgsql_t::pgsql_out_way(osmium::Way const &way, taglist_t *tags,
         double const split_at =
             m_options.projection->target_latlon() ? 1 : 100 * 1000;
         for (auto const &wkb : m_builder.get_wkb_line(way.nodes(), split_at)) {
-            expire.from_wkb(wkb.c_str(), way.id());
+            expire.from_wkb(wkb, way.id());
             m_tables[t_line]->write_row(way.id(), *tags, wkb);
             if (roads) {
                 m_tables[t_roads]->write_row(way.id(), *tags, wkb);
@@ -143,7 +143,7 @@ void output_pgsql_t::node_add(osmium::Node const &node)
     }
 
     auto wkb = m_builder.get_wkb_node(node.location());
-    expire.from_wkb(wkb.c_str(), node.id());
+    expire.from_wkb(wkb, node.id());
     m_tables[t_point]->write_row(node.id(), outtags, wkb);
 }
 
@@ -206,7 +206,7 @@ void output_pgsql_t::pgsql_process_relation(osmium::Relation const &rel)
             m_options.projection->target_latlon() ? 1 : 100 * 1000;
         auto wkbs = m_builder.get_wkb_multiline(buffer, split_at);
         for (auto const &wkb : wkbs) {
-            expire.from_wkb(wkb.c_str(), -rel.id());
+            expire.from_wkb(wkb, -rel.id());
             m_tables[t_line]->write_row(-rel.id(), outtags, wkb);
             if (roads) {
                 m_tables[t_roads]->write_row(-rel.id(), outtags, wkb);
@@ -219,7 +219,7 @@ void output_pgsql_t::pgsql_process_relation(osmium::Relation const &rel)
         auto wkbs = m_builder.get_wkb_multipolygon(rel, buffer, m_options.enable_multi);
 
         for (auto const &wkb : wkbs) {
-            expire.from_wkb(wkb.c_str(), -rel.id());
+            expire.from_wkb(wkb, -rel.id());
             if (m_enable_way_area) {
                 auto const area =
                     m_options.reproject_area


### PR DESCRIPTION
A `std::string` reference contains more information, specifically the length of the string which is lost when using `c_str()`. So it is better to keep working with a std::string reference where possible.