### PR TITLE
Remove role list parameter from rel_way_members_get()

### DIFF
--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -428,7 +428,6 @@ bool middle_query_pgsql_t::way_get(osmid_t id,
 
 size_t
 middle_query_pgsql_t::rel_way_members_get(osmium::Relation const &rel,
-                                          rolelist_t *roles,
                                           osmium::memory::Buffer *buffer) const
 {
     assert(buffer);
@@ -466,9 +465,6 @@ middle_query_pgsql_t::rel_way_members_get(osmium::Relation const &rel,
                 }
 
                 buffer->commit();
-                if (roles) {
-                    roles->emplace_back(m.role());
-                }
                 ++outres;
                 break;
             }

--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -41,7 +41,7 @@ public:
 
     bool way_get(osmid_t id, osmium::memory::Buffer *buffer) const override;
 
-    size_t rel_way_members_get(osmium::Relation const &rel, rolelist_t *roles,
+    size_t rel_way_members_get(osmium::Relation const &rel,
                                osmium::memory::Buffer *buffer) const override;
 
     bool relation_get(osmid_t id,

--- a/src/middle-ram.cpp
+++ b/src/middle-ram.cpp
@@ -236,7 +236,6 @@ get_delta_encoded_way_nodes_list(std::string const &data, std::size_t offset,
 
 std::size_t
 middle_ram_t::rel_way_members_get(osmium::Relation const &rel,
-                                  rolelist_t *roles,
                                   osmium::memory::Buffer *buffer) const
 {
     assert(buffer);
@@ -263,9 +262,6 @@ middle_ram_t::rel_way_members_get(osmium::Relation const &rel,
                 if (offset != ordered_index_t::not_found_value()) {
                     buffer->add_item(m_object_buffer.get<osmium::Way>(offset));
                     buffer->commit();
-                    if (roles) {
-                        roles->emplace_back(member.role());
-                    }
                     ++count;
                 }
             } else if (m_store_options.way_nodes) {

--- a/src/middle-ram.hpp
+++ b/src/middle-ram.hpp
@@ -59,7 +59,7 @@ public:
     bool way_get(osmid_t id, osmium::memory::Buffer *buffer) const override;
 
     std::size_t
-    rel_way_members_get(osmium::Relation const &rel, rolelist_t *roles,
+    rel_way_members_get(osmium::Relation const &rel,
                         osmium::memory::Buffer *buffer) const override;
 
     bool relation_get(osmid_t id,

--- a/src/middle.hpp
+++ b/src/middle.hpp
@@ -52,11 +52,10 @@ struct middle_query_t : std::enable_shared_from_this<middle_query_t>
      * the given osmium buffer.
      *
      * \param      rel    Relation to get the members for.
-     * \param[out] roles  Roles for the ways that where retrived.
      * \param[out] buffer Buffer where to store the members in.
      */
     virtual size_t
-    rel_way_members_get(osmium::Relation const &rel, rolelist_t *roles,
+    rel_way_members_get(osmium::Relation const &rel,
                         osmium::memory::Buffer *buffer) const = 0;
 
     /**

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1004,8 +1004,7 @@ output_flex_t::run_transform(geom::osmium_builder_t *builder,
                              osmium::Relation const &relation)
 {
     m_buffer.clear();
-    auto const num_ways =
-        m_mid->rel_way_members_get(relation, nullptr, &m_buffer);
+    auto const num_ways = m_mid->rel_way_members_get(relation, &m_buffer);
 
     if (num_ways == 0) {
         return {};

--- a/src/output-gazetteer.cpp
+++ b/src/output-gazetteer.cpp
@@ -190,8 +190,7 @@ bool output_gazetteer_t::process_relation(osmium::Relation const &rel)
 
     /* get the boundary path (ways) */
     m_osmium_buffer.clear();
-    auto const num_ways =
-        m_mid->rel_way_members_get(rel, nullptr, &m_osmium_buffer);
+    auto const num_ways = m_mid->rel_way_members_get(rel, &m_osmium_buffer);
 
     if (num_ways == 0) {
         return false;

--- a/tests/test-middle.cpp
+++ b/tests/test-middle.cpp
@@ -235,9 +235,7 @@ TEMPLATE_TEST_CASE("middle import", "", options_slim_default,
         CHECK(orig_crc().checksum() == crc().checksum());
 
         // retrive the supporting ways
-        rolelist_t roles;
-        REQUIRE(mid_q->rel_way_members_get(rel, &roles, &outbuf) == 3);
-        REQUIRE(roles.size() == 3);
+        REQUIRE(mid_q->rel_way_members_get(rel, &outbuf) == 3);
 
         for (auto &w : outbuf.select<osmium::Way>()) {
             REQUIRE(w.id() >= 10);


### PR DESCRIPTION
It should not be the job of the middle to extract the roles from the
relation it retrieves. This removes the role list parameter from
rel_way_members_get() function.

But a quirk of the pgsql output is that the roles of all available
member ways of a relation are available in the Lua
"filter_tags_relation_member" callback function. This is probably not
used very often (if at all), but we need to keep that functionality
available for backwards compatibility.

So this adds a new function get_rolelist() to the pgsql output which
creates this role list.