### PR TITLE
Refactoring of WKB code

### DIFF
--- a/src/wkb.hpp
+++ b/src/wkb.hpp
@@ -101,22 +101,6 @@ inline std::string create_point(double x, double y, uint32_t srid = 4326)
  */
 class writer_t
 {
-
-    std::string m_data;
-    uint32_t m_srid;
-
-    std::size_t m_geometry_size_offset = 0;
-    std::size_t m_multigeometry_size_offset = 0;
-    std::size_t m_ring_size_offset = 0;
-
-    void set_size(std::size_t offset, std::size_t size)
-    {
-        assert(m_data.size() >= offset + sizeof(uint32_t));
-        auto const s = static_cast<uint32_t>(size);
-        std::memcpy(&m_data[offset], reinterpret_cast<char const *>(&s),
-                    sizeof(uint32_t));
-    }
-
 public:
     explicit writer_t(uint32_t srid) : m_srid(srid) {}
 
@@ -230,6 +214,23 @@ public:
 
         return data;
     }
+
+private:
+    void set_size(std::size_t offset, std::size_t size)
+    {
+        assert(m_data.size() >= offset + sizeof(uint32_t));
+        auto const s = static_cast<uint32_t>(size);
+        std::memcpy(&m_data[offset], reinterpret_cast<char const *>(&s),
+                    sizeof(uint32_t));
+    }
+
+    std::string m_data;
+
+    std::size_t m_geometry_size_offset = 0;
+    std::size_t m_multigeometry_size_offset = 0;
+    std::size_t m_ring_size_offset = 0;
+
+    uint32_t m_srid;
 }; // class writer_t
 
 /**

--- a/src/wkb.hpp
+++ b/src/wkb.hpp
@@ -81,6 +81,19 @@ inline std::size_t write_header_with_length(std::string *str,
     return offset;
 }
 
+/// Create EWKB Point geometry.
+inline std::string create_point(double x, double y, uint32_t srid = 4326)
+{
+    std::string data;
+    data.reserve(25); // Point geometries are always 25 bytes
+
+    write_header(&data, wkb_point, srid);
+    str_push(&data, x);
+    str_push(&data, y);
+
+    return data;
+}
+
 /**
  *  Writer for EWKB data suitable for postgres.
  *
@@ -124,12 +137,7 @@ public:
 
     std::string make_point(osmium::geom::Coordinates const &xy) const
     {
-        std::string data;
-        write_header(&data, wkb_point, m_srid);
-        str_push(&data, xy.x);
-        str_push(&data, xy.y);
-
-        return data;
+        return create_point(xy.x, xy.y, m_srid);
     }
 
     /* LineString */


### PR DESCRIPTION
These commits refactor some of the WKB code step by step to
* make it cleaner
* pull generation of points geometries out of the `ewkb::writer_t` class to make its use faster and simpler (we'll use this in the upcoming new pgsql middle)
* fix potential buffer overflow in `ewkb::parser_t`

This leaves the WKB code a bit cleaner, there is still the `get_area()` function etc. to clean up which doesn't really belong in the `parser_t` class and some of the code should probably be moved into a `.cpp` file, but I leave that for another day.