### PR TITLE
Refactor middle interface to get relation members

### DIFF
--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -427,10 +427,18 @@ bool middle_query_pgsql_t::way_get(osmid_t id,
 }
 
 size_t
-middle_query_pgsql_t::rel_way_members_get(osmium::Relation const &rel,
-                                          osmium::memory::Buffer *buffer) const
+middle_query_pgsql_t::rel_members_get(osmium::Relation const &rel,
+                                      osmium::memory::Buffer *buffer,
+                                      osmium::osm_entity_bits::type types) const
 {
     assert(buffer);
+
+    // Only way members are supported by this middle.
+    if (types != osmium::osm_entity_bits::way) {
+        // Not using assert() here because the "types" variable would then
+        // be detected as unused by the compiler generating a warning.
+        std::abort();
+    }
 
     util::string_id_list_t id_list;
 

--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -41,8 +41,9 @@ public:
 
     bool way_get(osmid_t id, osmium::memory::Buffer *buffer) const override;
 
-    size_t rel_way_members_get(osmium::Relation const &rel,
-                               osmium::memory::Buffer *buffer) const override;
+    size_t rel_members_get(osmium::Relation const &rel,
+                           osmium::memory::Buffer *buffer,
+                           osmium::osm_entity_bits::type types) const override;
 
     bool relation_get(osmid_t id,
                       osmium::memory::Buffer *buffer) const override;

--- a/src/middle-ram.cpp
+++ b/src/middle-ram.cpp
@@ -235,14 +235,21 @@ get_delta_encoded_way_nodes_list(std::string const &data, std::size_t offset,
 }
 
 std::size_t
-middle_ram_t::rel_way_members_get(osmium::Relation const &rel,
-                                  osmium::memory::Buffer *buffer) const
+middle_ram_t::rel_members_get(osmium::Relation const &rel,
+                              osmium::memory::Buffer *buffer,
+                              osmium::osm_entity_bits::type types) const
 {
     assert(buffer);
 
     std::size_t count = 0;
 
     for (auto const &member : rel.members()) {
+        auto const member_entity_type =
+            osmium::osm_entity_bits::from_item_type(member.type());
+        if ((member_entity_type & types) == 0) {
+            continue;
+        }
+
         switch (member.type()) {
         case osmium::item_type::node:
             if (m_store_options.nodes) {

--- a/src/middle-ram.hpp
+++ b/src/middle-ram.hpp
@@ -58,9 +58,9 @@ public:
 
     bool way_get(osmid_t id, osmium::memory::Buffer *buffer) const override;
 
-    std::size_t
-    rel_way_members_get(osmium::Relation const &rel,
-                        osmium::memory::Buffer *buffer) const override;
+    size_t rel_members_get(osmium::Relation const &rel,
+                           osmium::memory::Buffer *buffer,
+                           osmium::osm_entity_bits::type types) const override;
 
     bool relation_get(osmid_t id,
                       osmium::memory::Buffer *buffer) const override;

--- a/src/middle.hpp
+++ b/src/middle.hpp
@@ -11,6 +11,7 @@
  */
 
 #include <osmium/memory/buffer.hpp>
+#include <osmium/osm/entity_bits.hpp>
 
 #include <memory>
 
@@ -48,15 +49,18 @@ struct middle_query_t : std::enable_shared_from_this<middle_query_t>
     virtual bool way_get(osmid_t id, osmium::memory::Buffer *buffer) const = 0;
 
     /**
-     * Retrieves the way members of a relation and stores them in
-     * the given osmium buffer.
+     * Retrieves the members of a relation and stores them in an Osmium
+     * buffer. If a member is not available that is not an error.
      *
      * \param      rel    Relation to get the members for.
      * \param[out] buffer Buffer where to store the members in.
+     * \param      types  The types of members we are interested in.
+     *
+     * \return The number of members we could get.
      */
     virtual size_t
-    rel_way_members_get(osmium::Relation const &rel,
-                        osmium::memory::Buffer *buffer) const = 0;
+    rel_members_get(osmium::Relation const &rel, osmium::memory::Buffer *buffer,
+                    osmium::osm_entity_bits::type types) const = 0;
 
     /**
      * Retrives a single relation from the relation storage

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1004,7 +1004,8 @@ output_flex_t::run_transform(geom::osmium_builder_t *builder,
                              osmium::Relation const &relation)
 {
     m_buffer.clear();
-    auto const num_ways = m_mid->rel_way_members_get(relation, &m_buffer);
+    auto const num_ways = m_mid->rel_members_get(relation, &m_buffer,
+                                                 osmium::osm_entity_bits::way);
 
     if (num_ways == 0) {
         return {};

--- a/src/output-gazetteer.cpp
+++ b/src/output-gazetteer.cpp
@@ -190,7 +190,8 @@ bool output_gazetteer_t::process_relation(osmium::Relation const &rel)
 
     /* get the boundary path (ways) */
     m_osmium_buffer.clear();
-    auto const num_ways = m_mid->rel_way_members_get(rel, &m_osmium_buffer);
+    auto const num_ways = m_mid->rel_members_get(rel, &m_osmium_buffer,
+                                                 osmium::osm_entity_bits::way);
 
     if (num_ways == 0) {
         return false;

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -203,7 +203,8 @@ void output_pgsql_t::pgsql_process_relation(osmium::Relation const &rel)
     }
 
     buffer.clear();
-    auto const num_ways = m_mid->rel_way_members_get(rel, &buffer);
+    auto const num_ways =
+        m_mid->rel_members_get(rel, &buffer, osmium::osm_entity_bits::way);
 
     if (num_ways == 0) {
         return;

--- a/tests/test-middle.cpp
+++ b/tests/test-middle.cpp
@@ -234,8 +234,9 @@ TEMPLATE_TEST_CASE("middle import", "", options_slim_default,
         crc.update(rel);
         CHECK(orig_crc().checksum() == crc().checksum());
 
-        // retrive the supporting ways
-        REQUIRE(mid_q->rel_way_members_get(rel, &outbuf) == 3);
+        // retrieve the supporting ways
+        REQUIRE(mid_q->rel_members_get(rel, &outbuf,
+                                       osmium::osm_entity_bits::way) == 3);
 
         for (auto &w : outbuf.select<osmium::Way>()) {
             REQUIRE(w.id() >= 10);


### PR DESCRIPTION
In the future we want the middle to be able to return not only way
members of relations but any type of member. This renames the
function rel_way_members_get() to rel_members_get() and adds an extra
parameter that specifies which types of members we are interested
in. The ram middle already supports accessing non-way members, but
the pgsql middle still only supports way members.