### PR TITLE
Document PostgreSQL 9.5 as oldest supported version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           PGHOST: /tmp
 
 
-  ubuntu16-pg93-gcc5:
+  ubuntu16-pg95-gcc5:
     runs-on: ubuntu-16.04
 
     env:
@@ -44,8 +44,8 @@ jobs:
       CXX: g++-5
       LUA_VERSION: 5.1
       LUAJIT_OPTION: OFF
-      POSTGRESQL_VERSION: 9.3
-      POSTGIS_VERSION: 2.2
+      POSTGRESQL_VERSION: 9.5
+      POSTGIS_VERSION: 2.3
       BUILD_TYPE: Release
 
     steps:
@@ -53,7 +53,7 @@ jobs:
       - uses: ./.github/actions/ubuntu-prerequisites
       - uses: ./.github/actions/build-and-test
 
-  ubuntu16-pg94-clang6:
+  ubuntu16-pg95-clang6:
     runs-on: ubuntu-16.04
 
     env:
@@ -61,7 +61,7 @@ jobs:
       CXX: clang++-6.0
       LUA_VERSION: 5.2
       LUAJIT_OPTION: OFF
-      POSTGRESQL_VERSION: 9.4
+      POSTGRESQL_VERSION: 9.5
       POSTGIS_VERSION: 2.3
       BUILD_TYPE: Release
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Required libraries are
 * [Psycopg](http://initd.org/psycopg/) (only for running tests)
 
 It also requires access to a database server running
-[PostgreSQL](https://www.postgresql.org/) 9.3+ and
+[PostgreSQL](https://www.postgresql.org/) 9.5+ and
 [PostGIS](http://www.postgis.net/) 2.2+.
 
 Make sure you have installed the development packages for the libraries


### PR DESCRIPTION
Up from 9.3. We need to go to at least 9.4 because we will need the
JSONB datatype. 9.5 is used by Ubuntu 16.04. 9.6 is the oldest
version currently still supported by the PostgreSQL project.