### PR TITLE
Simplify code around expiry

### DIFF
--- a/src/expire-tiles.cpp
+++ b/src/expire-tiles.cpp
@@ -377,37 +377,6 @@ void expire_tiles::from_wkb_polygon(ewkb::parser_t *wkb, osmid_t osm_id)
     }
 }
 
-/*
- * Expire tiles based on an osm element.
- * What type of element (node, line, polygon) osm_id refers to depends on
- * sql_conn. Each type of table has its own sql_conn and the prepared statement
- * get_wkb refers to the appropriate table.
- *
- * The function returns -1 if expiry is not enabled. Otherwise it returns the number
- * of elements that refer to the osm_id.
-
- */
-int expire_tiles::from_db(table_t *table, osmid_t osm_id)
-{
-    //bail if we dont care about expiry
-    if (maxzoom == 0) {
-        return -1;
-    }
-
-    //grab the geom for this id
-    auto wkbs = table->get_wkb_reader(osm_id);
-
-    //dirty the stuff
-    char const *wkb = nullptr;
-    while ((wkb = wkbs.get_next())) {
-        auto const binwkb = ewkb::parser_t::wkb_from_hex(wkb);
-        from_wkb(binwkb, osm_id);
-    }
-
-    //return how many rows were affected
-    return wkbs.get_count();
-}
-
 int expire_tiles::from_result(pg_result_t const &result, osmid_t osm_id)
 {
     //bail if we dont care about expiry

--- a/src/expire-tiles.hpp
+++ b/src/expire-tiles.hpp
@@ -65,7 +65,17 @@ struct expire_tiles
     int from_bbox(double min_lon, double min_lat, double max_lon,
                   double max_lat);
     void from_wkb(std::string const &wkb, osmid_t osm_id);
-    int from_db(table_t *table, osmid_t osm_id);
+
+    /**
+     * Expire tiles based on an osm id.
+     *
+     * \param result Result of a database query into some table returning the
+     *               geometries. (This is usally done using the "get_wkb"
+     *               prepared statement.)
+     * \param osm_id The OSM id to look for.
+     * \return The number of elements that refer to the osm_id or -1 if
+     *         expire is disabled.
+     */
     int from_result(pg_result_t const &result, osmid_t osm_id);
 
     /**

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -294,7 +294,7 @@ void output_pgsql_t::relation_add(osmium::Relation const &rel)
  * contain the change for that also. */
 void output_pgsql_t::node_delete(osmid_t osm_id)
 {
-    if (m_expire.from_db(m_tables[t_point].get(), osm_id) != 0) {
+    if (m_expire.from_result(m_tables[t_point]->get_wkb(osm_id), osm_id) != 0) {
         m_tables[t_point]->delete_row(osm_id);
     }
 }
@@ -312,10 +312,10 @@ void output_pgsql_t::pgsql_delete_way_from_output(osmid_t osm_id)
     }
 
     m_tables[t_roads]->delete_row(osm_id);
-    if (m_expire.from_db(m_tables[t_line].get(), osm_id) != 0) {
+    if (m_expire.from_result(m_tables[t_line]->get_wkb(osm_id), osm_id) != 0) {
         m_tables[t_line]->delete_row(osm_id);
     }
-    if (m_expire.from_db(m_tables[t_poly].get(), osm_id) != 0) {
+    if (m_expire.from_result(m_tables[t_poly]->get_wkb(osm_id), osm_id) != 0) {
         m_tables[t_poly]->delete_row(osm_id);
     }
 }
@@ -329,10 +329,12 @@ void output_pgsql_t::way_delete(osmid_t osm_id)
 void output_pgsql_t::pgsql_delete_relation_from_output(osmid_t osm_id)
 {
     m_tables[t_roads]->delete_row(-osm_id);
-    if (m_expire.from_db(m_tables[t_line].get(), -osm_id) != 0) {
+    if (m_expire.from_result(m_tables[t_line]->get_wkb(-osm_id), -osm_id) !=
+        0) {
         m_tables[t_line]->delete_row(-osm_id);
     }
-    if (m_expire.from_db(m_tables[t_poly].get(), -osm_id) != 0) {
+    if (m_expire.from_result(m_tables[t_poly]->get_wkb(-osm_id), -osm_id) !=
+        0) {
         m_tables[t_poly]->delete_row(-osm_id);
     }
 }

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -442,8 +442,8 @@ void table_t::escape_type(std::string const &value, ColumnType flags)
     }
 }
 
-table_t::wkb_reader table_t::get_wkb_reader(osmid_t id)
+pg_result_t table_t::get_wkb(osmid_t id)
 {
-    auto res = m_sql_conn->exec_prepared("get_wkb", id);
-    return wkb_reader{std::move(res)};
+    return m_sql_conn->exec_prepared("get_wkb", id);
 }
+

--- a/src/table.hpp
+++ b/src/table.hpp
@@ -43,33 +43,7 @@ public:
     void write_row(osmid_t id, taglist_t const &tags, std::string const &geom);
     void delete_row(osmid_t id);
 
-    // interface for retrieving well known binary geometry from the table
-    class wkb_reader
-    {
-        friend table_t;
-
-    public:
-        char const *get_next()
-        {
-            if (m_current < m_count) {
-                return m_result.get_value(m_current++, 0);
-            }
-            return nullptr;
-        }
-
-        int get_count() const noexcept { return m_count; }
-
-    private:
-        explicit wkb_reader(pg_result_t &&result)
-        : m_result(std::move(result)), m_count(m_result.num_tuples()),
-          m_current(0)
-        {}
-
-        pg_result_t m_result;
-        int m_count;
-        int m_current;
-    };
-    wkb_reader get_wkb_reader(osmid_t id);
+    pg_result_t get_wkb(osmid_t id);
 
 protected:
     void connect();


### PR DESCRIPTION
Removes wkb_reader helper class and expire_tiles::from_db() function.
The wkb_reader class does nothing more than iterate over the results of
a database query but that can be done in an easier way