### PR TITLE
Keep track of capacity of an ordered index

### DIFF
--- a/src/ordered-index.cpp
+++ b/src/ordered-index.cpp
@@ -10,15 +10,6 @@
 #include "ordered-index.hpp"
 
 #include <algorithm>
-#include <numeric>
-
-std::size_t ordered_index_t::capacity() const noexcept
-{
-    return std::accumulate(m_ranges.cbegin(), m_ranges.cend(), 0ULL,
-                           [](std::size_t sum, range_entry const &range) {
-                               return sum + range.index.capacity();
-                           });
-}
 
 void ordered_index_t::add(osmid_t id, std::size_t offset)
 {
@@ -32,6 +23,7 @@ void ordered_index_t::add(osmid_t id, std::size_t offset)
             m_ranges.back().to = id - 1;
         }
         m_ranges.emplace_back(id, offset, m_block_size);
+        m_capacity += m_block_size;
         if (m_block_size < max_block_size) {
             m_block_size <<= 1U;
         }

--- a/src/ordered-index.hpp
+++ b/src/ordered-index.hpp
@@ -82,7 +82,7 @@ public:
      * is accurate for normal operations, but if there are huge gaps between
      * consecutive ids (> 2^32), less entries than this will fit.
      */
-    std::size_t capacity() const noexcept;
+    std::size_t capacity() const noexcept { return m_capacity; }
 
     /// The number of entries in the index.
     std::size_t size() const noexcept { return m_size; }
@@ -135,7 +135,7 @@ public:
     std::size_t used_memory() const noexcept
     {
         return m_ranges.capacity() * sizeof(range_entry) +
-               capacity() * sizeof(second_level_index_entry);
+               m_capacity * sizeof(second_level_index_entry);
     }
 
     /**
@@ -146,6 +146,7 @@ public:
     {
         m_ranges.clear();
         m_ranges.shrink_to_fit();
+        m_capacity = 0;
         m_size = 0;
     }
 
@@ -185,6 +186,7 @@ private:
 
     std::vector<range_entry> m_ranges;
     std::size_t m_block_size;
+    std::size_t m_capacity = 0;
     std::size_t m_size = 0;
 }; // class ordered_index_t
 


### PR DESCRIPTION
So we don't have to recalculate.

If we want to ask how much memory the index currently needs to keep
it under some limit, we will call capacity() quite often.