### PR TITLE
Add sql_type column field in flex output

### DIFF
--- a/flex-config/attributes.lua
+++ b/flex-config/attributes.lua
@@ -15,7 +15,10 @@ tables.points = osm2pgsql.define_node_table('points', {
     { column = 'geom', type = 'point', projection = srid },
     { column = 'version', type = 'int' },
     { column = 'changeset', type = 'int' },
-    { column = 'created', type = 'timestamp' },
+    -- There is no built-in type for timestamps in osm2pgsql. So we use the
+    -- PostgreSQL type "timestamp" and then have to convert our timestamps
+    -- to a valid text representation for that type.
+    { column = 'created', sql_type = 'timestamp' },
     { column = 'uid', type = 'int' },
     { column = 'user', type = 'text' },
 })
@@ -25,7 +28,7 @@ tables.lines = osm2pgsql.define_way_table('lines', {
     { column = 'geom', type = 'linestring', projection = srid },
     { column = 'version', type = 'int' },
     { column = 'changeset', type = 'int' },
-    { column = 'created', type = 'timestamp' },
+    { column = 'created', sql_type = 'timestamp' },
     { column = 'uid', type = 'int' },
     { column = 'user', type = 'text' },
 })
@@ -34,7 +37,7 @@ tables.relations = osm2pgsql.define_relation_table('relations', {
     { column = 'tags', type = 'jsonb' },
     { column = 'version', type = 'int' },
     { column = 'changeset', type = 'int' },
-    { column = 'created', type = 'timestamp' },
+    { column = 'created', sql_type = 'timestamp' },
     { column = 'uid', type = 'int' },
     { column = 'user', type = 'text' },
 })

--- a/flex-config/data-types.lua
+++ b/flex-config/data-types.lua
@@ -11,7 +11,7 @@ local highways = osm2pgsql.define_way_table('highways', {
 
     -- Add a SERIAL column and tell osm2pgsql not to fill it (PostgreSQL will
     -- do that for us)
-    { column = 'id',       type = 'serial', create_only = true },
+    { column = 'id',       sql_type = 'serial', create_only = true },
 
     -- type "direction" is special, see below
     { column = 'oneway',   type = 'direction' },
@@ -21,8 +21,10 @@ local highways = osm2pgsql.define_way_table('highways', {
     { column = 'lit',      type = 'bool' },
     { column = 'tags',     type = 'jsonb' }, -- also available: 'json', 'hstore'
 
-    -- an PostgreSQL array type, not specially handled by osm2pgsql, see below
-    { column = 'nodes',    type = 'int8[]' },
+    -- osm2pgsql doesn't know about PostgreSQL arrays, so we define the SQL
+    -- type of this column and then have to convert our array data into a
+    -- valid text representation for that type, see below.
+    { column = 'nodes',    sql_type = 'int8[]' },
     { column = 'geom',     type = 'linestring' },
 })
 

--- a/flex-config/route-relations.lua
+++ b/flex-config/route-relations.lua
@@ -14,7 +14,7 @@ local tables = {}
 tables.highways = osm2pgsql.define_way_table('highways', {
     { column = 'tags',     type = 'jsonb' },
     { column = 'rel_refs', type = 'text' }, -- for the refs from the relations
-    { column = 'rel_ids',  type = 'int8[]' }, -- array with integers (for relation IDs)
+    { column = 'rel_ids',  sql_type = 'int8[]' }, -- array with integers (for relation IDs)
     { column = 'geom',     type = 'linestring' },
 })
 

--- a/src/flex-table-column.hpp
+++ b/src/flex-table-column.hpp
@@ -18,8 +18,6 @@
 
 enum class table_column_type : uint8_t
 {
-    sql,
-
     text,
 
     boolean,
@@ -56,7 +54,8 @@ enum class table_column_type : uint8_t
 class flex_table_column_t
 {
 public:
-    flex_table_column_t(std::string name, std::string const &type);
+    flex_table_column_t(std::string name, std::string const &type,
+                        std::string const &sql_type);
 
     std::string const &name() const noexcept { return m_name; }
 
@@ -122,14 +121,18 @@ private:
     std::string m_name;
 
     /**
-     * The type name of the database table column. Either a name we recognize
-     * or just an SQL snippet.
+     * The type name of the column.
      */
     std::string m_type_name;
 
     /**
-     * The type of database column. Use table_column_type::sql as fallback
-     * in which case m_type_name is the SQL type used in the database.
+     * The SQL type of the database table column. If this is not set, use
+     * one generated from the m_type.
+     */
+    std::string m_sql_type;
+
+    /**
+     * The type of column.
      */
     table_column_type m_type;
 

--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -65,7 +65,8 @@ std::string flex_table_t::full_tmp_name() const
 }
 
 flex_table_column_t &flex_table_t::add_column(std::string const &name,
-                                              std::string const &type)
+                                              std::string const &type,
+                                              std::string const &sql_type)
 {
     // id_type (optional) and id_num must always be the first columns
     assert(type != "id_type" || m_columns.empty());
@@ -73,7 +74,7 @@ flex_table_column_t &flex_table_t::add_column(std::string const &name,
            (m_columns.size() == 1 &&
             m_columns[0].type() == table_column_type::id_type));
 
-    m_columns.emplace_back(name, type);
+    m_columns.emplace_back(name, type, sql_type);
     auto &column = m_columns.back();
 
     if (column.is_geometry_column()) {

--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -183,7 +183,8 @@ public:
     }
 
     flex_table_column_t &add_column(std::string const &name,
-                                    std::string const &type);
+                                    std::string const &type,
+                                    std::string const &sql_type);
 
     bool has_multicolumn_id_index() const noexcept;
     std::string id_column_names() const;

--- a/src/lua-utils.cpp
+++ b/src/lua-utils.cpp
@@ -125,6 +125,24 @@ char const *luaX_get_table_string(lua_State *lua_state, char const *key,
     return lua_tostring(lua_state, -1);
 }
 
+char const *luaX_get_table_string(lua_State *lua_state, char const *key,
+                                  int table_index, char const *error_msg,
+                                  char const *default_value)
+{
+    assert(lua_state);
+    assert(key);
+    lua_getfield(lua_state, table_index, key);
+    int const ltype = lua_type(lua_state, -1);
+    if (ltype == LUA_TNIL) {
+        return default_value;
+    }
+    if (ltype != LUA_TSTRING) {
+        throw std::runtime_error{
+            "{} must contain a '{}' string field."_format(error_msg, key)};
+    }
+    return lua_tostring(lua_state, -1);
+}
+
 bool luaX_get_table_bool(lua_State *lua_state, char const *key, int table_index,
                          char const *error_msg, bool default_value)
 {

--- a/src/lua-utils.hpp
+++ b/src/lua-utils.hpp
@@ -55,6 +55,10 @@ void luaX_add_table_array(lua_State *lua_state, char const *key,
 char const *luaX_get_table_string(lua_State *lua_state, char const *key,
                                   int table_index, char const *error_msg);
 
+char const *luaX_get_table_string(lua_State *lua_state, char const *key,
+                                  int table_index, char const *error_msg,
+                                  char const *default_value);
+
 bool luaX_get_table_bool(lua_State *lua_state, char const *key, int table_index,
                          char const *error_msg, bool default_value);
 

--- a/tests/data/test_output_flex_types.lua
+++ b/tests/data/test_output_flex_types.lua
@@ -9,7 +9,7 @@ local test_table = osm2pgsql.define_node_table("nodes", {
     { column = 'thstr', type = 'hstore' },
     { column = 'tjson', type = 'jsonb' },
     { column = 'tdirn', type = 'direction' },
-    { column = 'tsqlt', type = 'varchar' },
+    { column = 'tsqlt', sql_type = 'varchar' },
 })
 
 function osm2pgsql.process_node(object)


### PR DESCRIPTION
The "type" field in a flex output column definition really does two
things:
1. It defines the way Lua values are transformed into PostgreSQL
   values.
2. It defines which PostgreSQL type should be used in a the CREATE
   TABLE statement for a particular column.

This commit adds a new "sql_type" field which takes over the second
meaning. If it is not specified, the default is still defined by
the "type" field. The default for the type field is "text".

The result is that in most cases you use only the "type" field as before
and it does the right thing. If you need a special SQL type, use the
"sql_type" field instead or in addition to the "type" field.

Note that this is a breaking change, but still allowed because the flex
output is still marked experimental.