### PR TITLE
Remove use of boost::lexical_cast

### DIFF
--- a/tests/test-db-copy-mgr.cpp
+++ b/tests/test-db-copy-mgr.cpp
@@ -167,16 +167,13 @@ TEST_CASE("copy_mgr_t")
                         "\"rr\rrr\",\"s\\\\l\"}"});
 
         auto c = db.connect();
-        CHECK(c.require_scalar<std::string>("SELECT a[4] FROM test_copy_mgr") ==
+        CHECK(c.result_as_string("SELECT a[4] FROM test_copy_mgr") ==
               "with \"quote\"");
-        CHECK(c.require_scalar<std::string>("SELECT a[5] FROM test_copy_mgr") ==
-              "the\t");
-        CHECK(c.require_scalar<std::string>("SELECT a[6] FROM test_copy_mgr") ==
+        CHECK(c.result_as_string("SELECT a[5] FROM test_copy_mgr") == "the\t");
+        CHECK(c.result_as_string("SELECT a[6] FROM test_copy_mgr") ==
               "line\nbreak");
-        CHECK(c.require_scalar<std::string>("SELECT a[7] FROM test_copy_mgr") ==
-              "rr\rrr");
-        CHECK(c.require_scalar<std::string>("SELECT a[8] FROM test_copy_mgr") ==
-              "s\\l");
+        CHECK(c.result_as_string("SELECT a[7] FROM test_copy_mgr") == "rr\rrr");
+        CHECK(c.result_as_string("SELECT a[8] FROM test_copy_mgr") == "s\\l");
     }
 
     SECTION("Insert hashes")
@@ -194,7 +191,7 @@ TEST_CASE("copy_mgr_t")
         auto c = db.connect();
 
         for (auto const &v : values) {
-            auto const res = c.require_scalar<std::string>(
+            auto const res = c.result_as_string(
                 "SELECT h->'{}' FROM test_copy_mgr"_format(v.first));
             CHECK(res == v.second);
         }

--- a/tests/test-db-copy-thread.cpp
+++ b/tests/test-db-copy-thread.cpp
@@ -18,8 +18,7 @@ static testing::pg::tempdb_t db;
 static int table_count(testing::pg::conn_t const &conn,
                        std::string const &where = "")
 {
-    return conn.require_scalar<int>("SELECT count(*) FROM test_copy_thread " +
-                                    where);
+    return conn.result_as_int("SELECT count(*) FROM test_copy_thread " + where);
 }
 
 TEST_CASE("db_copy_thread_t with db_deleter_by_id_t")
@@ -46,8 +45,8 @@ TEST_CASE("db_copy_thread_t with db_deleter_by_id_t")
             t.add_buffer(std::unique_ptr<db_cmd_t>(cmd.release()));
             t.sync_and_wait();
 
-            REQUIRE(conn.require_scalar<int>(
-                        "SELECT id FROM test_copy_thread") == 42);
+            REQUIRE(conn.result_as_int("SELECT id FROM test_copy_thread") ==
+                    42);
         }
 
         SECTION("add multiple rows and sync")
@@ -67,8 +66,7 @@ TEST_CASE("db_copy_thread_t with db_deleter_by_id_t")
             t.add_buffer(std::unique_ptr<db_cmd_t>(cmd.release()));
             t.finish();
 
-            REQUIRE(conn.require_scalar<int>(
-                        "SELECT id FROM test_copy_thread") == 2);
+            REQUIRE(conn.result_as_int("SELECT id FROM test_copy_thread") == 2);
         }
     }
 

--- a/tests/test-options-projection.cpp
+++ b/tests/test-options-projection.cpp
@@ -84,6 +84,6 @@ TEST_CASE("Projection setup")
 
     auto conn = db.connect();
 
-    CHECK(conn.require_scalar<std::string>(
+    CHECK(conn.result_as_string(
               "SELECT Find_SRID('public', 'planet_osm_roads', 'way')") == srid);
 }

--- a/tests/test-output-gazetteer.cpp
+++ b/tests/test-output-gazetteer.cpp
@@ -232,7 +232,7 @@ public:
                           char const *cls, char const *column)
     {
         char const tchar = m_opl_factory.type();
-        return conn.require_scalar<std::string>(
+        return conn.result_as_string(
             "SELECT {} FROM place WHERE osm_type = '{}' AND osm_id = {}"
             " AND class = '{}'"_format(column, tchar, id, cls));
     }

--- a/tests/test-output-pgsql-int4.cpp
+++ b/tests/test-output-pgsql-int4.cpp
@@ -37,10 +37,10 @@ TEST_CASE("int4 conversion")
     conn.assert_null(population(3));
 
     // Check values that are valid for int4 columns, including limits
-    CHECK(2147483647 == conn.require_scalar<int>(population(4)));
-    CHECK(10000 == conn.require_scalar<int>(population(5)));
-    CHECK(-10000 == conn.require_scalar<int>(population(6)));
-    CHECK(-2147483648 == conn.require_scalar<int>(population(7)));
+    CHECK(2147483647 == conn.result_as_int(population(4)));
+    CHECK(10000 == conn.result_as_int(population(5)));
+    CHECK(-10000 == conn.result_as_int(population(6)));
+    CHECK(-2147483648 == conn.result_as_int(population(7)));
 
     // More out of range negative values
     conn.assert_null(population(8));
@@ -52,10 +52,10 @@ TEST_CASE("int4 conversion")
     conn.assert_null(population(12));
 
     // Check values that are valid for int4 columns, including limits
-    CHECK(2147483647 == conn.require_scalar<int>(population(13)));
-    CHECK(15000 == conn.require_scalar<int>(population(14)));
-    CHECK(-15000 == conn.require_scalar<int>(population(15)));
-    CHECK(-2147483648 == conn.require_scalar<int>(population(16)));
+    CHECK(2147483647 == conn.result_as_int(population(13)));
+    CHECK(15000 == conn.result_as_int(population(14)));
+    CHECK(-15000 == conn.result_as_int(population(15)));
+    CHECK(-2147483648 == conn.result_as_int(population(16)));
 
     // More out of range negative values
     conn.assert_null(population(17));
@@ -68,5 +68,5 @@ TEST_CASE("int4 conversion")
     conn.assert_null(population(22));
 
     // Zero is a valid value
-    CHECK(0 == conn.require_scalar<int>(population(23)));
+    CHECK(0 == conn.result_as_int(population(23)));
 }

--- a/tests/test-output-pgsql-z_order.cpp
+++ b/tests/test-output-pgsql-z_order.cpp
@@ -28,10 +28,10 @@ TEST_CASE("compute Z order")
         auto const sql = "SELECT highway FROM osm2pgsql_test_line"
                          " WHERE layer IS NULL ORDER BY z_order DESC"
                          " LIMIT 1 OFFSET {}"_format(i);
-        REQUIRE(expected[i] == conn.require_scalar<std::string>(sql));
+        REQUIRE(expected[i] == conn.result_as_string(sql));
     }
 
-    REQUIRE("residential" == conn.require_scalar<std::string>(
-                                 "SELECT highway FROM osm2pgsql_test_line "
-                                 "ORDER BY z_order DESC LIMIT 1 OFFSET 0"));
+    REQUIRE("residential" ==
+            conn.result_as_string("SELECT highway FROM osm2pgsql_test_line "
+                                  "ORDER BY z_order DESC LIMIT 1 OFFSET 0"));
 }


### PR DESCRIPTION
One less dependency and UB sanitizer warns that boost::lexical_cast has
undefined behaviour.

Fixes #1028