### PR TITLE
Bugfix: Do not create table as unlogged if it is not clustered

### DIFF
--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -173,7 +173,7 @@ void table_connection_t::start(bool append)
 
     if (!append) {
         m_db_connection->exec(table().build_sql_create_table(
-            table().has_geom_column() ? flex_table_t::table_type::interim
+            table().cluster_by_geom() ? flex_table_t::table_type::interim
                                       : flex_table_t::table_type::permanent,
             table().full_name()));
 


### PR DESCRIPTION
Tables created with the flex output that were marked `cluster: "no"`
were created as unlogged tables. This should only be done for tables
which will be replaced by their clustered copy later on.

See #27