### PR TITLE
Expose config dir in osm2pgsql.config_dir Lua var in flex output

### DIFF
--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -36,6 +36,8 @@ extern "C"
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
+#include <boost/filesystem.hpp>
+
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
@@ -1629,6 +1631,10 @@ void output_flex_t::init_lua(std::string const &filename)
     luaX_add_table_str(lua_state(), "mode",
                        m_options.append ? "append" : "create");
     luaX_add_table_int(lua_state(), "stage", 1);
+
+    std::string const dir_path =
+        boost::filesystem::path{filename}.parent_path().string();
+    luaX_add_table_str(lua_state(), "config_dir", dir_path.c_str());
 
     luaX_add_table_func(lua_state(), "define_table",
                         lua_trampoline_app_define_table);


### PR DESCRIPTION
The directory where the Lua config file was read from is now available
in the osm2pgsql.config_dir variable. This is useful, for instance, when
we want to include other files into our config file.