### PR TITLE
Bugfix: Nodes not stored in node location store correctly

### DIFF
--- a/src/ordered-index.cpp
+++ b/src/ordered-index.cpp
@@ -19,7 +19,8 @@ void ordered_index_t::add(osmid_t id, std::size_t offset)
             (last().offset_from + last().index.back().offset) < offset));
 
     if (need_new_2nd_level() ||
-        (id - last().from) > std::numeric_limits<uint32_t>::max()) {
+        (id - last().from) > std::numeric_limits<uint32_t>::max() ||
+        (offset - last().offset_from) >= std::numeric_limits<uint32_t>::max()) {
         if (!m_ranges.empty()) {
             m_ranges.back().to = id - 1;
         }

--- a/src/ordered-index.hpp
+++ b/src/ordered-index.hpp
@@ -31,7 +31,7 @@
  * An index that is never used doesn't need more memory than
  * sizeof(ordered_index_t).
  *
- * All allocated memory can be freed by calling clear(). Afer that the index
+ * All allocated memory can be freed by calling clear(). After that the index
  * can NOT be reused.
  *
  * There are two ways of accessing the data through the index:
@@ -185,7 +185,7 @@ private:
 
     std::pair<osmid_t, std::size_t> get_internal(osmid_t id) const noexcept;
 
-    static constexpr std::size_t const max_block_size = 16 * 1024 * 1204;
+    static constexpr std::size_t const max_block_size = 16 * 1024 * 1024;
 
     std::vector<range_entry> m_ranges;
     std::size_t m_block_size;


### PR DESCRIPTION
When importing a planet file or a huge extract, something with more than
about 1 billion nodes, the new RAM node location could overflow a 32bit
"offset" value which meant that the node locations would not be found
again. The result were missing features, because osm2pgsql just ignores
features with geometries that can not be built due to missing node
locations.

This fix has two parts: First, it fixes the typo which made the max
block size too large. This typo lead to a doubling of the max block size
which directly lead to the bug. The other fix is to check the "offset"
value and, if it becomes too large, start a new block. This probably
isn't necessary for "normal" OSM data which should usually work with the
new max block size, but it provides a safety net in case some the block
size becomes too large for some data.

See #1540