### PR TITLE
Remove IMMUTABLE volatility classification from trigger function

### DIFF
--- a/src/pgsql-helper.cpp
+++ b/src/pgsql-helper.cpp
@@ -48,7 +48,7 @@ void create_geom_check_trigger(pg_conn_t *db_connection,
         "  END IF;\n"
         "  RETURN NULL;\n"
         "END;"
-        "$$ LANGUAGE plpgsql IMMUTABLE;"_format(func_name, geom_column));
+        "$$ LANGUAGE plpgsql;"_format(func_name, geom_column));
 
     db_connection->exec(
         "CREATE TRIGGER \"{}\""


### PR DESCRIPTION
It is not clear how exactly the volatility classification works in
trigger functions, so it is better to be on the safe side here and not
declare the function IMMUTABLE (which makes it the default VOLATILE
instead).

https://www.postgresql.org/docs/current/xfunc-volatility.html