### PR TITLE
support older versions of python with osm2pgsql-replication

### DIFF
--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -77,7 +77,7 @@ def compute_database_date(conn, prefix):
     LOG.debug("Found timestamp %s", date)
 
     try:
-        date = dt.datetime.fromisoformat(date.replace('Z', '+00:00'))
+        date = dt.datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=dt.timezone.utc)
     except ValueError:
         LOG.fatal("Cannot parse timestamp '%s'", date)
         return None


### PR DESCRIPTION
Older versions don't have .fromisoformat() function