### PR TITLE
Change normal output to go to stdout for osm2pgsql-replication

### DIFF
--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -350,7 +350,7 @@ def main():
         parser.print_help()
         exit(1)
 
-    logging.basicConfig(stream=sys.stderr,
+    logging.basicConfig(stream=sys.stdout,
                         format='{asctime} [{levelname}]: {message}',
                         style='{',
                         datefmt='%Y-%m-%d %H:%M:%S',


### PR DESCRIPTION
With this patch, regular default output from `osm2pgsql-replication` will go to stdout, not stderr, which is the unix standard.