### PR TITLE
add a 'status' command which prints the lag (& in JSON)

### DIFF
--- a/docs/osm2pgsql-replication.1
+++ b/docs/osm2pgsql-replication.1
@@ -3,7 +3,7 @@
 osm2pgsql-replication
 .SH SYNOPSIS
 .B osm2pgsql-replication
-[-h] {init,update} ...
+[-h] {init,update,status} ...
 .SH DESCRIPTION
 Update an osm2pgsql database with changes from a OSM replication server.
 .br
@@ -33,6 +33,9 @@ how to use osm2pgsql\-replication.
 .TP
 \fBosm2pgsql-replication\fR \fI\,update\/\fR
     Download newly available data and apply it to the database.
+.TP
+\fBosm2pgsql-replication\fR \fI\,status\/\fR
+    Print information about the current replication status, optionally as JSON.
 .SH OPTIONS 'osm2pgsql-replication init'
 usage: osm2pgsql-replication init [-h] [-q] [-v] [-d DB] [-U NAME] [-H HOST]
                                   [-P PORT] [-p PREFIX]
@@ -176,6 +179,120 @@ Run updates only once, even when more data is available.
 .TP
 \fB\-\-post\-processing\fR SCRIPT
 Post\-processing script to run after each execution of osm2pgsql.
+
+.TP
+\fB\-q\fR, \fB\-\-quiet\fR
+Print only error messages
+
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Increase verboseness of output
+
+.TP
+\fB\-d\fR DB, \fB\-\-database\fR DB
+Name of PostgreSQL database to connect to or conninfo string
+
+.TP
+\fB\-U\fR NAME, \fB\-\-username\fR NAME
+PostgreSQL user name
+
+.TP
+\fB\-H\fR HOST, \fB\-\-host\fR HOST
+Database server host name or socket location
+
+.TP
+\fB\-P\fR PORT, \fB\-\-port\fR PORT
+Database server port
+
+.TP
+\fB\-p\fR PREFIX, \fB\-\-prefix\fR PREFIX
+Prefix for table names (default 'planet_osm')
+
+
+.SH OPTIONS 'osm2pgsql-replication status'
+usage: osm2pgsql-replication status [-h] [-q] [-v] [-d DB] [-U NAME] [-H HOST]
+                                    [-P PORT] [-p PREFIX] [--json]
+
+Print information about the current replication status, optionally as JSON.
+.br
+
+.br
+Sample output:
+.br
+
+.br
+    2021\-08\-17 15:20:28 [INFO]: Using replication service 'https://planet.openstreetmap.org/replication/minute', which is at sequence 4675115 ( 2021\-08\-17T13:19:43Z )
+.br
+    2021\-08\-17 15:20:28 [INFO]: Replication server's most recent data is <1 minute old
+.br
+    2021\-08\-17 15:20:28 [INFO]: Local database is 8288 sequences behind the server, i.e. 5 day(s) 20 hour(s) 58 minute(s)
+.br
+    2021\-08\-17 15:20:28 [INFO]: Local database's most recent data is 5 day(s) 20 hour(s) 59 minute(s) old
+.br
+
+.br
+
+.br
+With the '\-\-json' option, the status is printed as a json object.
+.br
+
+.br
+    {
+.br
+      "server": {
+.br
+        "base_url": "https://planet.openstreetmap.org/replication/minute",
+.br
+        "sequence": 4675116,
+.br
+        "timestamp": "2021\-08\-17T13:20:43Z",
+.br
+        "age_sec": 27
+.br
+      },
+.br
+      "local": {
+.br
+        "sequence": 4666827,
+.br
+        "timestamp": "2021\-08\-11T16:21:09Z",
+.br
+        "age_sec": 507601
+.br
+      },
+.br
+      "status": 0
+.br
+    }
+.br
+
+.br
+
+.br
+'status' is 0 if there were no problems getting the status. 1 & 2 for
+.br
+improperly set up replication. 3 for network issues. If status ≠ 0, then
+.br
+the 'error' key is an error message (as string). 'status' is used as the
+.br
+exit code.
+.br
+
+.br
+'server' is the replication server's current status. 'sequence' is it's
+.br
+sequence number, 'timestamp' the time of that, and 'age_sec' the age of the
+.br
+data in seconds.
+.br
+
+.br
+'local' is the status of your server.
+
+
+.TP
+\fB\-\-json\fR
+Output status as json.
 
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR

--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -39,6 +39,28 @@ from osmium import WriteHandler
 
 LOG = logging.getLogger()
 
+def pretty_format_timedelta(seconds):
+    minutes = int(seconds/60)
+    (hours, minutes) = divmod(minutes, 60)
+    (days, hours) = divmod(hours, 24)
+    (weeks, days) = divmod(days, 7)
+
+    if 0 < seconds < 60:
+        output = "<1 minute"
+    else:
+        output = []
+        # If weeks > 1 but hours == 0, we still want to show "0 hours"
+        if weeks > 0:
+            output.append("{} week(s)".format(weeks))
+        if days > 0 or weeks > 0:
+            output.append("{} day(s)".format(days))
+        if hours > 0 or days > 0 or weeks > 0:
+            output.append("{} hour(s)".format(hours))
+
+        output.append("{} minute(s)".format(minutes))
+        output = " ".join(output)
+    return output
+
 def connect(args):
     """ Create a connection from the given command line arguments.
     """
@@ -114,6 +136,113 @@ def update_replication_state(conn, table, seq, date):
                         (seq,))
 
     conn.commit()
+
+def status(conn, args):
+    """\
+    Print information about the current replication status, optionally as JSON.
+
+    Sample output:
+
+        2021-08-17 15:20:28 [INFO]: Using replication service 'https://planet.openstreetmap.org/replication/minute', which is at sequence 4675115 ( 2021-08-17T13:19:43Z )
+        2021-08-17 15:20:28 [INFO]: Replication server's most recent data is <1 minute old
+        2021-08-17 15:20:28 [INFO]: Local database is 8288 sequences behind the server, i.e. 5 day(s) 20 hour(s) 58 minute(s)
+        2021-08-17 15:20:28 [INFO]: Local database's most recent data is 5 day(s) 20 hour(s) 59 minute(s) old
+
+
+    With the '--json' option, the status is printed as a json object.
+
+        {
+          "server": {
+            "base_url": "https://planet.openstreetmap.org/replication/minute",
+            "sequence": 4675116,
+            "timestamp": "2021-08-17T13:20:43Z",
+            "age_sec": 27
+          },
+          "local": {
+            "sequence": 4666827,
+            "timestamp": "2021-08-11T16:21:09Z",
+            "age_sec": 507601
+          },
+          "status": 0
+        }
+
+
+    'status' is 0 if there were no problems getting the status. 1 & 2 for
+    improperly set up replication. 3 for network issues. If status ≠ 0, then
+    the 'error' key is an error message (as string). 'status' is used as the
+    exit code.
+
+    'server' is the replication server's current status. 'sequence' is it's
+    sequence number, 'timestamp' the time of that, and 'age_sec' the age of the
+    data in seconds.
+
+    'local' is the status of your server.
+    """
+
+    results = {}
+
+    with conn.cursor() as cur:
+        cur.execute('SELECT * FROM pg_tables where tablename = %s', (args.table, ))
+        if cur.rowcount < 1:
+            results['status'] = 1
+            results['error'] = "Cannot find replication status table. Run 'osm2pgsql-replication init' first."
+        else:
+            cur.execute('SELECT * FROM "{}"'.format(args.table))
+            if cur.rowcount != 1:
+                results['status'] = 2
+                results['error'] = "Updates not set up correctly. Run 'osm2pgsql-updates init' first."
+            else:
+
+                base_url, db_seq, db_ts = cur.fetchone()
+                db_ts = db_ts.astimezone(dt.timezone.utc)
+                results['server'] = {}
+                results['local'] = {}
+                results['server']['base_url'] = base_url
+                results['local']['sequence'] = db_seq
+                results['local']['timestamp'] = db_ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+                repl = ReplicationServer(base_url)
+                state_info = repl.get_state_info()
+                if state_info is None:
+                    # PyOsmium was unable to download the state information
+                    results['status'] = 3
+                    results['error'] = "Unable to download the state information from {}".format(base_url)
+                else:
+                    results['status'] = 0
+                    now = dt.datetime.now(dt.timezone.utc)
+
+                    server_seq, server_ts = state_info
+                    server_ts = server_ts.astimezone(dt.timezone.utc)
+
+                    results['server']['sequence'] = server_seq
+                    results['server']['timestamp'] = server_ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+                    results['server']['age_sec'] = int((now-server_ts).total_seconds())
+
+                    results['local']['age_sec'] = int((now - db_ts).total_seconds())
+
+    if args.json:
+        print(json.dumps(results))
+    else:
+        if results['status'] != 0:
+            LOG.fatal(results['error'])
+        else:
+            print("Using replication service '{}', which is at sequence {} ( {} )".format(
+                     results['server']['base_url'], results['server']['sequence'], results['server']['timestamp']))
+            print("Replication server's most recent data is {} old".format(pretty_format_timedelta(results['server']['age_sec'])))
+
+            if results['local']['sequence'] == results['server']['sequence']:
+                print("Local database is up to date with server")
+            else:
+                print("Local database is {} sequences behind the server, i.e. {}".format(
+                        results['server']['sequence'] - results['local']['sequence'],
+                        pretty_format_timedelta(results['local']['age_sec'] - results['server']['age_sec'])
+                    ))
+
+            print("Local database's most recent data is {} old".format(pretty_format_timedelta(results['local']['age_sec'])))
+
+
+    return results['status']
 
 
 def init(conn, args):
@@ -339,6 +468,16 @@ def get_parser():
                      help='Run updates only once, even when more data is available.')
     cmd.add_argument('--post-processing', metavar='SCRIPT',
                      help='Post-processing script to run after each execution of osm2pgsql.')
+
+    # Arguments for status
+    cmd = subs.add_parser('status', parents=[default_args],
+                          help=status.__doc__.split('\n', 1)[0],
+                          description=dedent(status.__doc__),
+                          formatter_class=RawDescriptionHelpFormatter,
+                          add_help=False)
+    cmd.add_argument('--json', action="store_true", default=False, help="Output status as json.")
+    cmd.set_defaults(handler=status)
+
 
     return parser
 


### PR DESCRIPTION
This patch adds an `info` command which prints readable summary of the state of replication:

```
$ osm2pgsql-replication info -U osm -d gis
2021-08-04 14:12:28 [INFO]: Using replication service 'https://download.geofabrik.de/europe-updates/'. Current sequence 3052 (2021-08-03T20:21:39Z).
2021-08-04 14:12:28 [INFO]: Server is at sequence 3052 (2021-08-03T20:21:39Z)
2021-08-04 14:12:28 [INFO]: Server's most recent data is 17 hour(s) 50 minutes(s) old
2021-08-04 14:12:28 [INFO]: Database is up to date with server
2021-08-04 14:12:28 [INFO]: Database's most recent data is 17 hour(s) 50 minutes(s) old
```

with the `--json` option, the output is in JSON format, which is useful for writing scripts to detect if the replication has stopped, or to graph how far behind the server is:

`$ osm2pgsql-replication info -U osm -d gis --json`:
```json
{
  "server": {
    "base_url": "https://download.geofabrik.de/europe-updates/",
    "sequence": 3052,
    "timestamp": "2021-08-03T20:21:39Z",
    "age": {
      "seconds": 64920,
      "text": {
        "en": "18 hour(s) 2 minutes(s)"
      }
    }
  },
  "local": {
    "sequence": 3052,
    "timestamp": "2021-08-03T20:21:39Z",
    "age": {
      "seconds": 64920,
      "text": {
        "en": "18 hour(s) 2 minutes(s)"
      }
    }
  },
  "diff": {
    "sequence": 0,
    "timestamp": {
      "seconds": 0,
      "text": {
        "en": "0 minutes(s)"
      }
    }
  }
}
```