### PR TITLE
Update docs on making `osm2pgsql-replication` man page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ The [osm2pgsql man page](docs/osm2pgsql.1) can be built from [source](docs/osm2p
 with `make man`. The [osm2pgsql-replication man page](docs/osm2pgsql-replication.1)
 has been built with:
 
-    argparse-manpage --pyfile scripts/osm2pgsql-replication --function get_parser --project-name osm2pgsql-replication > docs/osm2pgsql-replication.1
+    argparse-manpage --pyfile scripts/osm2pgsql-replication --function get_parser --project-name osm2pgsql-replication --url osm2pgsql.org > docs/osm2pgsql-replication.1
 
 This command can be installed with:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ The [osm2pgsql man page](docs/osm2pgsql.1) can be built from [source](docs/osm2p
 with `make man`. The [osm2pgsql-replication man page](docs/osm2pgsql-replication.1)
 has been built with:
 
-    argparse-manpage --pyfile scripts/osm2pgsql-replication --function get_parser > docs/osm2pgsql-replication.1
+    argparse-manpage --pyfile scripts/osm2pgsql-replication --function get_parser --project-name osm2pgsql-replication > docs/osm2pgsql-replication.1
 
 This command can be installed with:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ This command can be installed with:
 sudo apt-get install python3-argparse-manpage
 ```
 
-Remove the `.SH AUTHORS` section which this command adds
+Remove the `.SH AUTHORS` section which this command adds.
 
 Results should be checked into the repository.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,7 @@ This command can be installed with:
 sudo apt-get install python3-argparse-manpage
 ```
 
+Remove the `.SH AUTHORS` section which this command adds
 
 Results should be checked into the repository.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,13 @@ has been built with:
 
     argparse-manpage --pyfile scripts/osm2pgsql-replication --function get_parser
 
+This command can be installed with:
+
+```sh
+sudo apt-get install python3-argparse-manpage
+```
+
+
 Results should be checked into the repository.
 
 ## Platforms targeted

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ The [osm2pgsql man page](docs/osm2pgsql.1) can be built from [source](docs/osm2p
 with `make man`. The [osm2pgsql-replication man page](docs/osm2pgsql-replication.1)
 has been built with:
 
-    argparse-manpage --pyfile scripts/osm2pgsql-replication --function get_parser
+    argparse-manpage --pyfile scripts/osm2pgsql-replication --function get_parser > docs/osm2pgsql-replication.1
 
 This command can be installed with:
 

--- a/docs/osm2pgsql-replication.1
+++ b/docs/osm2pgsql-replication.1
@@ -128,6 +128,30 @@ Any additional arguments to osm2pgsql need to be given after '\-\-'. Database
 and the prefix parameter are handed through to osm2pgsql. They do not need
 .br
 to be repeated. '\-\-append' and '\-\-slim' will always be added as well.
+.br
+
+.br
+Use the '\-\-post\-processing' parameter to execute a script after osm2pgsql has
+.br
+run successfully. If the updates consists of multiple runs because the
+.br
+maximum size of downloaded data was reached, then the script is executed
+.br
+each time that osm2pgsql has run. When the post\-processing fails, then
+.br
+the entire update run is considered a failure and the replication information
+.br
+is not updated. That means that when 'update' is run the next time it will
+.br
+recommence with downloading the diffs again and reapplying them to the
+.br
+database. This is usually safe. The script receives two parameters:
+.br
+the sequence ID and timestamp of the last successful run. The timestamp
+.br
+may be missing in the rare case that the replication service stops responding
+.br
+after the updates have been downloaded.
 
 .TP
 \fBparam\fR
@@ -148,6 +172,10 @@ Path to osm2pgsql command (default: osm2pgsql)
 .TP
 \fB\-\-once\fR
 Run updates only once, even when more data is available.
+
+.TP
+\fB\-\-post\-processing\fR SCRIPT
+Post\-processing script to run after each execution of osm2pgsql.
 
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
@@ -177,7 +205,10 @@ Database server port
 \fB\-\-prefix\fR PREFIX
 Prefix for table names (default 'planet_osm')
 
+.SH AUTHORS
+.B osm2pgsql\-replication
+was written by <<UNSET \-\-author OPTION>> <<<UNSET \-\-author_email OPTION>>>.
 .SH DISTRIBUTION
 The latest version of osm2pgsql\-replication may be downloaded from
-.UR <<UNSET \-\-url OPTION>>
+.UR osm2pgsql.org
 .UE

--- a/docs/osm2pgsql-replication.1
+++ b/docs/osm2pgsql-replication.1
@@ -205,9 +205,6 @@ Database server port
 \fB\-\-prefix\fR PREFIX
 Prefix for table names (default 'planet_osm')
 
-.SH AUTHORS
-.B osm2pgsql\-replication
-was written by <<UNSET \-\-author OPTION>> <<<UNSET \-\-author_email OPTION>>>.
 .SH DISTRIBUTION
 The latest version of osm2pgsql\-replication may be downloaded from
 .UR osm2pgsql.org


### PR DESCRIPTION
Update `CONTRIBUTING.md` with how to generate the `osm2pgsql-replication` man page, to ensure it's always the same the next time someone else does a PR. 😉

I also ran argparse-manpage to regenerate the `osm2pgsql-replication.1` doc.

I do not know how to get rid of the `AUTHORS` bit from the manpage.