### PR TITLE
Fix confusing log message

### DIFF
--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -88,7 +88,7 @@ void middle_pgsql_t::table_desc::drop_table(
     auto const qual_name = qualified_name(schema(), name());
     db_connection.exec("DROP TABLE IF EXISTS {}"_format(qual_name));
 
-    log_info("Done postprocessing on table '{}' in {}", name(),
+    log_info("Table '{}' dropped in {}", name(),
              util::human_readable_duration(timer.stop()));
 }
 


### PR DESCRIPTION
The message "Done postprocessing on table '{}' in {}" was logged twice
when `--drop` is used. This changes one of the log messages to the
more specific "Table '{}' dropped in {}".