### PR TITLE
Clean up pointers to middle_query_t in outputs to release memory

### DIFF
--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -24,6 +24,20 @@
 #include <memory>
 #include <utility>
 
+/**
+ * Output overall memory usage as debug message.
+ *
+ * This only works on Linux.
+ */
+static void show_memory_usage()
+{
+    osmium::MemoryUsage mem;
+    if (mem.peak() != 0) {
+        log_debug("Overall memory usage: peak={}MByte current={}MByte",
+                  mem.peak(), mem.current());
+    }
+}
+
 static void run(options_t const &options)
 {
     auto const files = prepare_input_files(
@@ -55,6 +69,8 @@ static void run(options_t const &options)
     process_files(files, &osmdata, options.append,
                   get_logger().show_progress());
 
+    show_memory_usage();
+
     // Process pending ways and relations. Cluster database tables and
     // create indexes.
     osmdata.stop();
@@ -76,13 +92,7 @@ int main(int argc, char *argv[])
 
         run(options);
 
-        // Output overall memory usage. This only works on Linux.
-        osmium::MemoryUsage mem;
-        if (mem.peak() != 0) {
-            log_debug("Overall memory usage: peak={}MByte current={}MByte",
-                      mem.peak(), mem.current());
-        }
-
+        show_memory_usage();
         log_info("osm2pgsql took {} overall.",
                  util::human_readable_duration(timer_overall.stop()));
     } catch (std::exception const &e) {

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -372,6 +372,8 @@ void osmdata_t::reprocess_marked() const { m_output->reprocess_marked(); }
 
 void osmdata_t::postprocess_database() const
 {
+    m_output->free_middle_references();
+
     if (m_droptemp) {
         // When dropping middle tables, make sure they are gone before
         // indexing starts.

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -687,7 +687,7 @@ std::size_t output_flex_t::get_way_nodes()
 {
     assert(m_context_way);
     if (m_num_way_nodes == std::numeric_limits<std::size_t>::max()) {
-        m_num_way_nodes = m_mid->nodes_get_list(&m_context_way->nodes());
+        m_num_way_nodes = middle().nodes_get_list(&m_context_way->nodes());
     }
 
     return m_num_way_nodes;
@@ -1186,15 +1186,15 @@ output_flex_t::run_transform(geom::osmium_builder_t *builder,
                              osmium::Relation const &relation)
 {
     m_buffer.clear();
-    auto const num_ways = m_mid->rel_members_get(relation, &m_buffer,
-                                                 osmium::osm_entity_bits::way);
+    auto const num_ways = middle().rel_members_get(
+        relation, &m_buffer, osmium::osm_entity_bits::way);
 
     if (num_ways == 0) {
         return {};
     }
 
     for (auto &way : m_buffer.select<osmium::Way>()) {
-        m_mid->nodes_get_list(&(way.nodes()));
+        middle().nodes_get_list(&(way.nodes()));
     }
 
     return transform->run(builder, target_geom_type, relation, m_buffer);
@@ -1275,7 +1275,7 @@ void output_flex_t::pending_way(osmid_t id)
     }
 
     m_buffer.clear();
-    if (!m_mid->way_get(id, &m_buffer)) {
+    if (!middle().way_get(id, &m_buffer)) {
         return;
     }
 
@@ -1359,7 +1359,7 @@ void output_flex_t::select_relation_members(osmid_t id)
         return;
     }
 
-    if (!m_mid->relation_get(id, &m_rels_buffer)) {
+    if (!middle().relation_get(id, &m_rels_buffer)) {
         return;
     }
 
@@ -1374,7 +1374,7 @@ void output_flex_t::pending_relation(osmid_t id)
         return;
     }
 
-    if (!m_mid->relation_get(id, &m_rels_buffer)) {
+    if (!middle().relation_get(id, &m_rels_buffer)) {
         return;
     }
     auto const &relation = m_rels_buffer.get<osmium::Relation>(0);
@@ -1397,7 +1397,7 @@ void output_flex_t::pending_relation_stage1c(osmid_t id)
         return;
     }
 
-    if (!m_mid->relation_get(id, &m_rels_buffer)) {
+    if (!middle().relation_get(id, &m_rels_buffer)) {
         return;
     }
     auto const &relation = m_rels_buffer.get<osmium::Relation>(0);
@@ -1755,7 +1755,7 @@ void output_flex_t::reprocess_marked()
 
     for (osmid_t const id : *m_stage2_way_ids) {
         m_buffer.clear();
-        if (!m_mid->way_get(id, &m_buffer)) {
+        if (!middle().way_get(id, &m_buffer)) {
             continue;
         }
         auto &way = m_buffer.get<osmium::Way>(0);

--- a/src/output-gazetteer.cpp
+++ b/src/output-gazetteer.cpp
@@ -129,7 +129,7 @@ bool output_gazetteer_t::process_way(osmium::Way *way)
     }
 
     // Fetch the node details.
-    m_mid->nodes_get_list(&(way->nodes()));
+    middle().nodes_get_list(&(way->nodes()));
 
     // Get the geometry of the object.
     geom::osmium_builder_t::wkb_t geom;
@@ -189,15 +189,15 @@ bool output_gazetteer_t::process_relation(osmium::Relation const &rel)
 
     /* get the boundary path (ways) */
     m_osmium_buffer.clear();
-    auto const num_ways = m_mid->rel_members_get(rel, &m_osmium_buffer,
-                                                 osmium::osm_entity_bits::way);
+    auto const num_ways = middle().rel_members_get(
+        rel, &m_osmium_buffer, osmium::osm_entity_bits::way);
 
     if (num_ways == 0) {
         return false;
     }
 
     for (auto &w : m_osmium_buffer.select<osmium::Way>()) {
-        m_mid->nodes_get_list(&(w.nodes()));
+        middle().nodes_get_list(&(w.nodes()));
     }
 
     auto const geoms =

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -79,7 +79,7 @@ void output_pgsql_t::pending_way(osmid_t id)
 {
     // Try to fetch the way from the DB
     m_buffer.clear();
-    if (m_mid->way_get(id, &m_buffer)) {
+    if (middle().way_get(id, &m_buffer)) {
         pgsql_delete_way_from_output(id);
 
         taglist_t outtags;
@@ -87,7 +87,7 @@ void output_pgsql_t::pending_way(osmid_t id)
         bool roads = false;
         auto &way = m_buffer.get<osmium::Way>(0);
         if (!m_tagtransform->filter_tags(way, &polygon, &roads, outtags)) {
-            auto nnodes = m_mid->nodes_get_list(&(way.nodes()));
+            auto nnodes = middle().nodes_get_list(&(way.nodes()));
             if (nnodes > 1) {
                 pgsql_out_way(way, &outtags, polygon, roads);
                 return;
@@ -103,7 +103,7 @@ void output_pgsql_t::pending_relation(osmid_t id)
     // we cannot keep a reference to the relation and an autogrow buffer
     // might be relocated when more data is added.
     m_rels_buffer.clear();
-    if (m_mid->relation_get(id, &m_rels_buffer)) {
+    if (middle().relation_get(id, &m_rels_buffer)) {
         pgsql_delete_relation_from_output(id);
 
         auto const &rel = m_rels_buffer.get<osmium::Relation>(0);
@@ -163,7 +163,7 @@ void output_pgsql_t::way_add(osmium::Way *way)
 
     if (!filter) {
         /* Get actual node data and generate output */
-        auto nnodes = m_mid->nodes_get_list(&(way->nodes()));
+        auto nnodes = middle().nodes_get_list(&(way->nodes()));
         if (nnodes > 1) {
             pgsql_out_way(*way, &outtags, polygon, roads);
         }
@@ -209,7 +209,7 @@ void output_pgsql_t::pgsql_process_relation(osmium::Relation const &rel)
 
     m_buffer.clear();
     auto const num_ways =
-        m_mid->rel_members_get(rel, &m_buffer, osmium::osm_entity_bits::way);
+        middle().rel_members_get(rel, &m_buffer, osmium::osm_entity_bits::way);
 
     if (num_ways == 0) {
         return;
@@ -234,7 +234,7 @@ void output_pgsql_t::pgsql_process_relation(osmium::Relation const &rel)
     }
 
     for (auto &w : m_buffer.select<osmium::Way>()) {
-        m_mid->nodes_get_list(&(w.nodes()));
+        middle().nodes_get_list(&(w.nodes()));
     }
 
     // linear features and boundaries

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -71,6 +71,11 @@ output_t::output_t(std::shared_ptr<middle_query_t> const &mid,
 
 output_t::~output_t() = default;
 
+void output_t::free_middle_references()
+{
+    m_mid.reset();
+}
+
 options_t const *output_t::get_options() const { return &m_options; }
 
 void output_t::merge_expire_trees(output_t *) {}

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -66,7 +66,7 @@ output_t::create_output(std::shared_ptr<middle_query_t> const &mid,
 output_t::output_t(std::shared_ptr<middle_query_t> const &mid,
                    std::shared_ptr<thread_pool_t> thread_pool,
                    options_t const &options)
-: m_thread_pool(std::move(thread_pool)), m_mid(mid), m_options(options)
+: m_mid(mid), m_thread_pool(std::move(thread_pool)), m_options(options)
 {}
 
 output_t::~output_t() = default;

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -95,6 +95,9 @@ public:
         return m_output_requirements;
     }
 
+private:
+    std::shared_ptr<middle_query_t> m_mid;
+
 protected:
     thread_pool_t &thread_pool() const noexcept
     {
@@ -102,8 +105,13 @@ protected:
         return *m_thread_pool;
     }
 
+    middle_query_t const &middle() const noexcept
+    {
+        assert(m_mid);
+        return *m_mid;
+    }
+
     std::shared_ptr<thread_pool_t> m_thread_pool;
-    std::shared_ptr<middle_query_t> m_mid;
     const options_t m_options;
     output_requirements m_output_requirements{};
 };

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -47,6 +47,13 @@ public:
     clone(std::shared_ptr<middle_query_t> const &mid,
           std::shared_ptr<db_copy_thread_t> const &copy_thread) const = 0;
 
+    /**
+     * Remove pointer to middle_query_t from output, so the middle_query_t
+     * is properly cleaned up and doesn't hold references to any datastructures
+     * any more.
+     */
+    void free_middle_references();
+
     virtual void start() = 0;
     virtual void stop() = 0;
     virtual void sync() = 0;


### PR DESCRIPTION
The outputs have a shared pointer to the middle_query_t to access the data held by the middle. This in turn holds pointers to potentially large datastructures and the flat node file. We need to release those pointers after we don't need them any more so that if and when the middle doesn't need those data structures any more they get cleaned up.

In effect this releases the memory used for the cache and flat node store earlier.

Fixes #1563

The second commit cleans up the code a bit using a proper accessor in `output_t` to access the `mid` pointer.