### PR TITLE
ci: improve the workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   macos:
-
-    env:
-      LUA_VERSION: 5.2
-
     runs-on: macos-latest
-
     steps:
       - uses: actions/checkout@v2
 
@@ -30,8 +25,6 @@ jobs:
         shell: bash
 
       - uses: ./.github/actions/build-and-test
-        with:
-          test-wrapper:
         env:
           PGHOST: /tmp
 
@@ -216,7 +209,7 @@ jobs:
       - uses: ./.github/actions/ubuntu-prerequisites
       - uses: ./.github/actions/build-and-test
 
-  ubuntu20-pg12-gcc10-release:
+  ubuntu20-pg13-gcc10-release:
     runs-on: ubuntu-20.04
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on: [ push, pull_request ]
 jobs:
   macos:
     runs-on: macos-latest
+    env:
+      LUA_VERSION: 5.4    
     steps:
       - uses: actions/checkout@v2
 
@@ -25,6 +27,8 @@ jobs:
         shell: bash
 
       - uses: ./.github/actions/build-and-test
+        with:
+          test-wrapper: ''
         env:
           PGHOST: /tmp
 


### PR DESCRIPTION
- remove LUA_VERSION env for macos build, https://github.com/Homebrew/homebrew-core/pull/82233 (it builds/runs fine with lua 5.4?)
- remove `test-wrapper` input arg (use the default value as it already did)
- fix the job ref for `ubuntu20-pg13-gcc10-release`