### PR TITLE
Github action: Add Windows CI build

### DIFF
--- a/.github/actions/win-build/action.yml
+++ b/.github/actions/win-build/action.yml
@@ -1,0 +1,10 @@
+name: Windows build
+
+runs:
+  using: composite
+  steps:
+    - name: Build
+      run: cmake --build . --config Release --verbose
+      shell: bash
+      working-directory: build
+

--- a/.github/actions/win-cmake/action.yml
+++ b/.github/actions/win-cmake/action.yml
@@ -1,0 +1,13 @@
+name: Windows CMake
+
+runs:
+  using: composite
+  steps:
+    - name: Create build directory
+      run: mkdir build
+      shell: bash
+    - name: Configure
+      run: cmake -LA .. -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_TESTS=ON -DGETOPT_INCLUDE_DIR=$GETOPT_INCLUDE_DIR -DGETOPT_LIBRARY=$GETOPT_LIBRARY -DBoost_USE_STATIC_LIBS=ON
+      shell: bash
+      working-directory: build
+

--- a/.github/actions/win-getopt/action.yml
+++ b/.github/actions/win-getopt/action.yml
@@ -1,0 +1,18 @@
+name: Windows getopt
+
+runs:
+  using: composite
+  steps:
+    - name: Install wingetopt
+      env:
+        WINGETOPT_VER: v0.95
+      run: |
+        git clone --quiet --depth 1 https://github.com/alex85k/wingetopt -b $WINGETOPT_VER ../wingetopt
+        mkdir ../wingetopt/build
+      shell: bash
+    - name: Build wingetopt
+      run: |
+        cmake -LA .. -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+        cmake --build . --config Release --verbose
+      working-directory: ../wingetopt/build
+      shell: bash

--- a/.github/actions/win-install/action.yml
+++ b/.github/actions/win-install/action.yml
@@ -1,0 +1,11 @@
+name: Windows install
+
+runs:
+  using: composite
+  steps:
+    - name: Install packages
+      run: vcpkg install bzip2:x64-windows expat:x64-windows zlib:x64-windows proj4:x64-windows boost-algorithm:x64-windows boost-system:x64-windows boost-filesystem:x64-windows boost-property-tree:x64-windows lua:x64-windows libpq:x64-windows
+      shell: bash
+    - name: Install psycopg2
+      run: python -m pip install psycopg2
+      shell: bash

--- a/.github/actions/win-test/action.yml
+++ b/.github/actions/win-test/action.yml
@@ -1,0 +1,10 @@
+name: Windows test
+
+runs:
+  using: composite
+  steps:
+    - name: Test
+      run: ctest --output-on-failure -C Release -L NoDB
+      shell: bash
+      working-directory: build
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,3 +197,33 @@ jobs:
       - uses: ./.github/actions/ubuntu-prerequisites
       - uses: ./.github/actions/build-and-test
 
+  windows-2019:
+    runs-on: windows-2019
+    env:
+      GETOPT_INCLUDE_DIR: ${{ github.workspace }}/../wingetopt/src
+      GETOPT_LIBRARY: ${{ github.workspace }}/../wingetopt/build/Release/wingetopt.lib
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: ./.github/actions/win-install
+      - uses: ./.github/actions/win-getopt
+      - uses: ./.github/actions/win-cmake
+      - uses: ./.github/actions/win-build
+      - uses: ./.github/actions/win-test
+
+  windows-2022:
+    runs-on: windows-2022
+    env:
+      GETOPT_INCLUDE_DIR: ${{ github.workspace }}/../wingetopt/src
+      GETOPT_LIBRARY: ${{ github.workspace }}/../wingetopt/build/Release/wingetopt.lib
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: ./.github/actions/win-install
+      - uses: ./.github/actions/win-getopt
+      - uses: ./.github/actions/win-cmake
+      - uses: ./.github/actions/win-build
+      - uses: ./.github/actions/win-test
+


### PR DESCRIPTION
So far this only compiles osm2pgsql on Windows. Only tests without database are run. We can later add functionality to export the compiled result as artefact, test that etc. 