### PR TITLE
remove CI runs on Ubuntu 16 images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,40 +36,6 @@ jobs:
           PGHOST: /tmp
 
 
-  ubuntu16-pg95-gcc5:
-    runs-on: ubuntu-16.04
-
-    env:
-      CC: gcc-5
-      CXX: g++-5
-      LUA_VERSION: 5.1
-      LUAJIT_OPTION: OFF
-      POSTGRESQL_VERSION: 9.5
-      POSTGIS_VERSION: 2.3
-      BUILD_TYPE: Release
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/ubuntu-prerequisites
-      - uses: ./.github/actions/build-and-test
-
-  ubuntu16-pg95-clang6:
-    runs-on: ubuntu-16.04
-
-    env:
-      CC: clang-6.0
-      CXX: clang++-6.0
-      LUA_VERSION: 5.2
-      LUAJIT_OPTION: OFF
-      POSTGRESQL_VERSION: 9.5
-      POSTGIS_VERSION: 2.3
-      BUILD_TYPE: Release
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: ./.github/actions/ubuntu-prerequisites
-      - uses: ./.github/actions/build-and-test
-
   ubuntu18-pg95-gcc7-jit:
     runs-on: ubuntu-18.04
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ It also requires access to a database server running
 
 Make sure you have installed the development packages for the libraries
 mentioned in the requirements section and a C++ compiler which supports C++14.
+We officially support gcc >= 7.0 and clang >= 8.
 
 To rebuild the included man page you'll need the [pandoc](https://pandoc.org/)
 tool.


### PR DESCRIPTION
These images are no longer available on the Github CI. This means that we won't be testing gcc < 7 and clang < 8 anymore, so add a note to that end in the prerequisites section.