### PR TITLE
Fix logging while progress display is on

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -17,3 +17,26 @@ logger the_logger{};
 /// Access the global logger singleton
 logger &get_logger() noexcept { return the_logger; }
 
+std::string logger::generate_common_prefix(fmt::text_style const &ts,
+                                           char const *prefix)
+{
+    std::string str;
+
+    if (m_needs_leading_return) {
+        m_needs_leading_return = false;
+        str += '\n';
+    }
+
+    str += fmt::format("{:%Y-%m-%d %H:%M:%S}  ",
+                       fmt::localtime(std::time(nullptr)));
+
+    if (m_current_level == log_level::debug) {
+        str += fmt::format(ts, "[{}] ", this_thread_num);
+    }
+
+    if (prefix) {
+        str += fmt::format(ts, "{}: ", prefix);
+    }
+
+    return str;
+}

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -36,6 +36,9 @@ enum class log_level
  */
 class logger
 {
+    std::string generate_common_prefix(fmt::text_style const &ts,
+                                       char const *prefix);
+
 public:
     template <typename S, typename... TArgs>
     void log(log_level with_level, char const *prefix,
@@ -47,23 +50,7 @@ public:
 
         auto const &ts = m_use_color ? style : fmt::text_style{};
 
-        std::string str;
-
-        if (m_needs_leading_return) {
-            m_needs_leading_return = false;
-            str += '\n';
-        }
-
-        str += fmt::format("{:%Y-%m-%d %H:%M:%S}  ",
-                           fmt::localtime(std::time(nullptr)));
-
-        if (m_current_level == log_level::debug) {
-            str += fmt::format(ts, "[{}] ", this_thread_num);
-        }
-
-        if (prefix) {
-            str += fmt::format(ts, "{}: ", prefix);
-        }
+        auto str = generate_common_prefix(ts, prefix);
 
         str += fmt::format(ts, format_str, std::forward<TArgs>(args)...);
         str += '\n';

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -40,7 +40,7 @@ public:
     template <typename S, typename... TArgs>
     void log(log_level with_level, char const *prefix,
              fmt::text_style const &style, S const &format_str,
-             TArgs &&... tags) const
+             TArgs &&... args) const
     {
         if (with_level < m_current_level) {
             return;
@@ -59,7 +59,7 @@ public:
             str += fmt::format(ts, "{}: ", prefix);
         }
 
-        str += fmt::format(ts, format_str, std::forward<TArgs>(tags)...);
+        str += fmt::format(ts, format_str, std::forward<TArgs>(args)...);
         str += '\n';
 
         std::fputs(str.c_str(), stderr);
@@ -98,51 +98,51 @@ private:
 logger &get_logger() noexcept;
 
 template <typename S, typename... TArgs>
-void log_debug(S const &format_str, TArgs &&... tags)
+void log_debug(S const &format_str, TArgs &&... args)
 {
     get_logger().log(log_level::debug, nullptr, {}, format_str,
-                     std::forward<TArgs>(tags)...);
+                     std::forward<TArgs>(args)...);
 }
 
 template <typename S, typename... TArgs>
-void log_info(S const &format_str, TArgs &&... tags)
+void log_info(S const &format_str, TArgs &&... args)
 {
     get_logger().log(log_level::info, nullptr, {}, format_str,
-                     std::forward<TArgs>(tags)...);
+                     std::forward<TArgs>(args)...);
 }
 
 template <typename S, typename... TArgs>
-void log_warn(S const &format_str, TArgs &&... tags)
+void log_warn(S const &format_str, TArgs &&... args)
 {
     get_logger().log(log_level::warn, "WARNING", fg(fmt::color::red),
-                     format_str, std::forward<TArgs>(tags)...);
+                     format_str, std::forward<TArgs>(args)...);
 }
 
 template <typename S, typename... TArgs>
-void log_error(S const &format_str, TArgs &&... tags)
+void log_error(S const &format_str, TArgs &&... args)
 {
     get_logger().log(log_level::error, "ERROR",
                      fmt::emphasis::bold | fg(fmt::color::red), format_str,
-                     std::forward<TArgs>(tags)...);
+                     std::forward<TArgs>(args)...);
 }
 
 template <typename S, typename... TArgs>
-void log_sql(S const &format_str, TArgs &&... tags)
+void log_sql(S const &format_str, TArgs &&... args)
 {
     auto const &logger = get_logger();
     if (logger.log_sql()) {
         logger.log(log_level::error, "SQL", fg(fmt::color::blue), format_str,
-                   std::forward<TArgs>(tags)...);
+                   std::forward<TArgs>(args)...);
     }
 }
 
 template <typename S, typename... TArgs>
-void log_sql_data(S const &format_str, TArgs &&... tags)
+void log_sql_data(S const &format_str, TArgs &&... args)
 {
     auto const &logger = get_logger();
     if (logger.log_sql_data()) {
         logger.log(log_level::error, "SQL", {}, format_str,
-                   std::forward<TArgs>(tags)...);
+                   std::forward<TArgs>(args)...);
     }
 }
 

--- a/src/progress-display.cpp
+++ b/src/progress-display.cpp
@@ -40,6 +40,7 @@ void progress_display_t::print_summary() const
     std::time_t const now = std::time(nullptr);
 
     if (m_enabled) {
+        get_logger().no_leading_return();
         fmt::print(stderr, "\r{:90s}\r", "");
     }
 
@@ -62,6 +63,7 @@ void progress_display_t::print_summary() const
 void progress_display_t::print_status(std::time_t now) const
 {
     if (m_enabled) {
+        get_logger().needs_leading_return();
         fmt::print(stderr,
                    "\rProcessing: Node({}k {:.1f}k/s) Way({}k {:.2f}k/s)"
                    " Relation({} {:.1f}/s)",


### PR DESCRIPTION
When there is an active progress display, log messages show up after the progress display instead of the next line. This adds the necessary newline character to fix that. 