### PR TITLE
CMake config: Also set C as additional language in project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 cmake_minimum_required(VERSION 3.5.0)
 
-project(osm2pgsql VERSION 1.5.1 LANGUAGES CXX)
+project(osm2pgsql VERSION 1.5.1 LANGUAGES CXX C)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
Otherwise some versions of CMake will fail with error:
try_compile() works only for enabled languages.

Fixes #1600