### PR TITLE
Replication script: better checking for external libraries

### DIFF
--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -30,13 +30,22 @@ from textwrap import dedent
 from pathlib import Path
 import urllib.request as urlrequest
 
-import psycopg2
+missing_modules = []
 
-from osmium.replication.server import ReplicationServer
-from osmium.replication.utils import get_replication_header
-from osmium import WriteHandler
+try:
+    import psycopg2
+except ImportError:
+    missing_modules.append('psycopg2')
+
+try:
+    from osmium.replication.server import ReplicationServer
+    from osmium.replication.utils import get_replication_header
+    from osmium import WriteHandler
+except ImportError:
+    missing_modules.append('osmium')
 
 LOG = logging.getLogger()
+
 
 def pretty_format_timedelta(seconds):
     minutes = int(seconds/60)
@@ -484,9 +493,17 @@ def main():
     parser = get_parser()
     args = parser.parse_args()
 
+    if missing_modules:
+        LOG.fatal("Missing required Python libraries %(mods)s.\n\n"
+                  "To install them via pip run: pip install %(mods)s\n\n"
+                  "ERROR: libraries could not be loaded.",
+                  dict(mods=" ".join(missing_modules)))
+        return 1
+
+
     if args.subcommand is None:
         parser.print_help()
-        sys.exit(1)
+        return 1
 
     logging.basicConfig(stream=sys.stderr,
                         format='{asctime} [{levelname}]: {message}',

--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -33,9 +33,12 @@ import urllib.request as urlrequest
 missing_modules = []
 
 try:
-    import psycopg2
+    import psycopg2 as psycopg
 except ImportError:
-    missing_modules.append('psycopg2')
+    try:
+        import psycopg
+    except ImportError:
+        missing_modules.append('psycopg2')
 
 try:
     from osmium.replication.server import ReplicationServer
@@ -72,8 +75,8 @@ def pretty_format_timedelta(seconds):
 def connect(args):
     """ Create a connection from the given command line arguments.
     """
-    return psycopg2.connect(dbname=args.database, user=args.username,
-                            host=args.host, port=args.port)
+    return psycopg.connect(dbname=args.database, user=args.username,
+                           host=args.host, port=args.port)
 
 
 def compute_database_date(conn, prefix):


### PR DESCRIPTION
Print a helpful error message with instructions what to do when loading the psycopg or osmium libraries fails.

The second commit enables the script to work with psycopg>=3.0. (It will still prompt you to install psycopg2, just so that people who are on stable distributions are not confused.)