### PR TITLE
Remove dependency on boost::system and boost::filesystem

### DIFF
--- a/.github/actions/ubuntu-prerequisites/action.yml
+++ b/.github/actions/ubuntu-prerequisites/action.yml
@@ -19,7 +19,7 @@ runs:
 
     - name: Install software
       run: |
-        sudo apt-get install -yq --no-install-suggests --no-install-recommends postgresql-${POSTGRESQL_VERSION}-postgis-${POSTGIS_VERSION} postgresql-${POSTGRESQL_VERSION}-postgis-${POSTGIS_VERSION}-scripts postgresql-client postgresql-contrib-${POSTGRESQL_VERSION} postgresql-${POSTGRESQL_VERSION} libpq-dev libboost-system-dev libboost-filesystem-dev libexpat1-dev zlib1g-dev libbz2-dev libproj-dev pandoc python3-psycopg2 libluajit-5.1-dev
+        sudo apt-get install -yq --no-install-suggests --no-install-recommends postgresql-${POSTGRESQL_VERSION}-postgis-${POSTGIS_VERSION} postgresql-${POSTGRESQL_VERSION}-postgis-${POSTGIS_VERSION}-scripts postgresql-client postgresql-contrib-${POSTGRESQL_VERSION} postgresql-${POSTGRESQL_VERSION} libpq-dev libboost-dev libexpat1-dev zlib1g-dev libbz2-dev libproj-dev pandoc python3-psycopg2 libluajit-5.1-dev
         if [ "$CC" = clang-6.0 ]; then sudo apt-get install -yq --no-install-suggests --no-install-recommends clang-6.0; fi
         if [ "$CC" = clang-8 ]; then sudo apt-get install -yq --no-install-suggests --no-install-recommends clang-8; fi
       shell: bash

--- a/.github/actions/win-install/action.yml
+++ b/.github/actions/win-install/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Install packages
-      run: vcpkg install bzip2:x64-windows expat:x64-windows zlib:x64-windows proj4:x64-windows boost-system:x64-windows boost-filesystem:x64-windows boost-property-tree:x64-windows lua:x64-windows libpq:x64-windows
+      run: vcpkg install bzip2:x64-windows expat:x64-windows zlib:x64-windows proj4:x64-windows boost-property-tree:x64-windows lua:x64-windows libpq:x64-windows
       shell: bash
     - name: Install psycopg2
       run: python -m pip install psycopg2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ if (WITH_LUA)
     find_program(LUA_EXE lua)
 endif()
 
-find_package(Boost 1.50 REQUIRED COMPONENTS system filesystem)
+find_package(Boost 1.50 REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 
 find_package(PostgreSQL REQUIRED)
@@ -256,6 +256,7 @@ elseif (LUA_FOUND)
 endif()
 
 if (WIN32)
+    add_definitions(/D_CRT_NONSTDC_NO_WARNINGS) # suppress warning for unlink()
     list(APPEND LIBS ws2_32)
     if (MSVC)
         find_path(GETOPT_INCLUDE_DIR getopt.h)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Required libraries are
 * [proj](https://proj.org/)
 * [bzip2](http://www.bzip.org/)
 * [zlib](https://www.zlib.net/)
-* [Boost libraries](https://www.boost.org/), including system and filesystem
+* [Boost libraries](https://www.boost.org/)
 * [PostgreSQL](https://www.postgresql.org/) client libraries
 * [Lua](https://www.lua.org/) (Optional, used for Lua tag transforms
   and the flex output)
@@ -81,8 +81,8 @@ First install the dependencies.
 On a Debian or Ubuntu system, this can be done with:
 
 ```sh
-sudo apt-get install make cmake g++ libboost-dev libboost-system-dev \
-  libboost-filesystem-dev libexpat1-dev zlib1g-dev \
+sudo apt-get install make cmake g++ libboost-dev \
+  libexpat1-dev zlib1g-dev \
   libbz2-dev libpq-dev libproj-dev lua5.3 liblua5.3-dev pandoc
 ```
 

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -36,8 +36,6 @@ extern "C"
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
-#include <boost/filesystem.hpp>
-
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
@@ -1632,8 +1630,7 @@ void output_flex_t::init_lua(std::string const &filename)
                        m_options.append ? "append" : "create");
     luaX_add_table_int(lua_state(), "stage", 1);
 
-    std::string const dir_path =
-        boost::filesystem::path{filename}.parent_path().string();
+    std::string const dir_path = util::parent_path(filename);
     luaX_add_table_str(lua_state(), "config_dir", dir_path.c_str());
 
     luaX_add_table_func(lua_state(), "define_table",

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -85,4 +85,10 @@ std::string get_password()
     return password;
 }
 
+std::string parent_path(std::string const &path)
+{
+    auto const pos = path.find_last_of("/\\");
+    return path.substr(0, pos);
+}
+
 } // namespace util

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -129,6 +129,8 @@ std::string human_readable_duration(std::chrono::milliseconds ms);
 
 std::string get_password();
 
+std::string parent_path(std::string const &path);
+
 } // namespace util
 
 #endif // OSM2PGSQL_UTIL_HPP

--- a/tests/common-cleanup.hpp
+++ b/tests/common-cleanup.hpp
@@ -14,7 +14,13 @@
 
 #include <string>
 
-#include <boost/filesystem.hpp>
+// for unlink()
+#ifdef _WIN32
+#include <io.h>
+#include <cstdio>
+#else
+#include <unistd.h>
+#endif
 
 namespace testing {
 namespace cleanup {
@@ -45,11 +51,10 @@ private:
             return;
         }
 
-        boost::system::error_code ec;
-        boost::filesystem::remove(m_filename, ec);
-        if (ec && warn) {
+        int result = unlink(m_filename.c_str());
+        if (result != 0 && warn) {
             fmt::print(stderr, "WARNING: Unable to remove \"{}\": {}\n",
-                       m_filename, ec.message());
+                       m_filename, std::strerror(result));
         }
     }
 

--- a/tests/test-util.cpp
+++ b/tests/test-util.cpp
@@ -82,3 +82,14 @@ TEST_CASE("human readable time durations", "[NoDB]")
     REQUIRE(util::human_readable_duration(152592) == "152592s (42h 23m 12s)");
 }
 
+TEST_CASE("get parent path")
+{
+    REQUIRE(util::parent_path("/foo/bar/baz") == "/foo/bar");
+    REQUIRE(util::parent_path("/foo/bar/") == "/foo/bar");
+    REQUIRE(util::parent_path("/foo/bar") == "/foo");
+    REQUIRE(util::parent_path("/") == "");
+    REQUIRE(util::parent_path("C:\\foo\\bar\\baz") == "C:\\foo\\bar");
+    REQUIRE(util::parent_path("C:\\foo\\bar\\") == "C:\\foo\\bar");
+    REQUIRE(util::parent_path("C:\\foo\\bar") == "C:\\foo");
+    REQUIRE(util::parent_path("C:\\") == "C:");
+}


### PR DESCRIPTION
Not the cleanest of code with the `ifdef` etc. but it removes a large dependency. If and when we switch to C++17, we can revert that and use std::filesystem.