### PR TITLE
Install osm2pgsql-replication script/man page on make install

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -1,0 +1,94 @@
+name: Test install
+
+on: [ push, pull_request ]
+
+jobs:
+  ubuntu-test-install:
+    runs-on: ubuntu-20.04
+
+    env:
+      LUA_VERSION: 5.3
+      POSTGRESQL_VERSION: 12
+      POSTGIS_VERSION: 3
+      BUILD_TYPE: Release
+      CXXFLAGS: -pedantic -Wextra -Werror
+      PREFIX: /usr/local
+      OSMURL: https://download.geofabrik.de/europe/monaco-latest.osm.pbf
+      OSMFILE: monaco-latest.osm.pbf
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Show installed PostgreSQL packages
+        run: apt-cache search postgresql | sort
+      - name: Install prerequisites
+        run: |
+          sudo apt-get purge -yq postgresql*
+          sudo apt-get install -yq --no-install-suggests --no-install-recommends \
+            libboost-filesystem-dev \
+            libboost-system-dev \
+            libbz2-dev \
+            libexpat1-dev \
+            liblua${LUA_VERSION}-dev \
+            libluajit-5.1-dev \
+            libpq-dev \
+            libproj-dev \
+            lua${LUA_VERSION} \
+            pandoc \
+            postgresql-${POSTGRESQL_VERSION} \
+            postgresql-${POSTGRESQL_VERSION}-postgis-${POSTGIS_VERSION} \
+            postgresql-${POSTGRESQL_VERSION}-postgis-${POSTGIS_VERSION}-scripts \
+            postgresql-client-${POSTGRESQL_VERSION} \
+            python3-pyosmium \
+            python3-psycopg2 \
+            zlib1g-dev
+      - name: Run CMake
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      - name: Build osm2pgsql
+        working-directory: build
+        run: make -j3 all man
+      - name: Install osm2pgsql
+        working-directory: build
+        run: sudo make install
+      - name: Check osm2pgsql install
+        run: |
+          test -d $PREFIX/bin
+          test -e $PREFIX/bin/osm2pgsql
+          test -e $PREFIX/bin/osm2pgsql-replication
+          test -d $PREFIX/share/man/man1
+          test -f $PREFIX/share/man/man1/osm2pgsql.1
+          test -f $PREFIX/share/man/man1/osm2pgsql-replication.1
+          test -d $PREFIX/share/osm2pgsql
+          test -f $PREFIX/share/osm2pgsql/default.style
+          test -f $PREFIX/share/osm2pgsql/empty.style
+      - name: Set up test databases
+        run: |
+          sudo systemctl start postgresql
+          sudo -u postgres createuser runner
+          sudo -u postgres createdb -O runner o2ptest
+          sudo -u postgres psql o2ptest -c "CREATE EXTENSION postgis;"
+          sudo -u postgres psql o2ptest -c "CREATE EXTENSION hstore;"
+      - name: Remove repository
+        # Remove contents of workspace to be sure the install runs independently
+        working-directory: /
+        run: rm -fr "${{github.workspace}}"/*
+      - name: Show man pages
+        run: |
+          man -P cat osm2pgsql
+          man -P cat osm2pgsql-replication
+      - name: Download test file
+        run: wget --quiet $OSMURL
+        working-directory: /tmp
+      - name: Test run of osm2pgsql
+        run: $PREFIX/bin/osm2pgsql -d o2ptest --slim $OSMFILE
+        working-directory: /tmp
+      - name: Test run osm2pgsql-replication
+        run: |
+          $PREFIX/bin/osm2pgsql-replication init -v -d o2ptest
+          $PREFIX/bin/osm2pgsql-replication status -v -d o2ptest
+          $PREFIX/bin/osm2pgsql-replication update -v -d o2ptest --once --max-diff-size=1
+          $PREFIX/bin/osm2pgsql-replication status -v -d o2ptest --json
+        working-directory: /tmp
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,5 +335,7 @@ add_subdirectory(docs)
 
 if (ENABLE_INSTALL)
     install(TARGETS osm2pgsql DESTINATION bin)
+    install(PROGRAMS scripts/osm2pgsql-replication DESTINATION bin)
+    install(FILES docs/osm2pgsql-replication.1 DESTINATION share/man/man1)
     install(FILES default.style empty.style DESTINATION share/osm2pgsql)
 endif()


### PR DESCRIPTION
This also adds a new Github actions workflow which tests the
installation of osm2pgsql and osm2pgsql-replication.