### PR TITLE
Fix manpage issues reported by lintian.

### DIFF
--- a/docs/osm2pgsql-replication.1
+++ b/docs/osm2pgsql-replication.1
@@ -1,6 +1,6 @@
 .TH osm2pgsql-replication "1" Manual
 .SH NAME
-osm2pgsql-replication
+osm2pgsql-replication - osm2pgsql database updater
 .SH SYNOPSIS
 .B osm2pgsql-replication
 [-h] {init,update,status} ...
@@ -269,25 +269,25 @@ With the '\-\-json' option, the status is printed as a json object.
 .br
 
 .br
-'status' is 0 if there were no problems getting the status. 1 & 2 for
+\(cqstatus\(cq is 0 if there were no problems getting the status. 1 & 2 for
 .br
 improperly set up replication. 3 for network issues. If status ≠ 0, then
 .br
-the 'error' key is an error message (as string). 'status' is used as the
+the \(cqerror\(cq key is an error message (as string). \(cqstatus\(cq is used
 .br
-exit code.
+as the exit code.
 .br
 
 .br
-'server' is the replication server's current status. 'sequence' is it's
+\(cqserver\(cq is the replication server\(cqs current status. \(cqsequence\(cq is it\(cqs
 .br
-sequence number, 'timestamp' the time of that, and 'age_sec' the age of the
+sequence number, \(cqtimestamp\(cq the time of that, and \(cqage_sec\(cq the age of the
 .br
 data in seconds.
 .br
 
 .br
-'local' is the status of your server.
+\(cqlocal\(cq is the status of your server.
 
 
 .TP


### PR DESCRIPTION
The lintian QA tool reported a few issues with the `osm2pgsql-replication` manpage:

 * [bad-whatis-entry](https://lintian.debian.org/tags/bad-whatis-entry)
   The `NAME` section requires the format: `<name> - <description>`
 * [groff-message](https://lintian.debian.org/tags/groff-message): warning: macro '&lt;foo&gt;'' not defined
   `'` at the start of a line is special, from the [groff(7)](https://manpages.debian.org/bullseye/groff/groff.7.en.html) documentation:
   > The single quote has two controlling tasks. At the beginning of a line and in the conditional requests it is the non-breaking control character. That means that it introduces a request like the dot, but with the additional property that this request doesn't cause a linebreak. By using the `c2` request, the non-break control character can be set to a different character. 
   > As a second task, it is the most commonly used argument separator in some functional escape sequences (but any pair of characters not part of the argument do work). In all other positions, it denotes the single quote or apostrophe character. Groff provides a printable representation with the `\(cq` escape sequence. 
