### PR TITLE
Github action: Disable fail-fast for Windows matrix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   macos:
     runs-on: macos-latest
     env:
-      LUA_VERSION: 5.4    
+      LUA_VERSION: 5.4
     steps:
       - uses: actions/checkout@v2
 
@@ -218,6 +218,7 @@ jobs:
 
   windows:
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-2019, windows-2022]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
So we see if there is a difference in the built results if one fails.