### PR TITLE
Fix reprojection when using Proj version 6 and above

### DIFF
--- a/tests/test-reprojection.cpp
+++ b/tests/test-reprojection.cpp
@@ -49,18 +49,18 @@ TEST_CASE("projection 3857", "[NoDB]")
 }
 
 #ifdef HAVE_GENERIC_PROJ
-TEST_CASE("projection 5520", "[NoDB]")
+TEST_CASE("projection 5651", "[NoDB]")
 {
     osmium::Location const loc{10.0, 53.0};
-    int const srs = 5520; // DHDN / 3-degree Gauss-Kruger zone 1
+    int const srs = 5651; // ETRS89 / UTM zone 31N (N-zE)
 
     auto const reprojection = reprojection::create_projection(srs);
     REQUIRE(reprojection->target_srs() == srs);
     REQUIRE_FALSE(reprojection->target_latlon());
 
     auto const c = reprojection->reproject(loc);
-    REQUIRE(c.x == Approx(1969579.14));
-    REQUIRE(c.y == Approx(5896972.95));
+    REQUIRE(c.x == Approx(31969448.78));
+    REQUIRE(c.y == Approx(5895222.39));
 
     auto const ct = reprojection->target_to_tile(c);
     REQUIRE(ct.x == Approx(1113194.91));

--- a/tests/test-reprojection.cpp
+++ b/tests/test-reprojection.cpp
@@ -9,6 +9,7 @@
 
 #include <catch.hpp>
 
+#include "config.h"
 #include "reprojection.hpp"
 
 TEST_CASE("projection 4326", "[NoDB]")
@@ -58,8 +59,8 @@ TEST_CASE("projection 5520", "[NoDB]")
     REQUIRE_FALSE(reprojection->target_latlon());
 
     auto const c = reprojection->reproject(loc);
-    REQUIRE(c.x == Approx(1969644.93));
-    REQUIRE(c.y == Approx(5897146.04));
+    REQUIRE(c.x == Approx(1969579.14));
+    REQUIRE(c.y == Approx(5896972.95));
 
     auto const ct = reprojection->target_to_tile(c);
     REQUIRE(ct.x == Approx(1113194.91));


### PR DESCRIPTION
The test was never run so we did not notice that the projection did not
work correctly.

Code modelled after https://proj.org/development/migration.html .