### PR TITLE
Simplify tests that include Lua files

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,8 +11,7 @@ function(set_test test_name)
     target_link_libraries(${test_name} osm2pgsql_lib catch_main_lib)
     add_test(NAME ${test_name} COMMAND ${test_name})
 
-    set_tests_properties(${test_name} PROPERTIES TIMEOUT ${TESTING_TIMEOUT}
-                                                 ENVIRONMENT SRCPATH=${CMAKE_CURRENT_SOURCE_DIR})
+    set_tests_properties(${test_name} PROPERTIES TIMEOUT ${TESTING_TIMEOUT})
 
     if (DEFINED test_param_LABELS)
         list(FIND test_param_LABELS Tablespace test_num_labels)

--- a/tests/data/test_output_flex_area_25832_25832.lua
+++ b/tests/data/test_output_flex_area_25832_25832.lua
@@ -1,5 +1,5 @@
 
 test = { geom_proj = 25832, area_proj = 25832 }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_area.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_area.lua')
 

--- a/tests/data/test_output_flex_area_25832_3857.lua
+++ b/tests/data/test_output_flex_area_25832_3857.lua
@@ -1,5 +1,5 @@
 
 test = { geom_proj = 25832, area_proj = 3857 }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_area.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_area.lua')
 

--- a/tests/data/test_output_flex_area_25832_4326.lua
+++ b/tests/data/test_output_flex_area_25832_4326.lua
@@ -1,5 +1,5 @@
 
 test = { geom_proj = 25832, area_proj = 4326 }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_area.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_area.lua')
 

--- a/tests/data/test_output_flex_area_3857_25832.lua
+++ b/tests/data/test_output_flex_area_3857_25832.lua
@@ -1,5 +1,5 @@
 
 test = { geom_proj = 3857, area_proj = 25832 }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_area.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_area.lua')
 

--- a/tests/data/test_output_flex_area_3857_3857.lua
+++ b/tests/data/test_output_flex_area_3857_3857.lua
@@ -1,5 +1,5 @@
 
 test = { geom_proj = 3857, area_proj = 3857 }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_area.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_area.lua')
 

--- a/tests/data/test_output_flex_area_3857_4326.lua
+++ b/tests/data/test_output_flex_area_3857_4326.lua
@@ -1,5 +1,5 @@
 
 test = { geom_proj = 3857, area_proj = 4326 }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_area.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_area.lua')
 

--- a/tests/data/test_output_flex_area_4326_25832.lua
+++ b/tests/data/test_output_flex_area_4326_25832.lua
@@ -1,5 +1,5 @@
 
 test = { geom_proj = 4326, area_proj = 25832 }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_area.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_area.lua')
 

--- a/tests/data/test_output_flex_area_4326_3857.lua
+++ b/tests/data/test_output_flex_area_4326_3857.lua
@@ -1,5 +1,5 @@
 
 test = { geom_proj = 4326, area_proj = 3857 }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_area.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_area.lua')
 

--- a/tests/data/test_output_flex_area_4326_4326.lua
+++ b/tests/data/test_output_flex_area_4326_4326.lua
@@ -1,5 +1,5 @@
 
 test = { geom_proj = 4326, area_proj = 4326 }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_area.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_area.lua')
 

--- a/tests/data/test_output_flex_area_mix.lua
+++ b/tests/data/test_output_flex_area_mix.lua
@@ -1,5 +1,5 @@
 
 test = { geom_proj = 'latlong', area_proj = 'merc' }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_area.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_area.lua')
 

--- a/tests/data/test_output_flex_multigeom_geometry.lua
+++ b/tests/data/test_output_flex_multigeom_geometry.lua
@@ -1,5 +1,5 @@
 
 test = { type = 'geometry' }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_multigeom.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_multigeom.lua')
 

--- a/tests/data/test_output_flex_multigeom_geometry_split.lua
+++ b/tests/data/test_output_flex_multigeom_geometry_split.lua
@@ -1,5 +1,5 @@
 
 test = { type = 'geometry', split_at = 'multi' }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_multigeom.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_multigeom.lua')
 

--- a/tests/data/test_output_flex_multigeom_multipolygon.lua
+++ b/tests/data/test_output_flex_multigeom_multipolygon.lua
@@ -1,5 +1,5 @@
 
 test = { type = 'multipolygon' }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_multigeom.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_multigeom.lua')
 

--- a/tests/data/test_output_flex_multigeom_multipolygon_split.lua
+++ b/tests/data/test_output_flex_multigeom_multipolygon_split.lua
@@ -1,5 +1,5 @@
 
 test = { type = 'multipolygon', split_at = 'multi' }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_multigeom.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_multigeom.lua')
 

--- a/tests/data/test_output_flex_multigeom_polygon.lua
+++ b/tests/data/test_output_flex_multigeom_polygon.lua
@@ -1,5 +1,5 @@
 
 test = { type = 'polygon', split_at = 'multi' }
 
-dofile(os.getenv('SRCPATH') .. '/data/test_output_flex_multigeom.lua')
+dofile(osm2pgsql.config_dir .. '/test_output_flex_multigeom.lua')
 


### PR DESCRIPTION
This is possible because we added the ?osm2pgsql.config_dir` variable a while back.