### PR TITLE
Use std::system_error instead of runtime_error/strerror

### DIFF
--- a/src/node-persistent-cache.cpp
+++ b/src/node-persistent-cache.cpp
@@ -11,8 +11,8 @@
 #include "node-persistent-cache.hpp"
 
 #include <cassert>
-#include <cstring>
 #include <stdexcept>
+#include <system_error>
 
 void node_persistent_cache::set(osmid_t id, osmium::Location location)
 {
@@ -36,8 +36,9 @@ node_persistent_cache::node_persistent_cache(std::string file_name,
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, hicpp-signed-bitwise)
     m_fd = open(m_file_name.c_str(), O_RDWR | O_CREAT, 0644);
     if (m_fd < 0) {
-        throw std::runtime_error{"Unable to open flatnode file '{}': {}"_format(
-            m_file_name, std::strerror(errno))};
+        throw std::system_error{
+            errno, std::system_category(),
+            "Unable to open flatnode file '{}'"_format(m_file_name)};
     }
 
     m_index = std::make_unique<index_t>(m_fd);

--- a/src/taginfo.cpp
+++ b/src/taginfo.cpp
@@ -15,6 +15,7 @@
 #include <cstring>
 #include <map>
 #include <stdexcept>
+#include <system_error>
 
 #include <osmium/util/string.hpp>
 
@@ -88,8 +89,9 @@ bool read_style_file(std::string const &filename, export_list *exlist)
 
     FILE *const in = std::fopen(filename.c_str(), "rt");
     if (!in) {
-        throw std::runtime_error{"Couldn't open style file '{}': {}."_format(
-            filename, std::strerror(errno))};
+        throw std::system_error{
+            errno, std::system_category(),
+            "Couldn't open style file '{}'"_format(filename)};
     }
 
     char buffer[1024];
@@ -177,8 +179,9 @@ bool read_style_file(std::string const &filename, export_list *exlist)
     if (std::ferror(in)) {
         int const err = errno;
         std::fclose(in);
-        throw std::runtime_error{
-            "{}: {}."_format(filename, std::strerror(err))};
+        throw std::system_error{
+            err, std::system_category(),
+            "Error reading style file '{}'"_format(filename)};
     }
 
     std::fclose(in);


### PR DESCRIPTION
`std::strerror()` is not thread-safe, so it is best avoided. Also the output of the error messages will be more uniform this way.

There is one other case where we use `strerror()` (in [expire-tiles.cpp](https://github.com/openstreetmap/osm2pgsql/blob/master/src/expire-tiles.cpp#L44)) but that's only a warning, so we can't replace it by `system_error`, although maybe it shouldn't be a warning? Leaving that for later, the expire code needs some work anyway.