### PR TITLE
Add directory separator to end of config_dir

### DIFF
--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1660,8 +1660,11 @@ void output_flex_t::init_lua(std::string const &filename)
                        m_options.append ? "append" : "create");
     luaX_add_table_int(lua_state(), "stage", 1);
 
-    std::string const dir_path =
+    std::string dir_path =
         boost::filesystem::path{filename}.parent_path().string();
+    if (!dir_path.empty()) {
+        dir_path += boost::filesystem::path::preferred_separator;
+    }
     luaX_add_table_str(lua_state(), "config_dir", dir_path.c_str());
 
     luaX_add_table_func(lua_state(), "define_table",


### PR DESCRIPTION
This allows the filename that will usually be concatenated to the
directory name in the Lua code to be written without the trailing
separator (usually '/'). This will make it work if there is no directory
used in the -S option.