### PR TITLE
Refactor of way/relation "cache" in flex output

### DIFF
--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -216,6 +216,9 @@ private:
 
     lua_State *lua_state() noexcept { return m_lua_state.get(); }
 
+    bool init_relation_cache(osmid_t id);
+    void init_relation_cache(osmium::Relation const &relation);
+
     std::shared_ptr<std::vector<flex_table_t>> m_tables;
     std::vector<table_connection_t> m_table_connections;
 

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -166,7 +166,7 @@ public:
 
 private:
     void init_clone();
-    void select_relation_members(osmium::Relation const &relation);
+    void select_relation_members();
 
     /**
      * Call a Lua function that was "prepared" earlier with the OSMObject

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -218,6 +218,7 @@ private:
 
     bool init_relation_cache(osmid_t id);
     void init_relation_cache(osmium::Relation const &relation);
+    std::size_t add_members_to_relation_cache();
 
     std::shared_ptr<std::vector<flex_table_t>> m_tables;
     std::vector<table_connection_t> m_table_connections;

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -212,9 +212,11 @@ private:
                            osmium::item_type type, osmid_t osm_id);
     void delete_from_tables(osmium::item_type type, osmid_t osm_id);
 
-    std::size_t get_way_nodes();
-
     lua_State *lua_state() noexcept { return m_lua_state.get(); }
+
+    bool init_way_cache(osmid_t id);
+    void init_way_cache(osmium::Way *way);
+    std::size_t add_nodes_to_way_cache();
 
     bool init_relation_cache(osmid_t id);
     void init_relation_cache(osmium::Relation const &relation);


### PR DESCRIPTION
This refactors the somewhat difficult to understand code in the flex output that handles getting and caching ways and their nodes, and relations and their members. The changes are in several steps, each in their own commit.