### PR TITLE
Get bbox relation

### DIFF
--- a/flex-config/bbox.lua
+++ b/flex-config/bbox.lua
@@ -1,0 +1,153 @@
+-- This config example file is released into the Public Domain.
+--
+-- This config shows how to use the get_bbox() function to get the bounding
+-- boxes of features.
+
+local tables = {}
+
+tables.pois = osm2pgsql.define_node_table('pois', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'bbox', type = 'text', sql_type = 'box2d' },
+    { column = 'geom', type = 'point' },
+})
+
+tables.ways = osm2pgsql.define_way_table('ways', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'bbox', type = 'text', sql_type = 'box2d' },
+    { column = 'geom', type = 'linestring' },
+})
+
+tables.polygons = osm2pgsql.define_area_table('polygons', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'bbox', type = 'text', sql_type = 'box2d' },
+    { column = 'geom', type = 'geometry' }
+})
+
+tables.boundaries = osm2pgsql.define_relation_table('boundaries', {
+    { column = 'type', type = 'text' },
+    { column = 'tags', type = 'jsonb' },
+    { column = 'bbox', type = 'text', sql_type = 'box2d' },
+    { column = 'geom', type = 'multilinestring' },
+})
+
+-- Helper function to remove some of the tags we usually are not interested in.
+-- Returns true if there are no tags left.
+function clean_tags(tags)
+    tags.odbl = nil
+    tags.created_by = nil
+    tags.source = nil
+    tags['source:ref'] = nil
+
+    return next(tags) == nil
+end
+
+-- Helper function that looks at the tags and decides if this is possibly
+-- an area.
+function has_area_tags(tags)
+    if tags.area == 'yes' then
+        return true
+    end
+    if tags.area == 'no' then
+        return false
+    end
+
+    return tags.aeroway
+        or tags.amenity
+        or tags.building
+        or tags.harbour
+        or tags.historic
+        or tags.landuse
+        or tags.leisure
+        or tags.man_made
+        or tags.military
+        or tags.natural
+        or tags.office
+        or tags.place
+        or tags.power
+        or tags.public_transport
+        or tags.shop
+        or tags.sport
+        or tags.tourism
+        or tags.water
+        or tags.waterway
+        or tags.wetland
+        or tags['abandoned:aeroway']
+        or tags['abandoned:amenity']
+        or tags['abandoned:building']
+        or tags['abandoned:landuse']
+        or tags['abandoned:power']
+        or tags['area:highway']
+end
+
+-- Format the bounding box we get from calling get_bbox() on the parameter
+-- in the way needed for the PostgreSQL/PostGIS box2d type.
+function format_bbox(object)
+    xmin, ymin, xmax, ymax = object.get_bbox()
+    if xmin == nil then
+        return nil
+    end
+    return 'BOX(' .. tostring(xmin) .. ' ' .. tostring(ymin)
+           .. ',' .. tostring(xmax) .. ' ' .. tostring(ymax) .. ')'
+end
+
+function osm2pgsql.process_node(object)
+    if clean_tags(object.tags) then
+        return
+    end
+
+    tables.pois:add_row({
+        bbox = format_bbox(object),
+        tags = object.tags
+    })
+end
+
+function osm2pgsql.process_way(object)
+    if clean_tags(object.tags) then
+        return
+    end
+
+    -- A closed way that also has the right tags for an area is a polygon.
+    if object.is_closed and has_area_tags(object.tags) then
+        tables.polygons:add_row({
+            tags = object.tags,
+            bbox = format_bbox(object),
+            geom = { create = 'area' }
+        })
+    else
+        tables.ways:add_row({
+            tags = object.tags,
+            bbox = format_bbox(object),
+            geom = { create = 'line' }
+        })
+    end
+end
+
+function osm2pgsql.process_relation(object)
+    if clean_tags(object.tags) then
+        return
+    end
+
+    local type = object:grab_tag('type')
+
+    -- Store boundary relations as multilinestrings
+    if type == 'boundary' then
+        tables.boundaries:add_row({
+            type = type,
+            bbox = format_bbox(object),
+            tags = object.tags,
+            geom = { create = 'line' }
+        })
+        return
+    end
+
+    -- Store multipolygon relations as polygons
+    if type == 'multipolygon' then
+        tables.polygons:add_row({
+            type = type,
+            bbox = format_bbox(object),
+            tags = object.tags,
+            geom = { create = 'area' }
+        })
+    end
+end
+

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -701,12 +701,25 @@ void output_flex_t::write_row(table_connection_t *table_connection,
     copy_mgr->finish_line();
 }
 
+/**
+ * Helper function to push the lon/lat of the specified location onto the
+ * Lua stack
+ */
+static void push_location(lua_State *lua_state,
+                          osmium::Location location) noexcept
+{
+    lua_pushnumber(lua_state, location.lon());
+    lua_pushnumber(lua_state, location.lat());
+}
+
 int output_flex_t::app_get_bbox()
 {
     if (m_calling_context != calling_context::process_node &&
-        m_calling_context != calling_context::process_way) {
-        throw std::runtime_error{"The function get_bbox() can only be called"
-                                 " from process_node() or process_way()."};
+        m_calling_context != calling_context::process_way &&
+        m_calling_context != calling_context::process_relation) {
+        throw std::runtime_error{
+            "The function get_bbox() can only be called from the "
+            "process_node/way/relation() functions."};
     }
 
     if (lua_gettop(lua_state()) > 1) {
@@ -714,10 +727,8 @@ int output_flex_t::app_get_bbox()
     }
 
     if (m_calling_context == calling_context::process_node) {
-        lua_pushnumber(lua_state(), m_context_node->location().lon());
-        lua_pushnumber(lua_state(), m_context_node->location().lat());
-        lua_pushnumber(lua_state(), m_context_node->location().lon());
-        lua_pushnumber(lua_state(), m_context_node->location().lat());
+        push_location(lua_state(), m_context_node->location());
+        push_location(lua_state(), m_context_node->location());
         return 4;
     }
 
@@ -725,10 +736,32 @@ int output_flex_t::app_get_bbox()
         m_way_cache.add_nodes(middle());
         auto const bbox = m_way_cache.get().envelope();
         if (bbox.valid()) {
-            lua_pushnumber(lua_state(), bbox.bottom_left().lon());
-            lua_pushnumber(lua_state(), bbox.bottom_left().lat());
-            lua_pushnumber(lua_state(), bbox.top_right().lon());
-            lua_pushnumber(lua_state(), bbox.top_right().lat());
+            push_location(lua_state(), bbox.bottom_left());
+            push_location(lua_state(), bbox.top_right());
+            return 4;
+        }
+        return 0;
+    }
+
+    if (m_calling_context == calling_context::process_relation) {
+        m_relation_cache.add_members(middle());
+        osmium::Box bbox;
+
+        // Bounding boxes of all the member nodes
+        for (auto const &wnl :
+             m_relation_cache.members_buffer().select<osmium::WayNodeList>()) {
+            bbox.extend(wnl.envelope());
+        }
+
+        // Bounding boxes of all the member ways
+        for (auto const &way :
+             m_relation_cache.members_buffer().select<osmium::Way>()) {
+            bbox.extend(way.nodes().envelope());
+        }
+
+        if (bbox.valid()) {
+            push_location(lua_state(), bbox.bottom_left());
+            push_location(lua_state(), bbox.top_right());
             return 4;
         }
     }
@@ -1050,11 +1083,16 @@ void output_flex_t::relation_cache_t::init(osmium::Relation const &relation)
 bool output_flex_t::relation_cache_t::add_members(middle_query_t const &middle)
 {
     if (m_members_buffer.committed() == 0) {
-        auto const num_ways = middle.rel_members_get(
-            *m_relation, &m_members_buffer, osmium::osm_entity_bits::way);
+        auto const num_members = middle.rel_members_get(
+            *m_relation, &m_members_buffer,
+            osmium::osm_entity_bits::node | osmium::osm_entity_bits::way);
 
-        if (num_ways == 0) {
+        if (num_members == 0) {
             return false;
+        }
+
+        for (auto &nodes : m_members_buffer.select<osmium::WayNodeList>()) {
+            middle.nodes_get_list(&nodes);
         }
 
         for (auto &way : m_members_buffer.select<osmium::Way>()) {

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1047,26 +1047,22 @@ void output_flex_t::relation_cache_t::init(osmium::Relation const &relation)
     m_relation = &relation;
 }
 
-std::size_t
-output_flex_t::relation_cache_t::add_members(middle_query_t const &middle)
+bool output_flex_t::relation_cache_t::add_members(middle_query_t const &middle)
 {
     if (m_members_buffer.committed() == 0) {
         auto const num_ways = middle.rel_members_get(
             *m_relation, &m_members_buffer, osmium::osm_entity_bits::way);
 
         if (num_ways == 0) {
-            return 0;
+            return false;
         }
 
         for (auto &way : m_members_buffer.select<osmium::Way>()) {
             middle.nodes_get_list(&(way.nodes()));
         }
-
-        return num_ways;
     }
 
-    auto const ways = m_members_buffer.select<osmium::Way>();
-    return std::distance(ways.cbegin(), ways.cend());
+    return true;
 }
 
 int output_flex_t::table_add_row()
@@ -1260,7 +1256,7 @@ geom::geometry_t output_flex_t::run_transform(reprojection const &proj,
                                               geom_transform_t const *transform,
                                               osmium::Relation const &relation)
 {
-    if (m_relation_cache.add_members(middle()) == 0) {
+    if (!m_relation_cache.add_members(middle())) {
         return {};
     }
 

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -235,11 +235,19 @@ private:
     public:
         bool init(middle_query_t const &middle, osmid_t id);
         void init(osmium::Relation const &relation);
-        std::size_t add_members(middle_query_t const &middle);
+
+        /**
+         * Add members of relation to cache when it is first called.
+         *
+         * \returns True if at least one member was found, false otherwise
+         */
+        bool add_members(middle_query_t const &middle);
+
         osmium::Relation const &get() const noexcept
         {
             return *m_relation;
         }
+
         osmium::memory::Buffer const &members_buffer() const noexcept
         {
             return m_members_buffer;


### PR DESCRIPTION
The `get_bbox()` function now works for relations, too. Only node and way members are taken into account. The data is cached properly so that it is only requested from the database once even if `get_bbox()` and/or `add_row()` are called multiple times.

Part of this change is that we'll get the location of all nodes members of relations. This is new, we used to only get the way members and the locations in those ways. Getting all the node members keeps the code simpler, but has some overhead. It should be fairly small though compared to getting all the way members of the multipolygon and boundary relations which make up the bulk of what we are using.