### PR TITLE
Fix memory leak in Lua-related code

### DIFF
--- a/src/tagtransform-lua.cpp
+++ b/src/tagtransform-lua.cpp
@@ -21,11 +21,11 @@ lua_tagtransform_t::lua_tagtransform_t(std::string const *tag_transform_script,
                                        bool extra_attributes)
 : m_lua_file(tag_transform_script), m_extra_attributes(extra_attributes)
 {
-    L = luaL_newstate();
-    luaL_openlibs(L);
-    if (luaL_dofile(L, m_lua_file->c_str())) {
-        throw std::runtime_error{
-            "Lua tag transform style error: {}."_format(lua_tostring(L, -1))};
+    m_lua_state.reset(luaL_newstate());
+    luaL_openlibs(lua_state());
+    if (luaL_dofile(lua_state(), m_lua_file->c_str())) {
+        throw std::runtime_error{"Lua tag transform style error: {}."_format(
+            lua_tostring(lua_state(), -1))};
     }
 
     check_lua_function_exists(node_func);
@@ -34,7 +34,7 @@ lua_tagtransform_t::lua_tagtransform_t(std::string const *tag_transform_script,
     check_lua_function_exists(rel_mem_func);
 }
 
-lua_tagtransform_t::~lua_tagtransform_t() { lua_close(L); }
+lua_tagtransform_t::~lua_tagtransform_t() = default;
 
 std::unique_ptr<tagtransform_t> lua_tagtransform_t::clone() const
 {
@@ -43,13 +43,13 @@ std::unique_ptr<tagtransform_t> lua_tagtransform_t::clone() const
 
 void lua_tagtransform_t::check_lua_function_exists(char const *func_name)
 {
-    lua_getglobal(L, func_name);
-    if (!lua_isfunction(L, -1)) {
+    lua_getglobal(lua_state(), func_name);
+    if (!lua_isfunction(lua_state(), -1)) {
         throw std::runtime_error{
             "Tag transform style does not contain a function {}."_format(
                 func_name)};
     }
-    lua_pop(L, 1);
+    lua_pop(lua_state(), 1);
 }
 
 bool lua_tagtransform_t::filter_tags(osmium::OSMObject const &o, bool *polygon,
@@ -57,82 +57,84 @@ bool lua_tagtransform_t::filter_tags(osmium::OSMObject const &o, bool *polygon,
 {
     switch (o.type()) {
     case osmium::item_type::node:
-        lua_getglobal(L, node_func);
+        lua_getglobal(lua_state(), node_func);
         break;
     case osmium::item_type::way:
-        lua_getglobal(L, way_func);
+        lua_getglobal(lua_state(), way_func);
         break;
     case osmium::item_type::relation:
-        lua_getglobal(L, rel_func);
+        lua_getglobal(lua_state(), rel_func);
         break;
     default:
         throw std::runtime_error{"Unknown OSM type."};
     }
 
-    lua_newtable(L); /* key value table */
+    lua_newtable(lua_state()); /* key value table */
 
     lua_Integer sz = 0;
     for (auto const &t : o.tags()) {
-        lua_pushstring(L, t.key());
-        lua_pushstring(L, t.value());
-        lua_rawset(L, -3);
+        lua_pushstring(lua_state(), t.key());
+        lua_pushstring(lua_state(), t.value());
+        lua_rawset(lua_state(), -3);
         ++sz;
     }
     if (m_extra_attributes && o.version() > 0) {
         taglist_t tags;
         tags.add_attributes(o);
         for (auto const &t : tags) {
-            lua_pushstring(L, t.key.c_str());
-            lua_pushstring(L, t.value.c_str());
-            lua_rawset(L, -3);
+            lua_pushstring(lua_state(), t.key.c_str());
+            lua_pushstring(lua_state(), t.value.c_str());
+            lua_rawset(lua_state(), -3);
         }
         sz += tags.size();
     }
 
-    lua_pushinteger(L, sz);
+    lua_pushinteger(lua_state(), sz);
 
-    if (lua_pcall(L, 2, (o.type() == osmium::item_type::way) ? 4 : 2, 0)) {
+    if (lua_pcall(lua_state(), 2, (o.type() == osmium::item_type::way) ? 4 : 2,
+                  0)) {
         /* lua function failed */
-        throw std::runtime_error{"Failed to execute lua function for basic tag "
-                                 "processing: {}."_format(lua_tostring(L, -1))};
+        throw std::runtime_error{
+            "Failed to execute lua function for basic tag "
+            "processing: {}."_format(lua_tostring(lua_state(), -1))};
     }
 
     if (o.type() == osmium::item_type::way) {
         if (roads) {
-            *roads = (int)lua_tointeger(L, -1);
+            *roads = (int)lua_tointeger(lua_state(), -1);
         }
-        lua_pop(L, 1);
+        lua_pop(lua_state(), 1);
         if (polygon) {
-            *polygon = (int)lua_tointeger(L, -1);
+            *polygon = (int)lua_tointeger(lua_state(), -1);
         }
-        lua_pop(L, 1);
+        lua_pop(lua_state(), 1);
     }
 
-    lua_pushnil(L);
-    while (lua_next(L, -2) != 0) {
-        char const *const key = lua_tostring(L, -2);
-        char const *const value = lua_tostring(L, -1);
+    lua_pushnil(lua_state());
+    while (lua_next(lua_state(), -2) != 0) {
+        char const *const key = lua_tostring(lua_state(), -2);
+        char const *const value = lua_tostring(lua_state(), -1);
         if (key == nullptr) {
-            int const ltype = lua_type(L, -2);
+            int const ltype = lua_type(lua_state(), -2);
             throw std::runtime_error{
                 "Basic tag processing returned NULL key. Possibly this is "
                 "due an incorrect data type '{}'."_format(
-                    lua_typename(L, ltype))};
+                    lua_typename(lua_state(), ltype))};
         }
         if (value == nullptr) {
-            int const ltype = lua_type(L, -1);
+            int const ltype = lua_type(lua_state(), -1);
             throw std::runtime_error{
                 "Basic tag processing returned NULL value. Possibly this "
                 "is due an incorrect data type '{}'."_format(
-                    lua_typename(L, ltype))};
+                    lua_typename(lua_state(), ltype))};
         }
         out_tags->add_tag(key, value);
-        lua_pop(L, 1);
+        lua_pop(lua_state(), 1);
     }
 
-    bool const filter = lua_tointeger(L, -2);
+    bool const filter = lua_tointeger(lua_state(), -2);
 
-    lua_pop(L, 2);
+    lua_pop(lua_state(), 2);
 
     return filter;
 }
@@ -143,69 +145,69 @@ bool lua_tagtransform_t::filter_rel_member_tags(
     bool *roads, taglist_t *out_tags)
 {
     size_t const num_members = member_roles.size();
-    lua_getglobal(L, rel_mem_func);
+    lua_getglobal(lua_state(), rel_mem_func);
 
-    lua_newtable(L); /* relations key value table */
+    lua_newtable(lua_state()); /* relations key value table */
 
     for (auto const &rel_tag : rel_tags) {
-        lua_pushstring(L, rel_tag.key.c_str());
-        lua_pushstring(L, rel_tag.value.c_str());
-        lua_rawset(L, -3);
+        lua_pushstring(lua_state(), rel_tag.key.c_str());
+        lua_pushstring(lua_state(), rel_tag.value.c_str());
+        lua_rawset(lua_state(), -3);
     }
 
-    lua_newtable(L); /* member tags table */
+    lua_newtable(lua_state()); /* member tags table */
 
     int idx = 1;
     for (auto const &w : members.select<osmium::Way>()) {
-        lua_pushnumber(L, idx++);
-        lua_newtable(L); /* member key value table */
+        lua_pushnumber(lua_state(), idx++);
+        lua_newtable(lua_state()); /* member key value table */
         for (auto const &member_tag : w.tags()) {
-            lua_pushstring(L, member_tag.key());
-            lua_pushstring(L, member_tag.value());
-            lua_rawset(L, -3);
+            lua_pushstring(lua_state(), member_tag.key());
+            lua_pushstring(lua_state(), member_tag.value());
+            lua_rawset(lua_state(), -3);
         }
-        lua_rawset(L, -3);
+        lua_rawset(lua_state(), -3);
     }
 
-    lua_newtable(L); /* member roles table */
+    lua_newtable(lua_state()); /* member roles table */
 
     for (size_t i = 0; i < num_members; ++i) {
-        lua_pushnumber(L, i + 1);
-        lua_pushstring(L, member_roles[i]);
-        lua_rawset(L, -3);
+        lua_pushnumber(lua_state(), i + 1);
+        lua_pushstring(lua_state(), member_roles[i]);
+        lua_rawset(lua_state(), -3);
     }
 
-    lua_pushnumber(L, num_members);
+    lua_pushnumber(lua_state(), num_members);
 
-    if (lua_pcall(L, 4, 6, 0)) {
+    if (lua_pcall(lua_state(), 4, 6, 0)) {
         /* lua function failed */
         throw std::runtime_error{
             "Failed to execute lua function for relation tag "
-            "processing: {}."_format(lua_tostring(L, -1))};
+            "processing: {}."_format(lua_tostring(lua_state(), -1))};
     }
 
-    *roads = (int)lua_tointeger(L, -1);
-    lua_pop(L, 1);
-    *make_polygon = (int)lua_tointeger(L, -1);
-    lua_pop(L, 1);
-    *make_boundary = (int)lua_tointeger(L, -1);
-    lua_pop(L, 1);
+    *roads = (int)lua_tointeger(lua_state(), -1);
+    lua_pop(lua_state(), 1);
+    *make_polygon = (int)lua_tointeger(lua_state(), -1);
+    lua_pop(lua_state(), 1);
+    *make_boundary = (int)lua_tointeger(lua_state(), -1);
+    lua_pop(lua_state(), 1);
 
     // obsolete member superseded is ignored.
-    lua_pop(L, 1);
+    lua_pop(lua_state(), 1);
 
-    lua_pushnil(L);
-    while (lua_next(L, -2) != 0) {
-        char const *const key = lua_tostring(L, -2);
-        char const *const value = lua_tostring(L, -1);
+    lua_pushnil(lua_state());
+    while (lua_next(lua_state(), -2) != 0) {
+        char const *const key = lua_tostring(lua_state(), -2);
+        char const *const value = lua_tostring(lua_state(), -1);
         out_tags->add_tag(key, value);
-        lua_pop(L, 1);
+        lua_pop(lua_state(), 1);
     }
-    lua_pop(L, 1);
+    lua_pop(lua_state(), 1);
 
-    bool const filter = lua_tointeger(L, -1);
+    bool const filter = lua_tointeger(lua_state(), -1);
 
-    lua_pop(L, 1);
+    lua_pop(lua_state(), 1);
 
     return filter;
 }

--- a/src/tagtransform-lua.cpp
+++ b/src/tagtransform-lua.cpp
@@ -14,8 +14,9 @@ extern "C"
 }
 
 #include "format.hpp"
-#include "options.hpp"
 #include "tagtransform-lua.hpp"
+
+#include <stdexcept>
 
 lua_tagtransform_t::lua_tagtransform_t(std::string const *tag_transform_script,
                                        bool extra_attributes)
@@ -33,8 +34,6 @@ lua_tagtransform_t::lua_tagtransform_t(std::string const *tag_transform_script,
     check_lua_function_exists(rel_func);
     check_lua_function_exists(rel_mem_func);
 }
-
-lua_tagtransform_t::~lua_tagtransform_t() = default;
 
 std::unique_ptr<tagtransform_t> lua_tagtransform_t::clone() const
 {

--- a/src/tagtransform-lua.hpp
+++ b/src/tagtransform-lua.hpp
@@ -25,7 +25,7 @@ public:
     explicit lua_tagtransform_t(std::string const *tag_transform_script,
                                 bool extra_attributes);
 
-    ~lua_tagtransform_t() override;
+    ~lua_tagtransform_t() noexcept override = default;
 
     std::unique_ptr<tagtransform_t> clone() const override;
 

--- a/src/tagtransform-lua.hpp
+++ b/src/tagtransform-lua.hpp
@@ -21,10 +21,9 @@ extern "C"
 
 class lua_tagtransform_t : public tagtransform_t
 {
-    lua_tagtransform_t(lua_tagtransform_t const &other) = default;
-
 public:
-    explicit lua_tagtransform_t(options_t const *options);
+    explicit lua_tagtransform_t(std::string const *tag_transform_script,
+                                bool extra_attributes);
 
     ~lua_tagtransform_t() override;
 
@@ -46,11 +45,10 @@ private:
     constexpr static char const *const rel_mem_func =
         "filter_tags_relation_member";
 
-    void open_style();
     void check_lua_function_exists(char const *func_name);
 
     lua_State *L = nullptr;
-    std::string m_lua_file;
+    std::string const *m_lua_file;
     bool m_extra_attributes;
 };
 

--- a/src/tagtransform-lua.hpp
+++ b/src/tagtransform-lua.hpp
@@ -40,14 +40,16 @@ public:
                                 bool *roads, taglist_t *out_tags) override;
 
 private:
+    constexpr static char const *const node_func = "filter_tags_node";
+    constexpr static char const *const way_func = "filter_tags_way";
+    constexpr static char const *const rel_func = "filter_basic_tags_rel";
+    constexpr static char const *const rel_mem_func =
+        "filter_tags_relation_member";
+
     void open_style();
-    void check_lua_function_exists(std::string const &func_name);
+    void check_lua_function_exists(char const *func_name);
 
     lua_State *L = nullptr;
-    std::string m_node_func;
-    std::string m_way_func;
-    std::string m_rel_func;
-    std::string m_rel_mem_func;
     std::string m_lua_file;
     bool m_extra_attributes;
 };

--- a/src/tagtransform-lua.hpp
+++ b/src/tagtransform-lua.hpp
@@ -47,7 +47,15 @@ private:
 
     void check_lua_function_exists(char const *func_name);
 
-    lua_State *L = nullptr;
+    struct lua_state_deleter_t
+    {
+        void operator()(lua_State *state) const noexcept { lua_close(state); }
+    };
+
+    lua_State *lua_state() noexcept { return m_lua_state.get(); }
+
+    std::unique_ptr<lua_State, lua_state_deleter_t> m_lua_state;
+
     std::string const *m_lua_file;
     bool m_extra_attributes;
 };

--- a/src/tagtransform.cpp
+++ b/src/tagtransform.cpp
@@ -27,7 +27,8 @@ tagtransform_t::make_tagtransform(options_t const *options,
 #ifdef HAVE_LUA
         log_debug("Using lua based tag transformations with script {}",
                   options->tag_transform_script);
-        return std::make_unique<lua_tagtransform_t>(options);
+        return std::make_unique<lua_tagtransform_t>(
+            &options->tag_transform_script, options->extra_attributes);
 #else
         throw std::runtime_error{"Error: Could not init lua tag transform, as "
                                  "lua support was not compiled into this "


### PR DESCRIPTION
This fixes a memory leak of a Lua context. In the process quite some refactoring needed to be done and some more checks on the data osm2pgsql receives from Lua scripts. See the individual commits.