### PR TITLE
Call ANALYZE on tables with ids when two-stage processing is used

### DIFF
--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -274,7 +274,7 @@ void table_connection_t::stop(bool updateable, bool append)
     }
 
     log_info("Analyzing table '{}'...", table().name());
-    analyze_table(*m_db_connection, table().schema(), table().name());
+    analyze();
 
     teardown();
 }
@@ -285,6 +285,11 @@ void table_connection_t::prepare()
     if (table().has_id_column() && table().has_geom_column()) {
         m_db_connection->exec(table().build_sql_prepare_get_wkb());
     }
+}
+
+void table_connection_t::analyze()
+{
+    analyze_table(*m_db_connection, table().schema(), table().name());
 }
 
 void table_connection_t::create_id_index()

--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -253,6 +253,8 @@ public:
 
     void prepare();
 
+    void analyze();
+
     void create_id_index();
 
     pg_result_t get_geom_by_id(osmium::item_type type, osmid_t id) const;

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1825,6 +1825,7 @@ void output_flex_t::reprocess_marked()
         for (auto &table : m_table_connections) {
             if (table.table().matches_type(osmium::item_type::way) &&
                 table.table().has_id_column()) {
+                table.analyze();
                 table.create_id_index();
             }
         }


### PR DESCRIPTION
For these tables a (temporary) index is created but an ANALYZE might
help to speed up things.