### PR TITLE
Add run-behave script for convenience

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,10 @@ if (BUILD_TESTS)
         set(TESTING_TIMEOUT 1200)
     endif()
     add_subdirectory(tests)
+    configure_file(
+        ${PROJECT_SOURCE_DIR}/tests/run-behave.in
+        ${PROJECT_BINARY_DIR}/run-behave
+    )
 else()
     message(STATUS "Tests disabled. Set BUILD_TESTS=ON to enable tests.")
 endif()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,12 @@ behave -DBINARY=<your build directory>/osm2pgsql
 Per default, behave assumes that the build directory is under `osm2pgsql/build`.
 If your setup works like that, you can leave out the -D parameter.
 
+To make this a bit easier a shell script `run-behave` is provided in your
+build directory which sets those correct paths and calls `behave`. If run
+with `-p` as first option it will wrap the call to `behave` in a call to
+`pg_virtualenv` for your convenience. All other command line parameters of
+`run-behave` will be passed through to behave.
+
 To run a single test, simply add the name of the test file, followed by a
 column and the line number of the test:
 

--- a/tests/run-behave.in
+++ b/tests/run-behave.in
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ "$1" = "-p" ]; then
+    pgv=pg_virtualenv
+    shift
+fi
+
+cd @PROJECT_SOURCE_DIR@/tests/bdd
+exec $pgv behave -DBINARY=@PROJECT_BINARY_DIR@/osm2pgsql "$@"
+


### PR DESCRIPTION
If run with `-p` as first option it will wrap the call to `behave` in a
call to `pg_virtualenv` for your convenience. All other command line
parameters of `run-behave` will be passed through to behave.