### PR TITLE
osm2pgsql-replication: use custom SRID

### DIFF
--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -376,6 +376,28 @@ def update(conn, args):
         osm2pgsql.extend(('-H', args.host))
     if args.port:
         osm2pgsql.extend(('-P', args.port))
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT Find_SRID('public', '{}_point', 'way')".format(args.prefix))
+        srid = cur.fetchone()[0] if cur.rowcount == 1 else None
+        
+        if srid is None:
+            LOG.fatal("Could not find the SRID of the data.")
+            return 1
+
+    LOG.debug("SRID of data: {}".format(srid))
+
+    EPSG_LAT_LONG = 4326
+    EPSG_WEB_MERCATOR = 3857
+
+    if srid == EPSG_WEB_MERCATOR:
+        # we can leave the default behavior
+        pass
+    elif srid == EPSG_LAT_LONG:
+        osm2pgsql.append('--latlong')
+    else:
+        osm2pgsql.extend(('--proj', str(srid)))
+
     osm2pgsql.append(str(outfile))
     LOG.debug("Calling osm2pgsql with: %s", ' '.join(osm2pgsql))
 


### PR DESCRIPTION
I discovered the script `osm2pgsql-replication` only works if the OSM import is done using the "standard" SRID `3857` (Web Mercator). For other SRIDs the script fails with this error message:

```
2022-07-24 12:20:14  ERROR: DB copy thread failed: Ending COPY mode for 'munster_point' failed: ERROR:  Geometry SRID (3857) does not match column SRID (25832)
CONTEXT:  COPY munster_point, line 1, column way: "0101000020110F0000BBE39EB508C628413EAB91CF1BC25941"
.
Traceback (most recent call last):
  File "/usr/local/bin/osm2pgsql-replication", line 531, in <module>
    sys.exit(main())
  File "/usr/local/bin/osm2pgsql-replication", line 524, in main
    ret = args.handler(conn, args)
  File "/usr/local/bin/osm2pgsql-replication", line 395, in update
    subprocess.run(osm2pgsql, check=True)
  File "/usr/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['osm2pgsql', '--append', '--slim', '--prefix', 'munster', '/tmp/tmpxw8d_x4m/osm2pgsql_diff.osc.gz']' returned non-zero exit status 2.
```

This PR makes it possible to also update databases with other SRIDs.

Please let me know if I should change anything, I am ready to adapt the code if required.