### PR TITLE
Add "type" attribute to Lua "object" callback parameter

### DIFF
--- a/flex-config/simple.lua
+++ b/flex-config/simple.lua
@@ -50,6 +50,7 @@ tables.ways = osm2pgsql.define_way_table('ways', {
 -- running in "append" mode, osm2pgsql will automatically update this table
 -- using the way/relation ids.
 tables.polygons = osm2pgsql.define_area_table('polygons', {
+    { column = 'type', type = 'text' },
     { column = 'tags', type = 'jsonb' },
     -- The type of the `geom` column is `geometry`, because we need to store
     -- polygons AND multipolygons
@@ -117,6 +118,7 @@ function osm2pgsql.process_way(object)
     -- real stylesheet we'd have to also look at the tags...
     if object.is_closed then
         tables.polygons:add_row({
+            type = object.type,
             tags = object.tags,
             geom = { create = 'area' }
         })
@@ -142,6 +144,7 @@ function osm2pgsql.process_relation(object)
     if object.tags.type == 'multipolygon' or
        object.tags.type == 'boundary' then
          tables.polygons:add_row({
+            type = object.type,
             tags = object.tags,
             geom = { create = 'area' }
         })

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -113,15 +113,18 @@ static void push_osm_object_to_lua_stack(lua_State *lua_state,
     assert(lua_state);
 
     /**
-     * Table will have 7 fields (id, version, timestamp, changeset, uid, user,
-     * tags) for all object types plus 2 (is_closed, nodes) for ways or 1
-     * (members) for relations.
+     * Table will always have at least 3 fields (id, type, tags). And 5 more if
+     * with_attributes is true (version, timestamp, changeset, uid, user). For
+     * ways there are 2 more (is_closed, nodes), for relations 1 more (members).
      */
-    constexpr int const max_table_size = 9;
+    constexpr int const max_table_size = 10;
 
     lua_createtable(lua_state, 0, max_table_size);
 
     luaX_add_table_int(lua_state, "id", object.id());
+
+    luaX_add_table_str(lua_state, "type",
+                       osmium::item_type_to_name(object.type()));
 
     if (with_attributes) {
         if (object.version() != 0U) {

--- a/tests/bdd/flex/extra-attributes.feature
+++ b/tests/bdd/flex/extra-attributes.feature
@@ -14,6 +14,7 @@ Feature: Tests for including extra attributes
                 name = 'osm2pgsql_test_attr',
                 ids = { type = 'way', id_column = 'way_id' },
                 columns = {
+                    { column = 'type', type = 'text' },
                     { column = 'tags', type = 'hstore' },
                     { column = 'version', type = 'int4' },
                     { column = 'changeset', type = 'int4' },
@@ -35,8 +36,8 @@ Feature: Tests for including extra attributes
             | --slim |
 
         Then table osm2pgsql_test_attr contains
-            | way_id | tags->'highway' | version | changeset | timestamp | uid  | "user" |
-            | 20     | primary         | NULL    | NULL      | NULL      | NULL | NULL   |
+            | type | way_id | tags->'highway' | version | changeset | timestamp | uid  | "user" |
+            | way  | 20     | primary         | NULL    | NULL      | NULL      | NULL | NULL   |
 
         Given the grid
             |    |    |
@@ -45,8 +46,8 @@ Feature: Tests for including extra attributes
             | --slim | --append |
 
         Then table osm2pgsql_test_attr contains
-            | way_id | tags->'highway' | version | changeset | timestamp | uid  | "user" |
-            | 20     | primary         | NULL    | NULL      | NULL      | NULL | NULL   |
+            | type |  way_id | tags->'highway' | version | changeset | timestamp | uid  | "user" |
+            | way  |  20     | primary         | NULL    | NULL      | NULL      | NULL | NULL   |
 
 
     Scenario: Importing data with extra attributes
@@ -54,8 +55,8 @@ Feature: Tests for including extra attributes
             | --slim | -x |
 
         Then table osm2pgsql_test_attr contains
-            | way_id | tags->'highway' | version | changeset | timestamp  | uid  | "user" |
-            | 20     | primary         | 1       | 31        | 1578832496 | 17   | test   |
+            | type |  way_id | tags->'highway' | version | changeset | timestamp  | uid  | "user" |
+            | way  |  20     | primary         | 1       | 31        | 1578832496 | 17   | test   |
 
         Given the grid
             |    |    |
@@ -64,6 +65,6 @@ Feature: Tests for including extra attributes
             | --slim | --append | -x |
 
         Then table osm2pgsql_test_attr contains
-            | way_id | tags->'highway' | version | changeset | timestamp  | uid | "user" |
-            | 20     | primary         | 1       | 31        | 1578832496 | 17  | test   |
+            | type |  way_id | tags->'highway' | version | changeset | timestamp  | uid | "user" |
+            | way  |  20     | primary         | 1       | 31        | 1578832496 | 17  | test   |
 


### PR DESCRIPTION
This is either "node", "way", or "relation". Sometimes useful in scripts.