### PR TITLE
CMake config: Modernize setting of specific C++ standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,6 @@ jobs:
       LUAJIT_OPTION: OFF
       POSTGRESQL_VERSION: 10
       POSTGIS_VERSION: 3
-      CPP_VERSION: 17
       BUILD_TYPE: Debug
 
     steps:
@@ -98,7 +97,6 @@ jobs:
       LUAJIT_OPTION: OFF
       POSTGRESQL_VERSION: 11
       POSTGIS_VERSION: 2.5
-      CPP_VERSION: 17
       BUILD_TYPE: Debug
 
     steps:
@@ -116,7 +114,6 @@ jobs:
       LUAJIT_OPTION: ON
       POSTGRESQL_VERSION: 12
       POSTGIS_VERSION: 2.5
-      CPP_VERSION: 17
       BUILD_TYPE: Debug
 
     steps:
@@ -135,7 +132,6 @@ jobs:
       LUAJIT_OPTION: ON
       POSTGRESQL_VERSION: 13
       POSTGIS_VERSION: 3
-      CPP_VERSION: 17
       BUILD_TYPE: Debug
 
     steps:
@@ -153,7 +149,6 @@ jobs:
       LUAJIT_OPTION: OFF
       POSTGRESQL_VERSION: 13
       POSTGIS_VERSION: 3
-      CPP_VERSION: 17
       USE_PROJ_LIB: 6
       BUILD_TYPE: Debug
 
@@ -172,7 +167,6 @@ jobs:
       LUAJIT_OPTION: OFF
       POSTGRESQL_VERSION: 13
       POSTGIS_VERSION: 3
-      CPP_VERSION: 17
       USE_PROJ_LIB: off
       BUILD_TYPE: Debug
 
@@ -191,7 +185,6 @@ jobs:
       LUAJIT_OPTION: OFF
       POSTGRESQL_VERSION: 14
       POSTGIS_VERSION: 3
-      CPP_VERSION: 17
       USE_PROJ_LIB: 6
       BUILD_TYPE: Debug
 
@@ -210,7 +203,6 @@ jobs:
       LUAJIT_OPTION: ON
       POSTGRESQL_VERSION: 13
       POSTGIS_VERSION: 2.5
-      CPP_VERSION: 17
       BUILD_TYPE: Release
 
     steps:
@@ -226,8 +218,61 @@ jobs:
       CXX: g++-10
       POSTGRESQL_VERSION: 13
       POSTGIS_VERSION: 2.5
-      CPP_VERSION: 17
       BUILD_TYPE: Release
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/build-and-test
+
+  ubuntu22-pg14-clang12-cpp17:
+    runs-on: ubuntu-22.04
+
+    env:
+      CC: clang-12
+      CXX: clang++-12
+      LUA_VERSION: 5.3
+      LUAJIT_OPTION: OFF
+      POSTGRESQL_VERSION: 14
+      POSTGIS_VERSION: 3
+      CPP_VERSION: 17
+      BUILD_TYPE: Debug
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/build-and-test
+
+  ubuntu22-pg14-clang12-cpp20:
+    runs-on: ubuntu-22.04
+
+    env:
+      CC: clang-12
+      CXX: clang++-12
+      LUA_VERSION: 5.3
+      LUAJIT_OPTION: OFF
+      POSTGRESQL_VERSION: 14
+      POSTGIS_VERSION: 3
+      CPP_VERSION: 20
+      BUILD_TYPE: Debug
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/ubuntu-prerequisites
+      - uses: ./.github/actions/build-and-test
+
+  ubuntu22-pg14-gcc11-cpp20:
+    runs-on: ubuntu-22.04
+
+    env:
+      CC: gcc-11
+      CXX: g++-11
+      LUA_VERSION: 5.3
+      LUAJIT_OPTION: OFF
+      POSTGRESQL_VERSION: 14
+      POSTGIS_VERSION: 3
+      CPP_VERSION: 20
+      BUILD_TYPE: Debug
 
     steps:
       - uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.8.0)
 
 project(osm2pgsql VERSION 1.6.0 LANGUAGES CXX C)
 
@@ -37,12 +37,8 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
 
-if (NOT "${CMAKE_CXX_STANDARD}")
-    set(CMAKE_CXX_STANDARD 17)
-endif()
-message(STATUS "Building in C++${CMAKE_CXX_STANDARD} mode")
+# We don't want to use special compiler extensions because we want portability
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS -DNOMINMAX)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,10 @@
 
 add_library(osm2pgsql_lib STATIC)
 
+# Set the minimum required C++ version for the library and hence for all
+# binaries that use it.
+target_compile_features(osm2pgsql_lib PUBLIC cxx_std_17)
+
 target_sources(osm2pgsql_lib PRIVATE
   db-check.cpp
   db-copy.cpp

--- a/src/format.hpp
+++ b/src/format.hpp
@@ -13,7 +13,15 @@
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 
-// NOLINTNEXTLINE(google-global-names-in-headers,google-build-using-namespace)
-using namespace fmt::literals;
+inline auto operator"" _format(const char *s, std::size_t n)
+{
+    return [=](auto &&...args) {
+#if FMT_VERSION < 80100
+        return fmt::format(std::string_view{s, n}, args...);
+#else
+        return fmt::format(fmt::runtime(std::string_view{s, n}), args...);
+#endif
+    };
+}
 
 #endif // OSM2PGSQL_FORMAT_HPP

--- a/src/format.hpp
+++ b/src/format.hpp
@@ -13,7 +13,7 @@
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 
-inline auto operator"" _format(const char *s, std::size_t n)
+inline constexpr auto operator"" _format(const char *s, std::size_t n)
 {
     return [=](auto &&...args) {
 #if FMT_VERSION < 80100


### PR DESCRIPTION
We need C++17 currently. This changes the way we ask CMake for C++17 as a minimum version. We can still set CMAKE_CXX_STANDARD to force a newer standard for testing.

This needs CMake 3.8 which has been available for something like 5 years now.

Fixes #1010.