### PR TITLE
Implement ""_format operator ourselves instead of using from fmt

### DIFF
--- a/src/format.hpp
+++ b/src/format.hpp
@@ -13,7 +13,15 @@
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 
-// NOLINTNEXTLINE(google-global-names-in-headers,google-build-using-namespace)
-using namespace fmt::literals;
+inline auto operator"" _format(const char *s, std::size_t n)
+{
+    return [=](auto &&...args) {
+#if FMT_VERSION < 80100
+        return fmt::format(std::string_view{s, n}, args...);
+#else
+        return fmt::format(fmt::runtime(std::string_view{s, n}), args...);
+#endif
+    };
+}
 
 #endif // OSM2PGSQL_FORMAT_HPP


### PR DESCRIPTION
The one in fmt is deprecated in version 8.1 and removed in version 9.
This way we can keep the syntax and keep backwards compatibility
for a while.