### PR TITLE
All geometry creation functions are now available in two variants

### DIFF
--- a/src/geom-from-osm.hpp
+++ b/src/geom-from-osm.hpp
@@ -19,9 +19,21 @@
  * \file
  *
  * Functions to create geometries from OSM data.
+ *
+ * All functions here are available in two versions, one taking a pointer
+ * to an existing geometry as output parameter, the second which returns
+ * a new geometry instead.
  */
 
 namespace geom {
+
+/**
+ * Create a point geometry from a node.
+ *
+ * \param geom Pointer to an existing geometry which will be used as output.
+ * \param node The input node.
+ */
+void create_point(geometry_t *geom, osmium::Node const &node);
 
 /**
  * Create a point geometry from a node.
@@ -30,6 +42,19 @@ namespace geom {
  * \returns The created geometry.
  */
 geometry_t create_point(osmium::Node const &node);
+
+/**
+ * Create a linestring geometry from a way. Nodes without location are ignored.
+ * Consecutive nodes with the same location will only end up once in the
+ * linestring.
+ *
+ * If the resulting linestring would be invalid (< 1 nodes), a null geometry
+ * is created.
+ *
+ * \param geom Pointer to an existing geometry which will be used as output.
+ * \param way The input way.
+ */
+void create_linestring(geometry_t *geom, osmium::Way const &way);
 
 /**
  * Create a linestring geometry from a way. Nodes without location are ignored.
@@ -49,6 +74,16 @@ geometry_t create_linestring(osmium::Way const &way);
  *
  * If the resulting polygon would be invalid, a null geometry is returned.
  *
+ * \param geom Pointer to an existing geometry which will be used as output.
+ * \param way The input way.
+ */
+void create_polygon(geometry_t *geom, osmium::Way const &way);
+
+/**
+ * Create a polygon geometry from a way.
+ *
+ * If the resulting polygon would be invalid, a null geometry is returned.
+ *
  * \param way The input way.
  * \returns The created geometry.
  */
@@ -62,10 +97,37 @@ geometry_t create_polygon(osmium::Way const &way);
  * If the resulting multilinestring would be invalid, a null geometry is
  * returned.
  *
+ * \param geom Pointer to an existing geometry which will be used as output.
+ * \param ways Buffer containing all the input ways.
+ */
+void create_multilinestring(geometry_t *geom,
+                            osmium::memory::Buffer const &ways);
+
+/**
+ * Create a multilinestring geometry from a bunch of ways (usually this
+ * would be used for member ways of a relation). The result is always a
+ * multilinestring, even if it only contains one linestring.
+ *
+ * If the resulting multilinestring would be invalid, a null geometry is
+ * returned.
+ *
  * \param ways Buffer containing all the input ways.
  * \returns The created geometry.
  */
 geometry_t create_multilinestring(osmium::memory::Buffer const &ways);
+
+/**
+ * Create a (multi)polygon geometry from a relation and member ways.
+ *
+ * If the resulting (multi)polygon would be invalid, a null geometry is
+ * returned.
+ *
+ * \param geom Pointer to an existing geometry which will be used as output.
+ * \param relation The input relation.
+ * \param way_buffer Buffer containing all member ways.
+ */
+void create_multipolygon(geometry_t *geom, osmium::Relation const &relation,
+                         osmium::memory::Buffer const &way_buffer);
 
 /**
  * Create a (multi)polygon geometry from a relation and member ways.


### PR DESCRIPTION
All functions are now available in two variants: one taking a pointer to
an existing geometry as output parameter, and the second which returns a
new geometry instead. The first is faster if the geometry object already
exists, the second is more convenient in places where it doesn't.