### PR TITLE
Add assertions so we are not using the wrong func by accident

### DIFF
--- a/tests/common-buffer.hpp
+++ b/tests/common-buffer.hpp
@@ -28,11 +28,13 @@ public:
 
     osmium::Node const &add_node(std::string const &data)
     {
+        assert(!data.empty() && data[0] == 'n');
         return m_buffer.get<osmium::Node>(add_opl(data));
     }
 
     osmium::Way &add_way(std::string const &data)
     {
+        assert(!data.empty() && data[0] == 'w');
         return m_buffer.get<osmium::Way>(add_opl(data));
     }
 
@@ -52,6 +54,7 @@ public:
 
     osmium::Relation const &add_relation(std::string const &data)
     {
+        assert(!data.empty() && data[0] == 'r');
         return m_buffer.get<osmium::Relation>(add_opl(data));
     }
 

--- a/tests/test-geom-lines.cpp
+++ b/tests/test-geom-lines.cpp
@@ -51,7 +51,7 @@ TEST_CASE("line geometry", "[NoDB]")
 TEST_CASE("create_linestring from OSM data", "[NoDB]")
 {
     test_buffer_t buffer;
-    buffer.add_node("w20 Nn1x1y1,n2x2y2");
+    buffer.add_way("w20 Nn1x1y1,n2x2y2");
 
     auto const geom =
         geom::create_linestring(buffer.buffer().get<osmium::Way>(0));
@@ -68,7 +68,7 @@ TEST_CASE("create_linestring from OSM data", "[NoDB]")
 TEST_CASE("create_linestring from OSM data without locations", "[NoDB]")
 {
     test_buffer_t buffer;
-    buffer.add_node("w20 Nn1,n2");
+    buffer.add_way("w20 Nn1,n2");
 
     auto const geom =
         geom::create_linestring(buffer.buffer().get<osmium::Way>(0));
@@ -79,7 +79,7 @@ TEST_CASE("create_linestring from OSM data without locations", "[NoDB]")
 TEST_CASE("create_linestring from invalid OSM data", "[NoDB]")
 {
     test_buffer_t buffer;
-    buffer.add_node("w20 Nn1x1y1");
+    buffer.add_way("w20 Nn1x1y1");
 
     auto const geom =
         geom::create_linestring(buffer.buffer().get<osmium::Way>(0));


### PR DESCRIPTION
It doesn't matter which function we use as long as we don't use the
return value from them. So the existing cases aren't a problem, but
this way this will not happen in the future where it might be a
problem.