### PR TITLE
way.is_closed() should only be called when there are way nodes

### DIFF
--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -191,7 +191,8 @@ static void push_osm_object_to_lua_stack(lua_State *lua_state,
 
     if (object.type() == osmium::item_type::way) {
         auto const &way = static_cast<osmium::Way const &>(object);
-        luaX_add_table_bool(lua_state, "is_closed", way.is_closed());
+        luaX_add_table_bool(lua_state, "is_closed",
+                            !way.nodes().empty() && way.is_closed());
         luaX_add_table_array(lua_state, "nodes", way.nodes(),
                              [&](osmium::NodeRef const &wn) {
                                  lua_pushinteger(lua_state, wn.ref());

--- a/src/output-gazetteer.cpp
+++ b/src/output-gazetteer.cpp
@@ -137,7 +137,7 @@ bool output_gazetteer_t::process_way(osmium::Way *way)
 
     // Get the geometry of the object.
     geom::geometry_t geom;
-    if (way->is_closed()) {
+    if (!way->nodes().empty() && way->is_closed()) {
         geom = geom::transform(geom::create_polygon(*way), *m_proj);
     }
     if (geom.is_null()) {

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -61,7 +61,7 @@ static double calculate_area(bool reproject_area,
 void output_pgsql_t::pgsql_out_way(osmium::Way const &way, taglist_t *tags,
                                    bool polygon, bool roads)
 {
-    if (polygon && way.is_closed()) {
+    if (polygon && !way.nodes().empty() && way.is_closed()) {
         auto const geom = geom::create_polygon(way);
         auto const projected_geom = geom::transform(geom, *m_proj);
 


### PR DESCRIPTION
When you are feeding ways without nodes to osm2pgsql, which should never
happen in normal operation, osm2pgsql will break without this check.