### PR TITLE
Ensure that the result of geom::simplify() is a valid geom or null

### DIFF
--- a/src/geom-functions.cpp
+++ b/src/geom-functions.cpp
@@ -582,11 +582,17 @@ void simplify(geometry_t *output, geometry_t const &geom, double tolerance)
         return;
     }
 
-    output->set<linestring_t>();
+    auto &ls = output->set<linestring_t>();
     output->set_srid(geom.srid());
 
-    boost::geometry::simplify(geom.get<linestring_t>(),
-                              output->get<linestring_t>(), tolerance);
+    boost::geometry::simplify(geom.get<linestring_t>(), ls, tolerance);
+
+    // Linestrings with less then 2 nodes are invalid. Older boost::geometry
+    // versions will generate a "line" with two identical points which the
+    // second check finds.
+    if (ls.size() < 2 || ls[0] == ls[1]) {
+        output->reset();
+    }
 }
 
 geometry_t simplify(geometry_t const &geom, double tolerance)

--- a/tests/test-geom-linestrings.cpp
+++ b/tests/test-geom-linestrings.cpp
@@ -210,12 +210,51 @@ TEST_CASE("geom::simplify", "[NoDB]")
 
     SECTION("large tolerance simplifies linestring")
     {
-        auto const geom = geom::simplify(input, 2.0);
+        auto const geom = geom::simplify(input, 10.0);
 
         REQUIRE(geom.is_linestring());
         auto const &l = geom.get<geom::linestring_t>();
         REQUIRE(l.size() == 2);
         REQUIRE(l[0] == input.get<geom::linestring_t>()[0]);
         REQUIRE(l[1] == input.get<geom::linestring_t>()[5]);
+    }
+}
+
+TEST_CASE("geom::simplify of a loop", "[NoDB]")
+{
+    geom::geometry_t const input{
+        geom::linestring_t{{0, 0}, {0, 1}, {1, 1}, {1, 0}, {0.1, 0.1}, {0, 0}}};
+
+    SECTION("small tolerance leaves linestring as is")
+    {
+        auto const geom = geom::simplify(input, 0.01);
+
+        REQUIRE(geom.is_linestring());
+        auto const &l = geom.get<geom::linestring_t>();
+        REQUIRE(l.size() == 6);
+        REQUIRE(l == input.get<geom::linestring_t>());
+    }
+
+    SECTION("medium tolerance simplifies linestring")
+    {
+        auto const geom = geom::simplify(input, 0.5);
+
+        REQUIRE(geom.is_linestring());
+        auto const &l = geom.get<geom::linestring_t>();
+        REQUIRE(l.size() == 5);
+
+        auto const &il = input.get<geom::linestring_t>();
+        REQUIRE(l[0] == il[0]);
+        REQUIRE(l[1] == il[1]);
+        REQUIRE(l[2] == il[2]);
+        REQUIRE(l[3] == il[3]);
+        REQUIRE(l[4] == il[5]);
+    }
+
+    SECTION("large tolerance breaks linestring, null geometry is returned")
+    {
+        auto const geom = geom::simplify(input, 10.0);
+
+        REQUIRE(geom.is_null());
     }
 }


### PR DESCRIPTION
The simplification function can generate a linestring with a single
point in it, which wouldn't be a line any more. Return a null geometry
in that case.