### PR TITLE
Add get_node_location() function to middle

### DIFF
--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -37,6 +37,8 @@ public:
         std::string const &conninfo, std::shared_ptr<node_locations_t> cache,
         std::shared_ptr<node_persistent_cache> persistent_cache);
 
+    osmium::Location get_node_location(osmid_t id) const override;
+
     size_t nodes_get_list(osmium::WayNodeList *nodes) const override;
 
     bool way_get(osmid_t id, osmium::memory::Buffer *buffer) const override;
@@ -51,6 +53,8 @@ public:
     void exec_sql(std::string const &sql_cmd) const;
 
 private:
+    osmium::Location get_node_location_flatnodes(osmid_t id) const;
+    osmium::Location get_node_location_db(osmid_t id) const;
     std::size_t get_way_node_locations_flatnodes(osmium::WayNodeList *nodes) const;
     std::size_t get_way_node_locations_db(osmium::WayNodeList *nodes) const;
 

--- a/src/middle-ram.cpp
+++ b/src/middle-ram.cpp
@@ -184,6 +184,11 @@ void middle_ram_t::relation(osmium::Relation const &relation)
     }
 }
 
+osmium::Location middle_ram_t::get_node_location(osmid_t id) const
+{
+    return m_node_locations.get(id);
+}
+
 std::size_t middle_ram_t::nodes_get_list(osmium::WayNodeList *nodes) const
 {
     assert(nodes);

--- a/src/middle-ram.hpp
+++ b/src/middle-ram.hpp
@@ -54,6 +54,8 @@ public:
     void way(osmium::Way const &way) override;
     void relation(osmium::Relation const &) override;
 
+    osmium::Location get_node_location(osmid_t id) const override;
+
     std::size_t nodes_get_list(osmium::WayNodeList *nodes) const override;
 
     bool way_get(osmid_t id, osmium::memory::Buffer *buffer) const override;

--- a/src/middle.hpp
+++ b/src/middle.hpp
@@ -29,6 +29,11 @@ struct middle_query_t : std::enable_shared_from_this<middle_query_t>
     virtual ~middle_query_t() = 0;
 
     /**
+     * Retrieves node location for the given id.
+     */
+    virtual osmium::Location get_node_location(osmid_t id) const = 0;
+
+    /**
      * Retrieves node locations for the given node list.
      *
      * The locations are saved directly in the input list.

--- a/tests/test-middle.cpp
+++ b/tests/test-middle.cpp
@@ -28,10 +28,10 @@ static testing::pg::tempdb_t db;
 
 namespace {
 
-void expect_location(osmium::Location loc, osmium::Node const &expected)
+void check_locations_are_equal(osmium::Location a, osmium::Location b)
 {
-    CHECK(loc.lat() == Approx(expected.location().lat()));
-    CHECK(loc.lon() == Approx(expected.location().lon()));
+    CHECK(a.lat() == Approx(b.lat()));
+    CHECK(a.lon() == Approx(b.lon()));
 }
 
 } // namespace
@@ -136,11 +136,18 @@ TEMPLATE_TEST_CASE("middle import", "", options_slim_default,
 
         // get it back
         REQUIRE(mid_q->nodes_get_list(&nodes) == nodes.size());
-        expect_location(nodes[0].location(), node);
+        check_locations_are_equal(nodes[0].location(), node.location());
 
         // other nodes are not retrievable
         auto &n2 = buffer.add_way("w3 Nn1,n2,n1235").nodes();
         REQUIRE(mid_q->nodes_get_list(&n2) == 0);
+
+        // check the same thing again using get_node_location() function
+        check_locations_are_equal(mid_q->get_node_location(1234),
+                                  node.location());
+        CHECK_FALSE(mid_q->get_node_location(1).valid());
+        CHECK_FALSE(mid_q->get_node_location(2).valid());
+        CHECK_FALSE(mid_q->get_node_location(1235).valid());
     }
 
     SECTION("Set and retrieve a single way")


### PR DESCRIPTION
Before we had only a function to retrieve a list of locations from a
list of nodes which is inconvenient if you only need a single location.

The new function is needed in the context of retrieving locations for
member nodes of relations.

There are probably ways to improve on this:
* We are using the get_node_list prepared statement to get the single
  id when a simpler prepared statement would do. But then we'd need
  another prepared statement.
* When using this it might be possible to first assemble a list of
  several ids and get them all in one go. But its more difficult to
  write code like this and there aren't that many relations around
  that have lots of node members, so we'll leave it at that and
  optimize this later if needed.