### PR TITLE
Fiddling with the geometry_t type

### DIFF
--- a/src/geom.hpp
+++ b/src/geom.hpp
@@ -176,7 +176,7 @@ public:
 
     GEOM &add_geometry(GEOM &&geom)
     {
-        m_geometry.push_back(std::move(geom));
+        m_geometry.push_back(std::forward<GEOM>(geom));
         return m_geometry.back();
     }
 
@@ -234,8 +234,31 @@ class geometry_t
 public:
     constexpr geometry_t() = default;
 
-    template <typename T>
-    constexpr explicit geometry_t(T geom, int srid = 4326)
+    constexpr explicit geometry_t(point_t &&geom, int srid = 4326)
+    : m_geom(std::move(geom)), m_srid(srid)
+    {}
+
+    constexpr explicit geometry_t(linestring_t &&geom, int srid = 4326)
+    : m_geom(std::move(geom)), m_srid(srid)
+    {}
+
+    constexpr explicit geometry_t(polygon_t &&geom, int srid = 4326)
+    : m_geom(std::move(geom)), m_srid(srid)
+    {}
+
+    constexpr explicit geometry_t(multipoint_t &&geom, int srid = 4326)
+    : m_geom(std::move(geom)), m_srid(srid)
+    {}
+
+    constexpr explicit geometry_t(multilinestring_t &&geom, int srid = 4326)
+    : m_geom(std::move(geom)), m_srid(srid)
+    {}
+
+    constexpr explicit geometry_t(multipolygon_t &&geom, int srid = 4326)
+    : m_geom(std::move(geom)), m_srid(srid)
+    {}
+
+    constexpr explicit geometry_t(collection_t &&geom, int srid = 4326)
     : m_geom(std::move(geom)), m_srid(srid)
     {}
 

--- a/src/geom.hpp
+++ b/src/geom.hpp
@@ -166,7 +166,7 @@ class multigeometry_t
 {
 public:
     using const_iterator = typename std::vector<GEOM>::const_iterator;
-    using iterator = typename std::vector<GEOM>::const_iterator;
+    using iterator = typename std::vector<GEOM>::iterator;
     using value_type = GEOM;
 
     [[nodiscard]] std::size_t num_geometries() const noexcept
@@ -194,6 +194,8 @@ public:
         return a.m_geometry != b.m_geometry;
     }
 
+    iterator begin() noexcept { return m_geometry.begin(); }
+    iterator end() noexcept { return m_geometry.end(); }
     const_iterator begin() const noexcept { return m_geometry.cbegin(); }
     const_iterator end() const noexcept { return m_geometry.cend(); }
     const_iterator cbegin() const noexcept { return m_geometry.cbegin(); }

--- a/tests/test-geom-linestrings.cpp
+++ b/tests/test-geom-linestrings.cpp
@@ -89,26 +89,27 @@ TEST_CASE("create_linestring from invalid OSM data", "[NoDB]")
 
 TEST_CASE("geom::segmentize w/o split", "[NoDB]")
 {
-    geom::linestring_t const line{{0, 0}, {1, 2}, {2, 2}};
+    geom::linestring_t const expected{{0, 0}, {1, 2}, {2, 2}};
+    geom::linestring_t line = expected;
 
-    auto const geom = geom::segmentize(geom::geometry_t{line}, 10.0);
+    auto const geom = geom::segmentize(geom::geometry_t{std::move(line)}, 10.0);
 
     REQUIRE(geom.is_multilinestring());
     REQUIRE(num_geometries(geom) == 1);
     auto const &ml = geom.get<geom::multilinestring_t>();
     REQUIRE(ml.num_geometries() == 1);
-    REQUIRE(ml[0] == line);
+    REQUIRE(ml[0] == expected);
 }
 
 TEST_CASE("geom::segmentize with split 0.5", "[NoDB]")
 {
-    geom::linestring_t const line{{0, 0}, {1, 0}};
+    geom::linestring_t line{{0, 0}, {1, 0}};
 
     std::array<geom::linestring_t, 2> const expected{
         geom::linestring_t{{0, 0}, {0.5, 0}},
         geom::linestring_t{{0.5, 0}, {1, 0}}};
 
-    auto const geom = geom::segmentize(geom::geometry_t{line}, 0.5);
+    auto const geom = geom::segmentize(geom::geometry_t{std::move(line)}, 0.5);
 
     REQUIRE(geom.is_multilinestring());
     auto const &ml = geom.get<geom::multilinestring_t>();
@@ -119,14 +120,14 @@ TEST_CASE("geom::segmentize with split 0.5", "[NoDB]")
 
 TEST_CASE("geom::segmentize with split 0.4", "[NoDB]")
 {
-    geom::linestring_t const line{{0, 0}, {1, 0}};
+    geom::linestring_t line{{0, 0}, {1, 0}};
 
     std::array<geom::linestring_t, 3> const expected{
         geom::linestring_t{{0, 0}, {0.4, 0}},
         geom::linestring_t{{0.4, 0}, {0.8, 0}},
         geom::linestring_t{{0.8, 0}, {1, 0}}};
 
-    auto const geom = geom::segmentize(geom::geometry_t{line}, 0.4);
+    auto const geom = geom::segmentize(geom::geometry_t{std::move(line)}, 0.4);
 
     REQUIRE(geom.is_multilinestring());
     auto const &ml = geom.get<geom::multilinestring_t>();
@@ -138,13 +139,13 @@ TEST_CASE("geom::segmentize with split 0.4", "[NoDB]")
 
 TEST_CASE("geom::segmentize with split 1.0 at start", "[NoDB]")
 {
-    geom::linestring_t const line{{0, 0}, {2, 0}, {3, 0}, {4, 0}};
+    geom::linestring_t line{{0, 0}, {2, 0}, {3, 0}, {4, 0}};
 
     std::array<geom::linestring_t, 4> const expected{
         geom::linestring_t{{0, 0}, {1, 0}}, geom::linestring_t{{1, 0}, {2, 0}},
         geom::linestring_t{{2, 0}, {3, 0}}, geom::linestring_t{{3, 0}, {4, 0}}};
 
-    auto const geom = geom::segmentize(geom::geometry_t{line}, 1.0);
+    auto const geom = geom::segmentize(geom::geometry_t{std::move(line)}, 1.0);
 
     REQUIRE(geom.is_multilinestring());
     auto const &ml = geom.get<geom::multilinestring_t>();
@@ -157,13 +158,13 @@ TEST_CASE("geom::segmentize with split 1.0 at start", "[NoDB]")
 
 TEST_CASE("geom::segmentize with split 1.0 in middle", "[NoDB]")
 {
-    geom::linestring_t const line{{0, 0}, {1, 0}, {3, 0}, {4, 0}};
+    geom::linestring_t line{{0, 0}, {1, 0}, {3, 0}, {4, 0}};
 
     std::array<geom::linestring_t, 4> const expected{
         geom::linestring_t{{0, 0}, {1, 0}}, geom::linestring_t{{1, 0}, {2, 0}},
         geom::linestring_t{{2, 0}, {3, 0}}, geom::linestring_t{{3, 0}, {4, 0}}};
 
-    auto const geom = geom::segmentize(geom::geometry_t{line}, 1.0);
+    auto const geom = geom::segmentize(geom::geometry_t{std::move(line)}, 1.0);
 
     REQUIRE(geom.is_multilinestring());
     auto const &ml = geom.get<geom::multilinestring_t>();
@@ -176,13 +177,13 @@ TEST_CASE("geom::segmentize with split 1.0 in middle", "[NoDB]")
 
 TEST_CASE("geom::segmentize with split 1.0 at end", "[NoDB]")
 {
-    geom::linestring_t const line{{0, 0}, {1, 0}, {2, 0}, {4, 0}};
+    geom::linestring_t line{{0, 0}, {1, 0}, {2, 0}, {4, 0}};
 
     std::array<geom::linestring_t, 4> const expected{
         geom::linestring_t{{0, 0}, {1, 0}}, geom::linestring_t{{1, 0}, {2, 0}},
         geom::linestring_t{{2, 0}, {3, 0}}, geom::linestring_t{{3, 0}, {4, 0}}};
 
-    auto const geom = geom::segmentize(geom::geometry_t{line}, 1.0);
+    auto const geom = geom::segmentize(geom::geometry_t{std::move(line)}, 1.0);
 
     REQUIRE(geom.is_multilinestring());
     auto const &ml = geom.get<geom::multilinestring_t>();

--- a/tests/test-geom-multipoints.cpp
+++ b/tests/test-geom-multipoints.cpp
@@ -19,7 +19,8 @@
 
 TEST_CASE("multipoint_t with a single point", "[NoDB]")
 {
-    geom::point_t const point{1, 1};
+    geom::point_t const expected{1, 1};
+    geom::point_t point = expected;
 
     geom::geometry_t geom{geom::multipoint_t{}};
     auto &mp = geom.get<geom::multipoint_t>();
@@ -29,9 +30,9 @@ TEST_CASE("multipoint_t with a single point", "[NoDB]")
     REQUIRE(geometry_type(geom) == "MULTIPOINT");
     REQUIRE(num_geometries(geom) == 1);
     REQUIRE(area(geom) == Approx(0.0));
-    REQUIRE(centroid(geom) == geom::geometry_t{point});
+    REQUIRE(centroid(geom) == geom::geometry_t{std::move(point)});
 
-    REQUIRE(mp[0] == point);
+    REQUIRE(mp[0] == expected);
 }
 
 TEST_CASE("multipoint_t with several points", "[NoDB]")
@@ -50,7 +51,7 @@ TEST_CASE("multipoint_t with several points", "[NoDB]")
     REQUIRE(geometry_type(geom) == "MULTIPOINT");
     REQUIRE(num_geometries(geom) == 3);
     REQUIRE(area(geom) == Approx(0.0));
-    REQUIRE(centroid(geom) == geom::geometry_t{p1});
+    REQUIRE(centroid(geom) == geom::geometry_t{geom::point_t{2, 1}});
 
     REQUIRE(mp[0] == p0);
     REQUIRE(mp[1] == p1);


### PR DESCRIPTION
* Use extra functions for each type to be moved into `geometry_t` to avoid a template matching in the wrong places.
* It turns out we actually need a modifiable iterator so that we can move members out of the collection.
