### PR TITLE
Refactor split_multi() so it doesn't copy

### DIFF
--- a/src/geom-functions.cpp
+++ b/src/geom-functions.cpp
@@ -322,7 +322,7 @@ namespace {
 class split_visitor
 {
 public:
-    split_visitor(std::vector<geometry_t> *output, uint32_t srid) noexcept
+    split_visitor(std::vector<geometry_t> *output, int srid) noexcept
     : m_output(output), m_srid(srid)
     {}
 
@@ -330,35 +330,35 @@ public:
     void operator()(T) const
     {}
 
-    void operator()(geom::collection_t const &geom) const
+    void operator()(geom::collection_t &&geom) const
     {
-        for (auto sgeom : geom) {
+        for (auto &&sgeom : geom) {
             m_output->push_back(std::move(sgeom));
         }
     }
 
     template <typename T>
-    void operator()(geom::multigeometry_t<T> const &geom) const
+    void operator()(geom::multigeometry_t<T> &&geom) const
     {
-        for (auto sgeom : geom) {
+        for (auto &&sgeom : geom) {
             m_output->emplace_back(std::move(sgeom), m_srid);
         }
     }
 
 private:
     std::vector<geometry_t> *m_output;
-    uint32_t m_srid;
+    int m_srid;
 
 }; // class split_visitor
 
 } // anonymous namespace
 
-std::vector<geometry_t> split_multi(geometry_t geom, bool split_multi)
+std::vector<geometry_t> split_multi(geometry_t&& geom, bool split_multi)
 {
     std::vector<geometry_t> output;
 
     if (split_multi && geom.is_multi()) {
-        geom.visit(split_visitor{&output, static_cast<uint32_t>(geom.srid())});
+        visit(split_visitor{&output, geom.srid()}, std::move(geom));
     } else if (!geom.is_null()) {
         output.push_back(std::move(geom));
     }

--- a/src/geom-functions.hpp
+++ b/src/geom-functions.hpp
@@ -114,11 +114,11 @@ double area(geometry_t const &geom);
  * alone and will end up as the only geometry in the result vector. If the
  * input geometry is a nullgeom_t, the result vector will be empty.
  *
- * \param geom Input geometry.
+ * \param geom Input geometry (will be moved from).
  * \param split_multi Only split of this is set to true.
  * \returns Vector of result geometries.
  */
-std::vector<geometry_t> split_multi(geometry_t geom, bool split_multi = true);
+std::vector<geometry_t> split_multi(geometry_t &&geom, bool split_multi = true);
 
 /**
  * Merge lines in a multilinestring end-to-end as far as possible. Always

--- a/src/geom.hpp
+++ b/src/geom.hpp
@@ -333,6 +333,15 @@ public:
         return std::visit(std::forward<V>(visitor), m_geom);
     }
 
+    // This is non-member function visit(), different than the member
+    // function above, because we need to move the geometry into the function
+    // which we can't do for a member function.
+    template <typename V>
+    friend auto visit(V &&visitor, geometry_t &&geom)
+    {
+        return std::visit(std::forward<V>(visitor), std::move(geom.m_geom));
+    }
+
     [[nodiscard]] friend bool operator==(geometry_t const &a,
                                          geometry_t const &b) noexcept
     {

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1356,7 +1356,7 @@ void output_flex_t::add_row(table_connection_t *table_connection,
     // The geometry returned by run_transform() is in 4326 if it is a
     // (multi)polygon. If it is a point or linestring, it is already in the
     // target geometry.
-    auto const geom = run_transform(proj, transform, object);
+    auto geom = run_transform(proj, transform, object);
 
     // We need to split a multi geometry into its parts if the geometry
     // column can only take non-multi geometries or if the transform
@@ -1366,7 +1366,7 @@ void output_flex_t::add_row(table_connection_t *table_connection,
                              type == table_column_type::polygon ||
                              transform->split();
 
-    auto const geoms = geom::split_multi(geom, split_multi);
+    auto const geoms = geom::split_multi(std::move(geom), split_multi);
     for (auto const &sgeom : geoms) {
         m_expire.from_geometry(sgeom, id);
         write_row(table_connection, object.type(), id, sgeom,

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -268,7 +268,7 @@ void output_pgsql_t::pgsql_process_relation(osmium::Relation const &rel)
         if (!projected_geom.is_null() && split_at > 0.0) {
             projected_geom = geom::segmentize(projected_geom, split_at);
         }
-        auto const geoms = geom::split_multi(projected_geom);
+        auto const geoms = geom::split_multi(std::move(projected_geom));
         for (auto const &sgeom : geoms) {
             m_expire.from_geometry(sgeom, -rel.id());
             auto const wkb = geom_to_ewkb(sgeom);


### PR DESCRIPTION
Also removes an unneccessary cast from int to uint32_t and back.