### PR TITLE
Add geometry functions in Lua / new insert syntax

### DIFF
--- a/flex-config/new-insert-syntax.lua
+++ b/flex-config/new-insert-syntax.lua
@@ -1,0 +1,214 @@
+-- This config example file is released into the Public Domain.
+
+-- This is Lua config showing the handling of custom geometries.
+--
+-- This is "work in progress", changes are possible.
+--
+-- Note that the insert() function is used instead of the old add_row()!
+
+-- The following magic can be used to wrap the internal "insert" function
+local orig_insert = osm2pgsql.Table.insert
+local function my_insert(table, data)
+    local json = require 'json'
+    inserted, message, column, object = orig_insert(table, data)
+    if not inserted then
+        for key, value in pairs(data) do
+            if type(value) == 'userdata' then
+                data[key] = tostring(value)
+            end
+        end
+        print("insert() failed: " .. message .. " column='" .. column .. "' object='" .. json.encode(object) .. "' data='" .. json.encode(data) .. "'")
+    end
+end
+osm2pgsql.Table.insert = my_insert
+
+
+local tables = {}
+
+-- This table will get all nodes and areas with an "addr:street" tag, for
+-- areas we'll calculate the centroid.
+tables.addr = osm2pgsql.define_table({
+    name = 'addr',
+    ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+    columns = {
+        { column = 'tags', type = 'jsonb' },
+        { column = 'geom', type = 'point', projection = 4326 },
+    }
+})
+
+tables.ways = osm2pgsql.define_way_table('ways', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'geom', type = 'linestring', projection = 4326 },
+    { column = 'poly', type = 'polygon', projection = 4326 },
+    { column = 'geom3857', type = 'linestring', projection = 3857 },
+    { column = 'geomautoproj', type = 'linestring', projection = 3857 },
+})
+
+tables.major_roads = osm2pgsql.define_way_table('major_roads', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'geom', type = 'linestring' },
+    { column = 'sgeom', type = 'linestring' }
+})
+
+tables.polygons = osm2pgsql.define_area_table('polygons', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'geom', type = 'geometry', not_null = true },
+    { column = 'area4326', type = 'real' },
+    { column = 'area3857', type = 'real' }
+})
+
+tables.routes = osm2pgsql.define_relation_table('routes', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'geom', type = 'multilinestring', projection = 4326 },
+})
+
+tables.route_parts = osm2pgsql.define_relation_table('route_parts', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'geom', type = 'linestring', projection = 4326 },
+})
+
+-- Helper function to remove some of the tags we usually are not interested in.
+-- Returns true if there are no tags left.
+function clean_tags(tags)
+    tags.odbl = nil
+    tags.created_by = nil
+    tags.source = nil
+    tags['source:ref'] = nil
+
+    return next(tags) == nil
+end
+
+-- Helper function that looks at the tags and decides if this is possibly
+-- an area.
+function has_area_tags(tags)
+    if tags.area == 'yes' then
+        return true
+    end
+    if tags.area == 'no' then
+        return false
+    end
+
+    return tags.aeroway
+        or tags.amenity
+        or tags.building
+        or tags.harbour
+        or tags.historic
+        or tags.landuse
+        or tags.leisure
+        or tags.man_made
+        or tags.military
+        or tags.natural
+        or tags.office
+        or tags.place
+        or tags.power
+        or tags.public_transport
+        or tags.shop
+        or tags.sport
+        or tags.tourism
+        or tags.water
+        or tags.waterway
+        or tags.wetland
+        or tags['abandoned:aeroway']
+        or tags['abandoned:amenity']
+        or tags['abandoned:building']
+        or tags['abandoned:landuse']
+        or tags['abandoned:power']
+        or tags['area:highway']
+end
+
+function osm2pgsql.process_node(object)
+    if clean_tags(object.tags) then
+        return
+    end
+
+    if object.tags['addr:street'] then
+        tables.addr:insert({
+           tags = object.tags,
+           geom = object:as_point()
+        })
+    end
+end
+
+function osm2pgsql.process_way(object)
+    if clean_tags(object.tags) then
+        return
+    end
+
+    if object.is_closed and object.tags['addr:street'] then
+        tables.addr:insert({
+            tags = object.tags,
+            geom = object:as_polygon():centroid()
+        })
+    end
+
+    if object.tags.highway == 'motorway' or
+       object.tags.highway == 'trunk' or
+       object.tags.highway == 'primary' then
+        tables.major_roads:insert({
+            tags = object.tags,
+            geom = object:as_linestring(),
+            sgeom = object:as_linestring():simplify(100),
+        })
+    end
+
+    -- A closed way that also has the right tags for an area is a polygon.
+    if object.is_closed and has_area_tags(object.tags) then
+        local g = object:as_polygon()
+        local a = g:area()
+        if a < 0.0000001 then
+            tables.polygons:insert({
+                tags = object.tags,
+                geom = g,
+                area4326 = a,
+                area3857 = g:transform(3857):area()
+            })
+        end
+    else
+        tables.ways:insert({
+            tags = object.tags,
+            geom = object:as_linestring(),
+            poly = object:as_polygon(),
+            geom3857 = object:as_linestring():transform(3857), -- project geometry into target srid 3857
+            geomautoproj = object:as_linestring() -- automatically projected into projection of target column
+        })
+    end
+end
+
+function osm2pgsql.process_relation(object)
+    if clean_tags(object.tags) then
+        return
+    end
+
+    local relation_type = object:grab_tag('type')
+
+    if relation_type == 'multipolygon' then
+        local g = object:as_multipolygon()
+        local a = g:area()
+        if a < 0.0000001 then
+            tables.polygons:insert({
+                tags = object.tags,
+                geom = g,
+                area4326 = a,
+                area3857 = g:transform(3857):area()
+            })
+        end
+        return
+    end
+
+    if relation_type == 'route' then
+        local route_geom = object:as_multilinestring()
+        if not route_geom:is_null() then
+            tables.routes:insert({
+                tags = object.tags,
+                geom = route_geom
+            })
+            for line in route_geom:geometries() do
+                tables.route_parts:insert({
+                    tags = object.tags,
+                    geom = line
+                })
+            end
+        end
+    end
+end
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,7 @@ if (WITH_LUA)
     target_sources(osm2pgsql_lib PRIVATE
         flex-table.cpp
         flex-table-column.cpp
+        flex-lua-geom.cpp
         geom-transform.cpp
         lua-utils.cpp
         output-flex.cpp

--- a/src/flex-lua-geom.cpp
+++ b/src/flex-lua-geom.cpp
@@ -1,0 +1,225 @@
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2022 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+#include "flex-lua-geom.hpp"
+#include "geom-functions.hpp"
+#include "lua-utils.hpp"
+
+extern "C"
+{
+#include <lauxlib.h>
+#include <lua.h>
+}
+
+static char const *const osm2pgsql_geometry_class = "osm2pgsql.Geometry";
+
+geom::geometry_t *create_lua_geometry_object(lua_State *lua_state)
+{
+    void *ptr = lua_newuserdata(lua_state, sizeof(geom::geometry_t));
+    new (ptr) geom::geometry_t{};
+
+    // Set the metatable of this object
+    luaL_getmetatable(lua_state, osm2pgsql_geometry_class);
+    lua_setmetatable(lua_state, -2);
+
+    return static_cast<geom::geometry_t *>(ptr);
+}
+
+geom::geometry_t *unpack_geometry(lua_State *lua_state, int n) noexcept
+{
+    void *user_data = luaL_checkudata(lua_state, n, osm2pgsql_geometry_class);
+    luaL_argcheck(lua_state, user_data != nullptr, n, "'Geometry' expected");
+    return static_cast<geom::geometry_t *>(user_data);
+}
+
+/**
+ * This function is called by Lua garbage collection when a geometry object
+ * needs cleaning up. It calls the destructor of the C++ object. After that
+ * Lua will release the memory.
+ */
+int geom_gc(lua_State *lua_state) noexcept
+{
+    void *geom = lua_touserdata(lua_state, 1);
+    if (geom) {
+        static_cast<geom::geometry_t *>(geom)->~geometry_t();
+    }
+
+    return 0;
+}
+
+// The following functions are called when their counterparts in Lua are
+// called on geometry objects.
+
+static int geom_area(lua_State *lua_state)
+{
+    auto const *const input_geometry = unpack_geometry(lua_state);
+
+    try {
+        lua_pushnumber(lua_state, geom::area(*input_geometry));
+    } catch (...) {
+        return luaL_error(lua_state, "Unknown error in 'area()'.\n");
+    }
+
+    return 1;
+}
+
+static int geom_centroid(lua_State *lua_state)
+{
+    auto const *const input_geometry = unpack_geometry(lua_state);
+
+    try {
+        auto *geom = create_lua_geometry_object(lua_state);
+        *geom = geom::centroid(*input_geometry);
+    } catch (...) {
+        return luaL_error(lua_state, "Unknown error in 'centroid()'.\n");
+    }
+
+    return 1;
+}
+
+static int geom_geometry_n(lua_State *lua_state)
+{
+    auto const *const input_geometry = unpack_geometry(lua_state);
+    int const index = luaL_checkinteger(lua_state, 2);
+
+    try {
+        auto *geom = create_lua_geometry_object(lua_state);
+        geom::geometry_n(geom, *input_geometry, index);
+    } catch (...) {
+        return luaL_error(lua_state, "Unknown error in 'geometry_n()'.\n");
+    }
+
+    return 1;
+}
+
+static int geom_geometry_type(lua_State *lua_state)
+{
+    auto const *const input_geometry = unpack_geometry(lua_state);
+
+    try {
+        auto const type = geometry_type(*input_geometry);
+        lua_pushlstring(lua_state, type.data(), type.size());
+    } catch (...) {
+        return luaL_error(lua_state, "Unknown error in 'geometry_type()'.\n");
+    }
+
+    return 1;
+}
+
+static int geom_is_null(lua_State *lua_state)
+{
+    auto const *const input_geometry = unpack_geometry(lua_state);
+    lua_pushboolean(lua_state, input_geometry->is_null());
+    return 1;
+}
+
+static int geom_num_geometries(lua_State *lua_state)
+{
+    auto const *const input_geometry = unpack_geometry(lua_state);
+    lua_pushinteger(lua_state,
+                    static_cast<lua_Integer>(num_geometries(*input_geometry)));
+    return 1;
+}
+
+static int geom_segmentize(lua_State *lua_state)
+{
+    auto const *const input_geometry = unpack_geometry(lua_state);
+    double const max_segment_length = luaL_checknumber(lua_state, 2);
+
+    try {
+        auto *geom = create_lua_geometry_object(lua_state);
+        geom::segmentize(geom, *input_geometry, max_segment_length);
+    } catch (...) {
+        return luaL_error(lua_state, "Unknown error in 'segmentize()'.\n");
+    }
+
+    return 1;
+}
+
+static int geom_simplify(lua_State *lua_state)
+{
+    auto const *const input_geometry = unpack_geometry(lua_state);
+    double const tolerance = luaL_checknumber(lua_state, 2);
+
+    try {
+        auto *geom = create_lua_geometry_object(lua_state);
+        geom::simplify(geom, *input_geometry, tolerance);
+    } catch (...) {
+        return luaL_error(lua_state, "Unknown error in 'simplify()'.\n");
+    }
+
+    return 1;
+}
+
+static int geom_srid(lua_State *lua_state)
+{
+    auto const *const input_geometry = unpack_geometry(lua_state);
+    lua_pushinteger(lua_state,
+                    static_cast<lua_Integer>(input_geometry->srid()));
+    return 1;
+}
+
+// XXX Implementation for Lua __tostring function on geometries. Currently
+// just returns the type as string. This could be improved, for instance by
+// showing a WKT representation of the geometry.
+static int geom_tostring(lua_State *lua_state)
+{
+    return geom_geometry_type(lua_state);
+}
+
+static int geom_transform(lua_State *lua_state)
+{
+    auto const *const input_geometry = unpack_geometry(lua_state);
+    int const srid = luaL_checkinteger(lua_state, 2);
+
+    try {
+        if (input_geometry->srid() != 4326) {
+            throw std::runtime_error{
+                "Can not transform already transformed geometry."};
+        }
+        auto const proj = reprojection::create_projection(srid);
+
+        auto *geom = create_lua_geometry_object(lua_state);
+        geom::transform(geom, *input_geometry, *proj);
+    } catch (...) {
+        return luaL_error(lua_state, "Unknown error in 'transform()'.\n");
+    }
+
+    return 1;
+}
+
+void init_geometry_class(lua_State *lua_state)
+{
+    lua_getglobal(lua_state, "osm2pgsql");
+    if (luaL_newmetatable(lua_state, osm2pgsql_geometry_class) != 1) {
+        throw std::runtime_error{"Internal error: Lua newmetatable failed."};
+    }
+    lua_pushvalue(lua_state, -1); // Copy of new metatable
+
+    // Add metatable as osm2pgsql.Geometry so we can access it from Lua
+    lua_setfield(lua_state, -3, "Geometry");
+
+    luaX_add_table_func(lua_state, "__gc", geom_gc);
+    luaX_add_table_func(lua_state, "__len", geom_num_geometries);
+    luaX_add_table_func(lua_state, "__tostring", geom_tostring);
+    lua_pushvalue(lua_state, -1);
+    lua_setfield(lua_state, -2, "__index");
+    luaX_add_table_func(lua_state, "area", geom_area);
+    luaX_add_table_func(lua_state, "centroid", geom_centroid);
+    luaX_add_table_func(lua_state, "geometry_n", geom_geometry_n);
+    luaX_add_table_func(lua_state, "geometry_type", geom_geometry_type);
+    luaX_add_table_func(lua_state, "is_null", geom_is_null);
+    luaX_add_table_func(lua_state, "num_geometries", geom_num_geometries);
+    luaX_add_table_func(lua_state, "segmentize", geom_segmentize);
+    luaX_add_table_func(lua_state, "simplify", geom_simplify);
+    luaX_add_table_func(lua_state, "srid", geom_srid);
+    luaX_add_table_func(lua_state, "transform", geom_transform);
+
+    lua_pop(lua_state, 2); // __index, global osmp2gsql
+}

--- a/src/flex-lua-geom.hpp
+++ b/src/flex-lua-geom.hpp
@@ -1,0 +1,42 @@
+#ifndef OSM2PGSQL_FLEX_LUA_GEOM_HPP
+#define OSM2PGSQL_FLEX_LUA_GEOM_HPP
+
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2022 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+/**
+ * \file
+ *
+ * Functions implementing the Lua interface for the geometry functions.
+ */
+
+#include "geom.hpp"
+
+struct lua_State;
+
+/**
+ * Create a null geometry object on the Lua stack and return a pointer to it.
+ */
+geom::geometry_t *create_lua_geometry_object(lua_State *lua_state);
+
+/**
+ * Get a geometry object from the Lua stack and return a pointer to it.
+ *
+ * \param lua_state The lua state.
+ * \param n The position in the stack, usually 1 for the first function
+ *          parameter.
+ */
+geom::geometry_t *unpack_geometry(lua_State *lua_state, int n = 1) noexcept;
+
+/**
+ * Define the osm2pgsql.Geometry class/metatable.
+ */
+void init_geometry_class(lua_State *lua_state);
+
+#endif // OSM2PGSQL_FLEX_LUA_GEOM_HPP

--- a/src/flex-table-column.cpp
+++ b/src/flex-table-column.cpp
@@ -23,7 +23,7 @@ struct column_type_lookup
     table_column_type type;
 };
 
-static std::array<column_type_lookup, 25> const column_types = {
+static std::array<column_type_lookup, 26> const column_types = {
     {{"text", table_column_type::text},
      {"boolean", table_column_type::boolean},
      {"bool", table_column_type::boolean},
@@ -46,6 +46,7 @@ static std::array<column_type_lookup, 25> const column_types = {
      {"multipoint", table_column_type::multipoint},
      {"multilinestring", table_column_type::multilinestring},
      {"multipolygon", table_column_type::multipolygon},
+     {"geometrycollection", table_column_type::geometrycollection},
      {"area", table_column_type::area},
      {"id_type", table_column_type::id_type},
      {"id_num", table_column_type::id_num}}};
@@ -156,6 +157,8 @@ std::string flex_table_column_t::sql_type_name() const
         return "Geometry(MULTILINESTRING, {})"_format(m_srid);
     case table_column_type::multipolygon:
         return "Geometry(MULTIPOLYGON, {})"_format(m_srid);
+    case table_column_type::geometrycollection:
+        return "Geometry(GEOMETRYCOLLECTION, {})"_format(m_srid);
     case table_column_type::area:
         return "real";
     case table_column_type::id_type:

--- a/src/flex-table-column.hpp
+++ b/src/flex-table-column.hpp
@@ -39,6 +39,7 @@ enum class table_column_type : uint8_t
     multipoint,
     multilinestring,
     multipolygon,
+    geometrycollection,
 
     area,
 
@@ -81,7 +82,7 @@ public:
     bool is_geometry_column() const noexcept
     {
         return (m_type >= table_column_type::geometry) &&
-               (m_type <= table_column_type::multipolygon);
+               (m_type <= table_column_type::geometrycollection);
     }
 
     /**

--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -77,6 +77,9 @@ flex_table_column_t &flex_table_t::add_column(std::string const &name,
     auto &column = m_columns.back();
 
     if (column.is_geometry_column()) {
+        if (m_geom_column != std::numeric_limits<std::size_t>::max()) {
+            m_has_multiple_geom_columns = true;
+        }
         m_geom_column = m_columns.size() - 1;
         column.set_not_null();
     }

--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -191,6 +191,11 @@ public:
     std::string full_name() const;
     std::string full_tmp_name() const;
 
+    bool has_multiple_geom_columns() const noexcept
+    {
+        return m_has_multiple_geom_columns;
+    }
+
 private:
     /// The name of the table
     std::string m_name;
@@ -224,6 +229,9 @@ private:
 
     /// Cluster the table by geometry.
     bool m_cluster_by_geom = true;
+
+    /// Does this table have more than one geometry column?
+    bool m_has_multiple_geom_columns = false;
 
 }; // class flex_table_t
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -193,3 +193,13 @@ object_metatable = {
 
 setmetatable(object_metatable.__index, inner_metatable)
 
+-- This is used to iterate over (multi)geometries.
+function osm2pgsql.Geometry.geometries(geom)
+    local i = 0
+    local max = #geom
+    return function()
+        i = i + 1
+        if i <= max then return geom:geometry_n(i) end
+    end
+end
+

--- a/src/middle-ram.cpp
+++ b/src/middle-ram.cpp
@@ -264,6 +264,13 @@ middle_ram_t::rel_members_get(osmium::Relation const &rel,
                     buffer->commit();
                     ++count;
                 }
+            } else {
+                {
+                    osmium::builder::NodeBuilder builder{*buffer};
+                    builder.set_id(member.ref());
+                }
+                buffer->commit();
+                ++count;
             }
             break;
         case osmium::item_type::way:

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -153,12 +153,20 @@ public:
 
     void merge_expire_trees(output_t *other) override;
 
+    int app_as_point();
+    int app_as_linestring();
+    int app_as_polygon();
+    int app_as_multilinestring();
+    int app_as_multipolygon();
+    int app_as_geometrycollection();
+
     int app_define_table();
-    int app_mark_way();
     int app_get_bbox();
+    int app_mark_way();
 
     int table_tostring();
     int table_add_row();
+    int table_insert();
     int table_name();
     int table_schema();
     int table_cluster();
@@ -192,9 +200,13 @@ private:
 
     void write_column(db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
                       flex_table_column_t const &column);
+
     void write_row(table_connection_t *table_connection,
                    osmium::item_type id_type, osmid_t id,
                    geom::geometry_t const &geom, int srid);
+
+    osmium::OSMObject const &
+    check_and_get_context_object(flex_table_t const &table);
 
     geom::geometry_t run_transform(reprojection const &proj,
                                    geom_transform_t const *transform,

--- a/tests/bdd/flex/geometry-collection.feature
+++ b/tests/bdd/flex/geometry-collection.feature
@@ -1,0 +1,69 @@
+Feature: Create geometry collections from relations
+
+    Background:
+        Given the lua style
+            """
+            local dtable = osm2pgsql.define_table{
+                name = 'osm2pgsql_test_collection',
+                ids = { type = 'relation', id_column = 'osm_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'geom', type = 'geometrycollection', projection = 4326 }
+                }
+            }
+
+            function osm2pgsql.process_relation(object)
+                dtable:insert({
+                    name = object.tags.name,
+                    geom = object.as_geometrycollection()
+                })
+            end
+            """
+
+    Scenario: Create geometry collection from different relations
+        Given the 1.0 grid
+            | 13 | 12 | 17 |    | 16 |
+            | 10 | 11 |    | 14 | 15 |
+        And the OSM data
+            """
+            w20 Nn10,n11,n12,n13,n10
+            w21 Nn14,n15,n16
+            r30 Tname=single Mw20@
+            r31 Tname=multi Mw20@,w21@
+            r32 Tname=mixed Mn17@,w21@
+            r33 Tname=node Mn17@
+            """
+        When running osm2pgsql flex
+
+        Then table osm2pgsql_test_collection contains exactly
+            | osm_id | name   | ST_GeometryType(geom) | ST_NumGeometries(geom) | ST_GeometryType(ST_GeometryN(geom, 1)) |
+            | 30     | single | ST_GeometryCollection | 1                      | ST_LineString                          |
+            | 31     | multi  | ST_GeometryCollection | 2                      | ST_LineString                          |
+            | 32     | mixed  | ST_GeometryCollection | 2                      | ST_Point                               |
+            | 33     | node   | ST_GeometryCollection | 1                      | ST_Point                               |
+
+        And table osm2pgsql_test_collection contains exactly
+            | osm_id | ST_AsText(ST_GeometryN(geom, 1)) | ST_AsText(ST_GeometryN(geom, 2)) |
+            | 30     | 10, 11, 12, 13, 10               | NULL                             |
+            | 31     | 10, 11, 12, 13, 10               | 14, 15, 16                       |
+            | 32     | 17                               | 14, 15, 16                       |
+            | 33     | 17                               | NULL                             |
+
+    Scenario: NULL entry generated for broken geometries
+        Given the grid
+            | 10 |
+        And the OSM data
+            """
+            w20 Nn10
+            r30 Tname=foo Mn11@
+            r31 Tname=bar Mw20@
+            r32 Tname=baz Mw21@
+            """
+        When running osm2pgsql flex
+
+        Then table osm2pgsql_test_collection contains exactly
+            | osm_id | name   | ST_GeometryType(geom) |
+            | 30     | foo    | NULL                  |
+            | 31     | bar    | NULL                  |
+            | 32     | baz    | NULL                  |
+

--- a/tests/bdd/flex/geometry-function-area.feature
+++ b/tests/bdd/flex/geometry-function-area.feature
@@ -1,0 +1,67 @@
+Feature: Tests for area() function
+
+    Scenario Outline:
+        Given the 0.1 grid with origin 9.0 50.3
+            |    |    |  7 |    |    |  8 |
+            |    |    |    | 11 | 12 |    |
+            |  3 |  4 |    |  9 | 10 |    |
+            |  1 |  2 |  5 |    |    |  6 |
+        And the OSM data
+            """
+            w1 Tnatural=water,name=poly Nn1,n2,n4,n3,n1
+            w2 Nn5,n6,n8,n7,n5
+            w3 Nn9,n10,n12,n11,n9
+            r1 Tnatural=water,name=multi Mw2@,w3@
+            """
+        And the lua style
+            """
+            local polygons = osm2pgsql.define_table{
+                name = 'osm2pgsql_test_polygon',
+                ids = { type = 'area', id_column = 'osm_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'geom', type = 'geometry', projection = <geom proj> },
+                    { column = 'area', type = 'real' },
+                }
+            }
+
+            function osm2pgsql.process_way(object)
+                local polygon = object:as_polygon()
+                polygons:insert({
+                    name = object.tags.name,
+                    geom = polygon,
+                    area = polygon:transform(<area proj>):area()
+                })
+            end
+
+            function osm2pgsql.process_relation(object)
+                local polygon = object:as_multipolygon()
+                polygons:insert({
+                    name = object.tags.name,
+                    geom = polygon,
+                    area = polygon:transform(<area proj>):area()
+                })
+            end
+            """
+        When running osm2pgsql flex
+        Then table osm2pgsql_test_polygon contains
+            | name  | ST_Area(geom)  | area         | ST_Area(ST_Transform(geom, 4326)) |
+            | poly  | <st_area poly> | <area poly>  | 0.01 |
+            | multi | <st_area multi>| <area multi> | 0.08 |
+
+        Examples:
+            | geom proj | area proj | st_area poly | area poly    | st_area multi | area multi    |
+            | 4326      | 4326      | 0.01         | 0.01         | 0.08          | 0.08          |
+            | 4326      | 3857      | 0.01         | 192987010.0  | 0.08          | 1547130000.0  |
+            | 3857      | 4326      | 192987010.0  | 0.01         | 1547130000.0  | 0.08          |
+            | 3857      | 3857      | 192987010.0  | 192987010.0  | 1547130000.0  | 1547130000.0  |
+
+        @config.have_proj
+        Examples: Generic projection
+            | geom proj | area proj | st_area poly | area poly    | st_area multi | area multi    |
+            | 4326      | 25832     | 0.01         | 79600737.537 | 0.08          | 635499542.954 |
+            | 3857      | 25832     | 192987010.0  | 79600737.537 | 1547130000.0  | 635499542.954 |
+            | 25832     | 4326      | 79600737.537 | 0.01         | 635499542.954 | 0.08          |
+            | 25832     | 3857      | 79600737.537 | 192987010.0  | 635499542.954 | 1547130000.0  |
+            | 25832     | 25832     | 79600737.537 | 79600737.537 | 635499542.954 | 635499542.954 |
+

--- a/tests/bdd/flex/geometry-iteration.feature
+++ b/tests/bdd/flex/geometry-iteration.feature
@@ -1,0 +1,56 @@
+Feature: Tests for iterating over a (multi)geometry
+
+    Scenario:
+        Given the grid
+            |  1 |  2 |    |
+            |  4 |    |  3 |
+            |    |  5 |  6 |
+        And the OSM data
+            """
+            w20 Thighway=motorway Nn1,n2,n3
+            w21 Thighway=motorway Nn4,n5,n6
+            r30 Ttype=route,route=road Mw20@,w21@
+            r31 Ttype=route,route=road Mw20@
+            r32 Ttype=something Mw20@
+            r33 Ttype=route,route=road Mn1@
+            """
+        And the lua style
+            """
+            local routes = osm2pgsql.define_relation_table('osm2pgsql_test_routes', {
+                { column = 'geom', type = 'linestring', projection = 4326 },
+                { column = 'num_all', type = 'int' },
+                { column = 'num_one', type = 'int' }
+            })
+
+            local firsts = osm2pgsql.define_relation_table('osm2pgsql_test_firsts', {
+                { column = 'geom', type = 'linestring', projection = 4326 },
+            })
+
+            function osm2pgsql.process_relation(object)
+                if object.tags.type == 'route' then
+                    local mgeom = object:as_multilinestring()
+                    for sgeom in mgeom:geometries() do
+                        routes:insert({
+                            geom = sgeom,
+                            num_all = #mgeom,
+                            num_one = #sgeom
+                        })
+                    end
+                    firsts:insert({
+                        geom = mgeom:geometry_n(1), -- first geometry only
+                    })
+                end
+            end
+            """
+        When running osm2pgsql flex
+        Then table osm2pgsql_test_routes contains exactly
+            | relation_id | ST_AsText(geom) | num_all | num_one |
+            | 30          | 1, 2, 3         | 2       | 1       |
+            | 30          | 4, 5, 6         | 2       | 1       |
+            | 31          | 1, 2, 3         | 1       | 1       |
+        And table osm2pgsql_test_firsts contains exactly
+            | relation_id | ST_AsText(geom) |
+            | 30          | 1, 2, 3         |
+            | 31          | 1, 2, 3         |
+            | 33          | NULL            |
+

--- a/tests/bdd/flex/geometry-null.feature
+++ b/tests/bdd/flex/geometry-null.feature
@@ -1,0 +1,89 @@
+Feature: Null geometry handling
+
+    Scenario: Invalid geometries show up as NULL
+        Given the lua style
+            """
+            local tables = {}
+
+            tables.null = osm2pgsql.define_table{
+                name = 'osm2pgsql_test_null',
+                ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'geom', type = 'geometry', projection = 4326 },
+                    { column = 'num', type = 'int' }
+                }
+            }
+
+            tables.not_null = osm2pgsql.define_table{
+                name = 'osm2pgsql_test_not_null',
+                ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'geom', type = 'geometry', projection = 4326, not_null = true },
+                    { column = 'num', type = 'int' }
+                }
+            }
+
+            function osm2pgsql.process_node(object)
+                local g = object.as_point()
+                tables.null:insert({
+                    name = object.tags.name,
+                    geom = g,
+                    num = g:num_geometries()
+                })
+                if g then
+                    tables.not_null:insert({
+                        name = object.tags.name,
+                        geom = g,
+                        num = g:num_geometries()
+                    })
+                end
+            end
+
+            function osm2pgsql.process_way(object)
+                local g = object.as_linestring()
+                tables.null:insert({
+                    name = object.tags.name,
+                    geom = g,
+                    num = #g
+                })
+                if not g:is_null() then
+                    tables.not_null:insert({
+                        name = object.tags.name,
+                        geom = g,
+                        num = #g
+                    })
+                end
+            end
+            """
+
+        And the grid
+            | 10 |   | 11 |
+
+        And the OSM data
+            """
+            n12 x3.4 y5.6 Tname=valid
+            n13 x42 y42
+            n14 x42 y42
+            w20 Tname=valid Nn10,n11
+            w21 Tname=invalid Nn10
+            w22 Tname=invalid Nn13,n13
+            w23 Tname=invalid Nn13,n14
+            """
+
+        When running osm2pgsql flex
+
+        Then table osm2pgsql_test_null contains exactly
+            | osm_type | osm_id | ST_AsText(geom) | num |
+            | N        | 12     | 3.4 5.6         | 1   |
+            | W        | 20     | 10, 11          | 1   |
+            | W        | 21     | NULL            | 0   |
+            | W        | 22     | NULL            | 0   |
+            | W        | 23     | NULL            | 0   |
+
+        And table osm2pgsql_test_not_null contains exactly
+            | osm_type | osm_id | ST_AsText(geom) | num |
+            | N        | 12     | 3.4 5.6         | 1   |
+            | W        | 20     | 10, 11          | 1   |
+

--- a/tests/bdd/flex/geometry-processing.feature
+++ b/tests/bdd/flex/geometry-processing.feature
@@ -1,0 +1,140 @@
+Feature: Tests for Lua geometry processing functions
+
+    Scenario:
+        Given the OSM data
+            """
+            n1 Tamenity=restaurant,name=point x1.1 y1.2
+            """
+        And the lua style
+            """
+            local points = osm2pgsql.define_node_table('osm2pgsql_test_points', {
+                { column = 'name', type = 'text' },
+                { column = 'geom4326', type = 'point', projection = 4326 },
+                { column = 'geom3857', type = 'point', projection = 3857 },
+                { column = 'geomauto', type = 'point', projection = 3857 },
+            })
+
+            function osm2pgsql.process_node(object)
+                points:insert({
+                    name = object.tags.name,
+                    geom4326 = object:as_point(),
+                    geom3857 = object:as_point():transform(3857),
+                    geomauto = object:as_point()
+                })
+            end
+
+            """
+        When running osm2pgsql flex
+        Then table osm2pgsql_test_points contains
+            | node_id | name  | ST_AsText(geom4326) | geom3857 = geomauto |
+            | 1       | point | 1.1 1.2             | True                |
+
+    Scenario:
+        Given the 0.1 grid with origin 9.0 50.3
+            |    |    |  7 |    |    |  8 |
+            |    |    |    | 11 | 12 |    |
+            |  3 |  4 |    |  9 | 10 |    |
+            |  1 |  2 |  5 |    |    |  6 |
+        And the OSM data
+            """
+            w1 Tnatural=water,name=poly Nn1,n2,n4,n3,n1
+            w2 Nn5,n6,n8,n7,n5
+            w3 Nn9,n10,n12,n11,n9
+            r1 Tnatural=water,name=multi Mw2@,w3@
+            """
+        And the lua style
+            """
+            local tables = {}
+
+            tables.ways = osm2pgsql.define_way_table('osm2pgsql_test_ways', {
+                { column = 'name', type = 'text' },
+                { column = 'geom', type = 'linestring', projection = 4326 },
+                { column = 'geomsimple', type = 'linestring', projection = 4326 },
+            })
+
+            tables.polygons = osm2pgsql.define_area_table('osm2pgsql_test_polygons', {
+                { column = 'name', type = 'text' },
+                { column = 'geom', type = 'geometry', projection = 4326 },
+                { column = 'center', type = 'point', projection = 4326 },
+                { column = 'type', type = 'text' }
+            })
+
+            function is_empty(some_table)
+                return next(some_table) == nil
+            end
+
+            function osm2pgsql.process_way(object)
+                if is_empty(object.tags) then
+                    return
+                end
+
+                tables.ways:insert({
+                    name = object.tags.name,
+                    geom = object:as_linestring(),
+                    geomsimple = object:as_linestring():simplify(0.1)
+                })
+
+                local g = object:as_polygon()
+                tables.polygons:insert({
+                    name = object.tags.name,
+                    geom = g,
+                    center = g:centroid(),
+                    type = g:geometry_type()
+                })
+            end
+
+            function osm2pgsql.process_relation(object)
+                local g = object:as_multipolygon()
+                tables.polygons:insert({
+                    name = object.tags.name,
+                    geom = g,
+                    type = g:geometry_type()
+                })
+            end
+            """
+        When running osm2pgsql flex
+        Then table osm2pgsql_test_ways contains
+            | way_id | name  | ST_AsText(geom) | ST_AsText(geomsimple) |
+            | 1      | poly  | 1, 2, 4, 3, 1   | 1, 4, 1               |
+        And table osm2pgsql_test_polygons contains
+            | area_id | name  | ST_AsText(geom)                    | ST_AsText(center) | type    |
+            | 1       | poly  | (1, 2, 4, 3, 1)                    | 9.05 50.05        | POLYGON |
+            | -1      | multi | (5, 6, 8, 7, 5),(9, 11, 12, 10, 9) | NULL              | POLYGON |
+
+    Scenario:
+        Given the grid
+            | 1 | 2  |   |   |   |
+            |   | 3  |   |   | 4 |
+            |   |    |   |   |   |
+        And the OSM data
+            """
+            w1 Thighway=primary Nn1,n2,n3,n4
+            """
+        And the lua style
+            """
+            local roads = osm2pgsql.define_way_table('osm2pgsql_test_roads', {
+                { column = 'n', type = 'int' },
+                { column = 'geom', type = 'linestring', projection = 4326 },
+            })
+
+            function osm2pgsql.process_way(object)
+                local g = object:as_linestring():segmentize(0.1)
+                local n = 1
+                for sgeom in g:geometries() do
+                    roads:insert({
+                        n = n,
+                        geom = sgeom
+                    })
+                    n = n + 1
+                end
+            end
+            """
+        When running osm2pgsql flex
+        Then table osm2pgsql_test_roads contains
+            | way_id | n | ST_AsText(geom)      |
+            | 1      | 1 | 1, 2                 |
+            | 1      | 2 | 2, 3                 |
+            | 1      | 3 | 3, 20.2 19.9         |
+            | 1      | 4 | 20.2 19.9, 20.3 19.9 |
+            | 1      | 5 | 20.3 19.9, 4         |
+

--- a/tests/bdd/flex/invalid-lua.feature
+++ b/tests/bdd/flex/invalid-lua.feature
@@ -1,0 +1,12 @@
+Feature: Tests for basic Lua functions
+
+    Scenario:
+        Given the OSM data
+            """
+            n1 Tamenity=restaurant x10 y10
+            """
+        And the lua style
+            """
+            this-is-not-valid-lua
+            """
+        Then running osm2pgsql flex fails

--- a/tests/lua/tests.lua
+++ b/tests/lua/tests.lua
@@ -1,6 +1,6 @@
 
 -- fake "osm2pgsql" table for test, usually created by the main C++ program
-osm2pgsql = {}
+osm2pgsql = { Geometry = {} }
 
 -- load the init.lua script that is normally run by the main C++ program
 package.path = '../src/?.lua'


### PR DESCRIPTION
This is the future of geometry processing in Lua. Geometries are not something happening magically behind the scenes as before, but they are (mostly) normal objects that can be manipulated in Lua. There are several functions to create those geometry objects from the OSM objects:

* as_point() (for nodes)
* as_linestring() (for ways)
* as_polygon() (for ways)
* as_multilinestring() (for relations)
* as_multipolygon() (for relations)
* as_geometrycollection() (for relations)

Geometries can be manipulated with the following functions (all based on their equivalents in PostGIS):

* area() (for polygons)
* centroid() (for polygons)
* geometries() for iterating over (multi)geometries
* geometry_n() return the nth geometry from a (multi)geometry.
* geometry_type() returns type as string ('POINT', 'LINESTRING', ...)
* is_null() returns true if this is a null geometry
* num_geometries() returns the number of geometries (0 for null geom, 1 for point/linestring/polygon, n for multi* and geometrycollection geoms) (also available through the Lua # operator)
* simplify(tolerance) (for linestrings)
* srid()
* transform(target_srid)

Some of these functions are using boost::geometry for their implementation. More functions can be implemented in the future as needed.

There is a new syntax for inserting rows into a table. Instead of "add_row" the "insert" function is used. "add_row" is still available
and it works as before. But the new geometry types only work with the "insert" command. The "insert" function also allows multiple geometry columns which wasn't possible with "add_row".

See the file flex-config/new-insert-syntax.lua for an example that shows how to use the new capabilities.