### PR TITLE
gazetteer: parse full admin_level string only

### DIFF
--- a/src/gazetteer-style.cpp
+++ b/src/gazetteer-style.cpp
@@ -308,8 +308,13 @@ void gazetteer_style_t::process_tags(osmium::OSMObject const &o)
         char const *const v = item.value();
 
         if (std::strcmp(k, "admin_level") == 0) {
-            m_admin_level = std::atoi(v);
-            if (m_admin_level <= 0 || m_admin_level > MAX_ADMINLEVEL) {
+            char *endp = nullptr;
+            errno = 0;
+            auto const parsed = std::strtol(v, &endp, 10);
+            if (errno == 0 && *endp == '\0' && parsed > 0 &&
+                parsed < MAX_ADMINLEVEL) {
+                m_admin_level = static_cast<int>(parsed);
+            } else {
                 m_admin_level = MAX_ADMINLEVEL;
             }
             continue;

--- a/tests/test-output-gazetteer.cpp
+++ b/tests/test-output-gazetteer.cpp
@@ -697,6 +697,7 @@ TEST_CASE("Admin levels")
     t.add(9003, "place=city,admin_level=x");
     t.add(9004, "place=city,admin_level=1");
     t.add(9005, "place=city,admin_level=0");
+    t.add(9006, "place=city,admin_level=2.5");
 
     t.import();
 
@@ -707,6 +708,7 @@ TEST_CASE("Admin levels")
     CHECK("15" == t.obj_field(conn, 9003, "place", "admin_level"));
     CHECK("1" == t.obj_field(conn, 9004, "place", "admin_level"));
     CHECK("15" == t.obj_field(conn, 9005, "place", "admin_level"));
+    CHECK("15" == t.obj_field(conn, 9006, "place", "admin_level"));
 }
 
 TEST_CASE("Administrative boundaries with place tags")


### PR DESCRIPTION
std::atoi only parses a string to the first non-digit with the result that fractions like 2.5 end up being parsed despite not being a correct integer. Use strtol instead to check that the whole string gets parsed.

See https://github.com/osm-search/Nominatim/discussions/2787 for the issue.