### PR TITLE
Fix: Create point geometry from collection with single-node way

### DIFF
--- a/src/geom-from-osm.cpp
+++ b/src/geom-from-osm.cpp
@@ -202,6 +202,9 @@ void create_collection(geometry_t *geom,
             if (line.size() >= 2U) {
                 collection.add_geometry(std::move(item));
             }
+            if (line.size() == 1) {
+                collection.add_geometry(geometry_t{std::move(line[0])});
+            }
         }
     }
 

--- a/tests/bdd/flex/geometry-collection.feature
+++ b/tests/bdd/flex/geometry-collection.feature
@@ -54,7 +54,7 @@ Feature: Create geometry collections from relations
             | 10 |
         And the OSM data
             """
-            w20 Nn10
+            w20 Nn11
             r30 Tname=foo Mn11@
             r31 Tname=bar Mw20@
             r32 Tname=baz Mw21@
@@ -62,8 +62,25 @@ Feature: Create geometry collections from relations
         When running osm2pgsql flex
 
         Then table osm2pgsql_test_collection contains exactly
-            | osm_id | name   | ST_GeometryType(geom) |
-            | 30     | foo    | NULL                  |
-            | 31     | bar    | NULL                  |
-            | 32     | baz    | NULL                  |
+            | osm_id | name   | geom |
+            | 30     | foo    | NULL |
+            | 31     | bar    | NULL |
+            | 32     | baz    | NULL |
+
+    Scenario: Point entry generated for broken way lines
+        Given the grid
+            | 10 |
+        And the OSM data
+            """
+            w20 Nn10
+            w21 Nn10,n10
+            r30 Tname=w20 Mw20@
+            r31 Tname=w21 Mw21@
+            """
+        When running osm2pgsql flex
+
+        Then table osm2pgsql_test_collection contains exactly
+            | osm_id | name  | ST_NumGeometries(geom) | ST_AsText(ST_GeometryN(geom, 1)) |
+            | 30     | w20   | 1                      | 10                               |
+            | 31     | w21   | 1                      | 10                               |
 

--- a/tests/test-geom-collections.cpp
+++ b/tests/test-geom-collections.cpp
@@ -81,3 +81,17 @@ TEST_CASE("create_collection from no OSM data returns null geometry", "[NoDB]")
     REQUIRE(geometry_type(geom) == "NULL");
     REQUIRE(num_geometries(geom) == 0);
 }
+
+TEST_CASE("create_collection from OSM data with single-node way", "[NoDB]")
+{
+    test_buffer_t buffer;
+    buffer.add_way("w20 Nn1x1y1");
+
+    auto const geom = geom::create_collection(buffer.buffer());
+
+    REQUIRE(geometry_type(geom) == "GEOMETRYCOLLECTION");
+    REQUIRE(num_geometries(geom) == 1);
+
+    auto const &c = geom.get<geom::collection_t>();
+    REQUIRE(c[0] == geom::geometry_t{geom::point_t{1, 1}});
+}


### PR DESCRIPTION
If a geometry collection is created from a relation, any way member will normally end up as linestring relation. But if there is only a single point in the resulting linestring (because the way only contained a single node or multiple nodes with the same position), that linestring would be invalid. In this case create a point geometry instead.