### PR TITLE
Bugfix: Return relation members in order from pgsql middle

### DIFF
--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1298,10 +1298,6 @@ bool output_flex_t::relation_cache_t::add_members(middle_query_t const &middle)
             }
         }
 
-        for (auto &nodes : m_members_buffer.select<osmium::WayNodeList>()) {
-            middle.nodes_get_list(&nodes);
-        }
-
         for (auto &way : m_members_buffer.select<osmium::Way>()) {
             middle.nodes_get_list(&(way.nodes()));
         }

--- a/src/pgsql.hpp
+++ b/src/pgsql.hpp
@@ -37,6 +37,8 @@
 class pg_result_t
 {
 public:
+    pg_result_t() {}
+
     explicit pg_result_t(PGresult *result) noexcept : m_result(result) {}
 
     /// Get a pointer to the underlying PGresult object.
@@ -96,6 +98,9 @@ public:
     {
         return PQfnumber(m_result.get(), ('"' + name + '"').c_str());
     }
+
+    /// Return true if this holds an actual result.
+    operator bool() { return m_result.get(); }
 
 private:
     struct pg_result_deleter_t

--- a/tests/bdd/flex/geometry-collection.feature
+++ b/tests/bdd/flex/geometry-collection.feature
@@ -20,7 +20,7 @@ Feature: Create geometry collections from relations
             end
             """
 
-    Scenario: Create geometry collection from different relations
+    Scenario Outline: Create geometry collection from different relations
         Given the 1.0 grid
             | 13 | 12 | 17 |    | 16 |
             | 10 | 11 |    | 14 | 15 |
@@ -33,7 +33,9 @@ Feature: Create geometry collections from relations
             r32 Tname=mixed Mn17@,w21@
             r33 Tname=node Mn17@
             """
-        When running osm2pgsql flex
+        When running osm2pgsql flex with parameters
+            | -c      |
+            | <param> |
 
         Then table osm2pgsql_test_collection contains exactly
             | osm_id | name   | ST_GeometryType(geom) | ST_NumGeometries(geom) | ST_GeometryType(ST_GeometryN(geom, 1)) |
@@ -48,6 +50,11 @@ Feature: Create geometry collections from relations
             | 31     | 10, 11, 12, 13, 10               | 14, 15, 16                       |
             | 32     | 17                               | 14, 15, 16                       |
             | 33     | 17                               | NULL                             |
+
+        Examples:
+            | param  |
+            |        |
+            | --slim |
 
     Scenario: NULL entry generated for broken geometries
         Given the grid


### PR DESCRIPTION
Relation members were not returned in order from rel_members_get() when using the pgsql middle.

This also fixes an anomaly where node members where returned as a WayNodeList instead of as normal nodes.