### PR TITLE
Revert "Fix: Create point geometry from collection with single-node way"

### DIFF
--- a/src/geom-from-osm.cpp
+++ b/src/geom-from-osm.cpp
@@ -202,9 +202,6 @@ void create_collection(geometry_t *geom,
             if (line.size() >= 2U) {
                 collection.add_geometry(std::move(item));
             }
-            if (line.size() == 1) {
-                collection.add_geometry(geometry_t{std::move(line[0])});
-            }
         }
     }
 

--- a/tests/bdd/flex/geometry-collection.feature
+++ b/tests/bdd/flex/geometry-collection.feature
@@ -91,3 +91,20 @@ Feature: Create geometry collections from relations
             | 30     | w20   | NULL |
             | 31     | w21   | NULL |
 
+    Scenario: No geometry generated for broken way lines, others are there
+        Given the grid
+            | 10 | 11 |
+            | 13 | 12 |
+        And the OSM data
+            """
+            w20 Nn10,n11,n12,n13,n10
+            w21 Nn10
+            w22 Nn10,n11,n13
+            r30 Tname=three Mw20@,w21@,w22@
+            """
+        When running osm2pgsql flex
+
+        Then table osm2pgsql_test_collection contains exactly
+            | osm_id | name  | ST_NumGeometries(geom) | ST_AsText(ST_GeometryN(geom, 1)) | ST_AsText(ST_GeometryN(geom, 2)) |
+            | 30     | three | 2                      | 10, 11, 12, 13, 10               | 10, 11, 13                       |
+

--- a/tests/bdd/flex/geometry-collection.feature
+++ b/tests/bdd/flex/geometry-collection.feature
@@ -69,8 +69,25 @@ Feature: Create geometry collections from relations
         When running osm2pgsql flex
 
         Then table osm2pgsql_test_collection contains exactly
-            | osm_id | name   | ST_GeometryType(geom) |
-            | 30     | foo    | NULL                  |
-            | 31     | bar    | NULL                  |
-            | 32     | baz    | NULL                  |
+            | osm_id | name   | geom |
+            | 30     | foo    | NULL |
+            | 31     | bar    | NULL |
+            | 32     | baz    | NULL |
+
+    Scenario: Null geometry generated for broken way lines
+        Given the grid
+            | 10 |
+        And the OSM data
+            """
+            w20 Nn10
+            w21 Nn10,n10
+            r30 Tname=w20 Mw20@
+            r31 Tname=w21 Mw21@
+            """
+        When running osm2pgsql flex
+
+        Then table osm2pgsql_test_collection contains exactly
+            | osm_id | name  | geom |
+            | 30     | w20   | NULL |
+            | 31     | w21   | NULL |
 

--- a/tests/bdd/flex/geometry-collection.feature
+++ b/tests/bdd/flex/geometry-collection.feature
@@ -61,7 +61,7 @@ Feature: Create geometry collections from relations
             | 10 |
         And the OSM data
             """
-            w20 Nn11
+            w20 Nn10
             r30 Tname=foo Mn11@
             r31 Tname=bar Mw20@
             r32 Tname=baz Mw21@
@@ -69,25 +69,8 @@ Feature: Create geometry collections from relations
         When running osm2pgsql flex
 
         Then table osm2pgsql_test_collection contains exactly
-            | osm_id | name   | geom |
-            | 30     | foo    | NULL |
-            | 31     | bar    | NULL |
-            | 32     | baz    | NULL |
-
-    Scenario: Point entry generated for broken way lines
-        Given the grid
-            | 10 |
-        And the OSM data
-            """
-            w20 Nn10
-            w21 Nn10,n10
-            r30 Tname=w20 Mw20@
-            r31 Tname=w21 Mw21@
-            """
-        When running osm2pgsql flex
-
-        Then table osm2pgsql_test_collection contains exactly
-            | osm_id | name  | ST_NumGeometries(geom) | ST_AsText(ST_GeometryN(geom, 1)) |
-            | 30     | w20   | 1                      | 10                               |
-            | 31     | w21   | 1                      | 10                               |
+            | osm_id | name   | ST_GeometryType(geom) |
+            | 30     | foo    | NULL                  |
+            | 31     | bar    | NULL                  |
+            | 32     | baz    | NULL                  |
 

--- a/tests/test-geom-collections.cpp
+++ b/tests/test-geom-collections.cpp
@@ -81,17 +81,3 @@ TEST_CASE("create_collection from no OSM data returns null geometry", "[NoDB]")
     REQUIRE(geometry_type(geom) == "NULL");
     REQUIRE(num_geometries(geom) == 0);
 }
-
-TEST_CASE("create_collection from OSM data with single-node way", "[NoDB]")
-{
-    test_buffer_t buffer;
-    buffer.add_way("w20 Nn1x1y1");
-
-    auto const geom = geom::create_collection(buffer.buffer());
-
-    REQUIRE(geometry_type(geom) == "GEOMETRYCOLLECTION");
-    REQUIRE(num_geometries(geom) == 1);
-
-    auto const &c = geom.get<geom::collection_t>();
-    REQUIRE(c[0] == geom::geometry_t{geom::point_t{1, 1}});
-}

--- a/tests/test-geom-collections.cpp
+++ b/tests/test-geom-collections.cpp
@@ -81,3 +81,13 @@ TEST_CASE("create_collection from no OSM data returns null geometry", "[NoDB]")
     REQUIRE(geometry_type(geom) == "NULL");
     REQUIRE(num_geometries(geom) == 0);
 }
+
+TEST_CASE("create_collection from OSM data with single-node way", "[NoDB]")
+{
+    test_buffer_t buffer;
+    buffer.add_way("w20 Nn1x1y1");
+
+    auto const geom = geom::create_collection(buffer.buffer());
+
+    REQUIRE(geom.is_null());
+}


### PR DESCRIPTION
This reverts commit 748fc0ab5bf4d9b459f2cbab54f4523c7b09624a.

Turns out this wasn't such a good idea, see #1767 for details.

The gist of it is that we always return NULL geometry when there are problems and so this should be the case here also for consistency.