### PR TITLE
Consistent naming of buffer paramater in create_*() calls

### DIFF
--- a/src/geom-from-osm.cpp
+++ b/src/geom-from-osm.cpp
@@ -96,10 +96,10 @@ geometry_t create_polygon(osmium::Way const &way)
 }
 
 void create_multilinestring(geometry_t *geom,
-                            osmium::memory::Buffer const &ways_buffer,
+                            osmium::memory::Buffer const &buffer,
                             bool force_multi)
 {
-    auto ways = ways_buffer.select<osmium::Way>();
+    auto ways = buffer.select<osmium::Way>();
     if (ways.size() == 1 && !force_multi) {
         auto &line = geom->set<linestring_t>();
         auto &way = *ways.begin();
@@ -122,11 +122,11 @@ void create_multilinestring(geometry_t *geom,
     }
 }
 
-geometry_t create_multilinestring(osmium::memory::Buffer const &ways,
+geometry_t create_multilinestring(osmium::memory::Buffer const &buffer,
                                   bool force_multi)
 {
     geometry_t geom{};
-    create_multilinestring(&geom, ways, force_multi);
+    create_multilinestring(&geom, buffer, force_multi);
     return geom;
 }
 
@@ -148,14 +148,14 @@ static void fill_polygon(polygon_t *polygon, osmium::Area const &area,
 }
 
 void create_multipolygon(geometry_t *geom, osmium::Relation const &relation,
-                         osmium::memory::Buffer const &way_buffer)
+                         osmium::memory::Buffer const &buffer)
 {
     osmium::area::AssemblerConfig area_config;
     area_config.ignore_invalid_locations = true;
     osmium::area::GeomAssembler assembler{area_config};
     osmium::memory::Buffer area_buffer{1024};
 
-    if (!assembler(relation, way_buffer, area_buffer)) {
+    if (!assembler(relation, buffer, area_buffer)) {
         geom->reset();
         return;
     }
@@ -176,19 +176,18 @@ void create_multipolygon(geometry_t *geom, osmium::Relation const &relation,
 }
 
 geometry_t create_multipolygon(osmium::Relation const &relation,
-                               osmium::memory::Buffer const &way_buffer)
+                               osmium::memory::Buffer const &buffer)
 {
     geometry_t geom{};
-    create_multipolygon(&geom, relation, way_buffer);
+    create_multipolygon(&geom, relation, buffer);
     return geom;
 }
 
-void create_collection(geometry_t *geom,
-                       osmium::memory::Buffer const &member_buffer)
+void create_collection(geometry_t *geom, osmium::memory::Buffer const &buffer)
 {
     auto &collection = geom->set<collection_t>();
 
-    for (auto const &obj : member_buffer) {
+    for (auto const &obj : buffer) {
         if (obj.type() == osmium::item_type::node) {
             auto const &node = static_cast<osmium::Node const &>(obj);
             if (node.location().valid()) {
@@ -210,10 +209,10 @@ void create_collection(geometry_t *geom,
     }
 }
 
-geometry_t create_collection(osmium::memory::Buffer const &member_buffer)
+geometry_t create_collection(osmium::memory::Buffer const &buffer)
 {
     geometry_t geom{};
-    create_collection(&geom, member_buffer);
+    create_collection(&geom, buffer);
     return geom;
 }
 

--- a/src/geom-from-osm.hpp
+++ b/src/geom-from-osm.hpp
@@ -92,31 +92,39 @@ void create_polygon(geometry_t *geom, osmium::Way const &way);
 /**
  * Create a multilinestring geometry from a bunch of ways (usually this
  * would be used for member ways of a relation). The result is always a
- * multilinestring, even if it only contains one linestring.
+ * multilinestring, even if it only contains one linestring, unless
+ * `force_multi` is set to false.
  *
  * If the resulting multilinestring would be invalid, a null geometry is
  * returned.
  *
  * \param geom Pointer to an existing geometry which will be used as output.
- * \param ways Buffer containing all the input ways.
+ * \param ways Buffer containing all the input ways. Object types other than
+ *             ways in the buffer are ignored.
+ * \param force_multi Should the result be a multilinestring even if it
+ *                    contains only a single linestring?
  */
 void create_multilinestring(geometry_t *geom,
-                            osmium::memory::Buffer const &ways,
+                            osmium::memory::Buffer const &buffer,
                             bool force_multi = true);
 
 /**
  * Create a multilinestring geometry from a bunch of ways (usually this
  * would be used for member ways of a relation). The result is always a
- * multilinestring, even if it only contains one linestring.
+ * multilinestring, even if it only contains one linestring, unless
+ * `force_multi` is set to false.
  *
  * If the resulting multilinestring would be invalid, a null geometry is
  * returned.
  *
- * \param ways Buffer containing all the input ways.
+ * \param ways Buffer containing all the input ways. Object types other than
+ *             ways in the buffer are ignored.
+ * \param force_multi Should the result be a multilinestring even if it
+ *                    contains only a single linestring?
  * \returns The created geometry.
  */
 [[nodiscard]] geometry_t
-create_multilinestring(osmium::memory::Buffer const &ways,
+create_multilinestring(osmium::memory::Buffer const &buffer,
                        bool force_multi = true);
 
 /**
@@ -127,10 +135,10 @@ create_multilinestring(osmium::memory::Buffer const &ways,
  *
  * \param geom Pointer to an existing geometry which will be used as output.
  * \param relation The input relation.
- * \param way_buffer Buffer containing all member ways.
+ * \param buffer Buffer with OSM objects. Anything but ways are ignored.
  */
 void create_multipolygon(geometry_t *geom, osmium::Relation const &relation,
-                         osmium::memory::Buffer const &way_buffer);
+                         osmium::memory::Buffer const &buffer);
 
 /**
  * Create a (multi)polygon geometry from a relation and member ways.
@@ -139,37 +147,40 @@ void create_multipolygon(geometry_t *geom, osmium::Relation const &relation,
  * returned.
  *
  * \param relation The input relation.
- * \param way_buffer Buffer containing all member ways.
+ * \param buffer Buffer with OSM objects. Anything but ways are ignored.
  * \returns The created geometry.
  */
 [[nodiscard]] geometry_t
 create_multipolygon(osmium::Relation const &relation,
-                    osmium::memory::Buffer const &way_buffer);
+                    osmium::memory::Buffer const &buffer);
 
 /**
- * Create a geometry collection from a relation and node/way members.
+ * Create a geometry collection from nodes and ways, usually used for
+ * relation members.
  *
  * If the resulting geometry would be empty or invalid, a null geometry is
  * returned.
  *
  * \param geom Pointer to an existing geometry which will be used as output.
- * \param relation The input relation.
- * \param way_buffer Buffer containing all member nodes and ways.
+ * \param buffer Buffer with OSM objects. Nodes are turned into points,
+ *               ways into linestrings, anything else in the buffer is ignored.
  */
 void create_collection(geometry_t *geom,
-                       osmium::memory::Buffer const &member_buffer);
+                       osmium::memory::Buffer const &buffer);
 
 /**
- * Create a geometry collection from a relation and node/way members.
+ * Create a geometry collection from nodes and ways, usually used for
+ * relation members.
  *
  * If the resulting geometry would be empty or invalid, a null geometry is
  * returned.
  *
- * \param way_buffer Buffer containing all member nodes and ways.
+ * \param buffer Buffer with OSM objects. Nodes are turned into points,
+ *               ways into linestrings, anything else in the buffer is ignored.
  * \returns The created geometry.
  */
 [[nodiscard]] geometry_t
-create_collection(osmium::memory::Buffer const &member_buffer);
+create_collection(osmium::memory::Buffer const &buffer);
 
 } // namespace geom
 


### PR DESCRIPTION
They are now always called "buffer" in .hpp and .cpp file. Document the fact that the input buffer can contain other object types which will be ignored.