### PR TITLE
Add implementation of simplify function for multilinestrings

### DIFF
--- a/src/geom-from-osm.cpp
+++ b/src/geom-from-osm.cpp
@@ -29,7 +29,14 @@ geometry_t create_point(osmium::Node const &node)
     return geometry_t{point_t{node.location()}};
 }
 
-static void fill_point_list(point_list_t *list,
+/**
+ * Fill point list with locations from nodes list. Consecutive identical
+ * locations are collapsed into a single point.
+ *
+ * Returns true if the result is a valid linestring, i.e. it has more than
+ * one point.
+ */
+static bool fill_point_list(point_list_t *list,
                             osmium::NodeRefList const &nodes)
 {
     osmium::Location last{};
@@ -41,16 +48,15 @@ static void fill_point_list(point_list_t *list,
             last = loc;
         }
     }
+
+    return list->size() > 1;
 }
 
 void create_linestring(geometry_t *geom, osmium::Way const &way)
 {
     auto &line = geom->set<linestring_t>();
 
-    fill_point_list(&line, way.nodes());
-
-    // Return nullgeom_t if the line geometry is invalid
-    if (line.size() <= 1U) {
+    if (!fill_point_list(&line, way.nodes())) {
         geom->reset();
     }
 }
@@ -103,16 +109,14 @@ void create_multilinestring(geometry_t *geom,
     if (ways.size() == 1 && !force_multi) {
         auto &line = geom->set<linestring_t>();
         auto &way = *ways.begin();
-        fill_point_list(&line, way.nodes());
-        if (line.size() < 2U) {
+        if (!fill_point_list(&line, way.nodes())) {
             geom->reset();
         }
     } else {
         auto &multiline = geom->set<multilinestring_t>();
         for (auto const &way : ways) {
             linestring_t line;
-            fill_point_list(&line, way.nodes());
-            if (line.size() >= 2U) {
+            if (fill_point_list(&line, way.nodes())) {
                 multiline.add_geometry(std::move(line));
             }
         }
@@ -197,8 +201,7 @@ void create_collection(geometry_t *geom, osmium::memory::Buffer const &buffer)
             auto const &way = static_cast<osmium::Way const &>(obj);
             geometry_t item;
             auto &line = item.set<linestring_t>();
-            fill_point_list(&line, way.nodes());
-            if (line.size() >= 2U) {
+            if (fill_point_list(&line, way.nodes())) {
                 collection.add_geometry(std::move(item));
             }
         }

--- a/src/geom.cpp
+++ b/src/geom.cpp
@@ -14,6 +14,12 @@
 
 namespace geom {
 
+void point_list_t::remove_duplicates()
+{
+    auto const it = std::unique(begin(), end());
+    erase(it, end());
+}
+
 bool operator==(polygon_t const &a, polygon_t const &b) noexcept
 {
     return (a.outer() == b.outer()) && (a.inners() == b.inners());

--- a/src/geom.hpp
+++ b/src/geom.hpp
@@ -90,7 +90,15 @@ private:
 
 }; // class point_t
 
-/// This type is used as the basis for linestrings and rings.
+/**
+ * This type is used as the basis for linestrings and rings.
+ *
+ * Point lists should not contain consecutive duplicate points. You can
+ * use the remove_duplicates() function to remove them if needed. (OGC validity
+ * only requires there to be at least two different points in a linestring, but
+ * we are more strict here to make sure we don't have to handle that anomaly
+ * later on.)
+ */
 class point_list_t : public std::vector<point_t>
 {
 public:
@@ -104,6 +112,9 @@ public:
     point_list_t(std::initializer_list<point_t> list)
     : std::vector<point_t>(list.begin(), list.end())
     {}
+
+    /// Collapse consecutive identical points into a single point (in-place).
+    void remove_duplicates();
 
 }; // class point_list_t
 

--- a/tests/test-geom-linestrings.cpp
+++ b/tests/test-geom-linestrings.cpp
@@ -39,6 +39,15 @@ TEST_CASE("geom::linestring_t", "[NoDB]")
     REQUIRE(ls1.num_geometries() == 1);
 }
 
+TEST_CASE("remove duplicate points in linestring", "[NoDB]")
+{
+    geom::linestring_t ls{{1, 1}, {1, 2}, {1, 2}, {2, 2}};
+    REQUIRE(ls.size() == 4);
+    ls.remove_duplicates();
+    REQUIRE(ls.size() == 3);
+    REQUIRE(ls == geom::linestring_t{{1, 1}, {1, 2}, {2, 2}});
+}
+
 TEST_CASE("line geometry", "[NoDB]")
 {
     geom::geometry_t const geom{geom::linestring_t{{1, 1}, {2, 2}}};
@@ -276,5 +285,32 @@ TEST_CASE("geom::simplify of a loop", "[NoDB]")
         auto const geom = geom::simplify(input, 10.0);
 
         REQUIRE(geom.is_null());
+    }
+}
+
+TEST_CASE("geom::simplify of straight line", "[NoDB]")
+{
+    geom::geometry_t const input{geom::linestring_t{{1, 1}, {1, 2}, {1, 3}}};
+
+    SECTION("small tolerance simplifies linestring")
+    {
+        auto const geom = geom::simplify(input, 0.5);
+
+        REQUIRE(geom.is_linestring());
+        auto const &l = geom.get<geom::linestring_t>();
+        REQUIRE(l.size() == 2);
+        REQUIRE(l[0] == input.get<geom::linestring_t>()[0]);
+        REQUIRE(l[1] == input.get<geom::linestring_t>()[2]);
+    }
+
+    SECTION("large tolerance also simplifies linestring")
+    {
+        auto const geom = geom::simplify(input, 10.0);
+
+        REQUIRE(geom.is_linestring());
+        auto const &l = geom.get<geom::linestring_t>();
+        REQUIRE(l.size() == 2);
+        REQUIRE(l[0] == input.get<geom::linestring_t>()[0]);
+        REQUIRE(l[1] == input.get<geom::linestring_t>()[2]);
     }
 }


### PR DESCRIPTION
We already have an implementation for linestring, which is slightly improved in this commit. Simplification for anything other than (multi)linestring is not supported.

In the first commit there is also a refactor of the `fill_point_list()` function which makes the code more readable and consistent.