### PR TITLE
Move some more complex functions from .hpp into .cpp file

### DIFF
--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -84,14 +84,7 @@ public:
 
     void set_id_type(osmium::item_type type) noexcept { m_id_type = type; }
 
-    bool has_id_column() const noexcept
-    {
-        if (m_columns.empty()) {
-            return false;
-        }
-        return (m_columns[0].type() == table_column_type::id_type) ||
-               (m_columns[0].type() == table_column_type::id_num);
-    }
+    bool has_id_column() const noexcept;
 
     std::size_t num_columns() const noexcept { return m_columns.size(); }
 
@@ -110,13 +103,7 @@ public:
         return m_geom_column != std::numeric_limits<std::size_t>::max();
     }
 
-    bool has_hstore_column() const noexcept
-    {
-        auto const it = std::find_if(begin(), end(), [&](auto const &column) {
-            return column.type() == table_column_type::hstore;
-        });
-        return it != end();
-    }
+    bool has_hstore_column() const noexcept;
 
     /// Get the (first, if there are multiple) geometry column.
     flex_table_column_t const &geom_column() const noexcept
@@ -140,55 +127,10 @@ public:
     std::string build_sql_create_id_index() const;
 
     /// Does this table take objects of the specified type?
-    bool matches_type(osmium::item_type type) const noexcept
-    {
-        // This table takes any type -> okay
-        if (m_id_type == osmium::item_type::undefined) {
-            return true;
-        }
-
-        // Type and table type match -> okay
-        if (type == m_id_type) {
-            return true;
-        }
-
-        // Relations can be written as linestrings into way tables -> okay
-        if (type == osmium::item_type::relation &&
-            m_id_type == osmium::item_type::way) {
-            return true;
-        }
-
-        // Area tables can take ways or relations, but not nodes
-        return m_id_type == osmium::item_type::area &&
-               type != osmium::item_type::node;
-    }
+    bool matches_type(osmium::item_type type) const noexcept;
 
     /// Map way/node/relation ID to id value used in database table column
-    osmid_t map_id(osmium::item_type type, osmid_t id) const noexcept
-    {
-        if (m_id_type == osmium::item_type::undefined) {
-            if (has_multicolumn_id_index()) {
-                return id;
-            }
-
-            switch (type) {
-            case osmium::item_type::node:
-                return id;
-            case osmium::item_type::way:
-                return -id;
-            case osmium::item_type::relation:
-                return -id - 100000000000000000LL;
-            default:
-                assert(false);
-            }
-        }
-
-        if (m_id_type != osmium::item_type::relation &&
-            type == osmium::item_type::relation) {
-            return -id;
-        }
-        return id;
-    }
+    osmid_t map_id(osmium::item_type type, osmid_t id) const noexcept;
 
     flex_table_column_t &add_column(std::string const &name,
                                     std::string const &type,


### PR DESCRIPTION
Only very simple accessor-type functions should be defined directly in .hpp file.