### PR TITLE
Add non-const accessor to multigeometry members for performance

### DIFF
--- a/src/geom-from-osm.cpp
+++ b/src/geom-from-osm.cpp
@@ -168,6 +168,8 @@ void create_multilinestring(geometry_t *geom,
         // others were not available turn it into a linestring geometry
         // retroactively.
         if (multiline.num_geometries() == 1 && !force_multi) {
+            // This has to be done in two steps, because the set<>()
+            // destroys the content of mulitline.
             auto p = std::move(multiline[0]);
             geom->set<linestring_t>() = std::move(p);
         }

--- a/src/geom.hpp
+++ b/src/geom.hpp
@@ -212,9 +212,14 @@ public:
     const_iterator cbegin() const noexcept { return m_geometry.cbegin(); }
     const_iterator cend() const noexcept { return m_geometry.cend(); }
 
-    GEOM const &operator[](std::size_t i) const noexcept
+    GEOM const &operator[](std::size_t n) const noexcept
     {
-        return m_geometry[i];
+        return m_geometry[n];
+    }
+
+    GEOM &operator[](std::size_t n) noexcept
+    {
+        return m_geometry[n];
     }
 
     void remove_last()


### PR DESCRIPTION
Without it the std::move() does not work, but a copy is needed.