### PR TITLE
Avoid parallel execution for pending items when there are only a few of them

### DIFF
--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -301,6 +301,8 @@ private:
         util::timer_t timer;
 
         if (ids_queued < 100) {
+            // Worker startup is quite expensive. Run the processing directly
+            // when only few items need to be processed.
             log_info("Going over {} pending {}s"_format(ids_queued, type));
 
             for (auto const oid : list) {


### PR DESCRIPTION
Worker handling for parallel processing of pending items has quite a large overhead of around 1s. This is not much of a problem when handling larger update files. It is noticable in the tests where we process update batches with one or two items only.

This avoids parallel processing entirely when only a few items are involved. I've set an completely arbitrary limit of 100 items. 