### PR TITLE
Make timer_t use microseconds and make it restartable

### DIFF
--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -237,7 +237,7 @@ public:
         return *m_proj;
     }
 
-    void task_set(std::future<std::chrono::milliseconds> &&future)
+    void task_set(std::future<std::chrono::microseconds> &&future)
     {
         m_task_result.set(std::move(future));
     }

--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -122,12 +122,12 @@ struct middle_pgsql_t : public middle_t
         std::string m_prepare_fw_dep_lookups;
         std::string m_create_fw_dep_indexes;
 
-        void task_set(std::future<std::chrono::milliseconds> &&future)
+        void task_set(std::future<std::chrono::microseconds> &&future)
         {
             m_task_result.set(std::move(future));
         }
 
-        std::chrono::milliseconds task_wait() { return m_task_result.wait(); }
+        std::chrono::microseconds task_wait() { return m_task_result.wait(); }
 
     private:
         std::shared_ptr<db_target_descr_t> m_copy_target;

--- a/src/table.hpp
+++ b/src/table.hpp
@@ -43,7 +43,7 @@ public:
 
     void sync();
 
-    void task_set(std::future<std::chrono::milliseconds> &&future)
+    void task_set(std::future<std::chrono::microseconds> &&future)
     {
         m_task_result.set(std::move(future));
     }

--- a/src/thread-pool.cpp
+++ b/src/thread-pool.cpp
@@ -14,14 +14,14 @@
 #include <cassert>
 #include <string>
 
-std::chrono::milliseconds task_result_t::wait()
+std::chrono::microseconds task_result_t::wait()
 {
     if (m_future.valid()) {
         m_result = m_future.get();
 
         // Make sure the result is not 0 so it is different than
         // "no result yet".
-        if (m_result == std::chrono::milliseconds::zero()) {
+        if (m_result == std::chrono::microseconds::zero()) {
             ++m_result;
         }
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -48,10 +48,10 @@ std::string human_readable_duration(uint64_t seconds)
     return "{}s ({}h {}m {}s)"_format(seconds, mins / 60, mins % 60, secs);
 }
 
-std::string human_readable_duration(std::chrono::milliseconds ms)
+std::string human_readable_duration(std::chrono::microseconds duration)
 {
     return human_readable_duration(static_cast<uint64_t>(
-        std::chrono::duration_cast<std::chrono::seconds>(ms).count()));
+        std::chrono::duration_cast<std::chrono::seconds>(duration).count()));
 }
 
 std::string get_password()


### PR DESCRIPTION
We can use the timer in more places if we have better resolution. For places where we don't need the resolution it doesn't matter because it will just get rounded. While we are at it we also use microseconds in the thread_pool code so that we use the same unit everywhere.

The timer is restartable now, by repeatedly calling start/stop() we can add up the times.

Also we are trying, as much as possible, to keep to the time types supplied by chrono. This gives us automatic correct time output with the fmt library which knows about those types. And it should make time conversions easier.