### PR TITLE
Cleanup output construction

### DIFF
--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -97,20 +97,17 @@ private:
 
 class output_flex_t : public output_t
 {
-
 public:
+    /// Constructor for new objects
     output_flex_t(
         std::shared_ptr<middle_query_t> const &mid,
         std::shared_ptr<thread_pool_t> thread_pool, options_t const &options,
-        std::shared_ptr<db_copy_thread_t> const &copy_thread,
-        bool is_clone = false, std::shared_ptr<lua_State> lua_state = nullptr,
-        prepared_lua_function_t process_node = {},
-        prepared_lua_function_t process_way = {},
-        prepared_lua_function_t process_relation = {},
-        prepared_lua_function_t select_relation_members = {},
-        std::shared_ptr<std::vector<flex_table_t>> tables =
-            std::make_shared<std::vector<flex_table_t>>(),
-        std::shared_ptr<idset_t> stage2_way_ids = std::make_shared<idset_t>());
+        std::shared_ptr<db_copy_thread_t> const &copy_thread);
+
+    /// Constructor for cloned objects
+    output_flex_t(output_flex_t const *other,
+                  std::shared_ptr<middle_query_t> mid,
+                  std::shared_ptr<db_copy_thread_t> copy_thread);
 
     output_flex_t(output_flex_t const &) = delete;
     output_flex_t &operator=(output_flex_t const &) = delete;
@@ -281,12 +278,14 @@ private:
 
     }; // relation_cache_t
 
-    std::shared_ptr<std::vector<flex_table_t>> m_tables;
+    std::shared_ptr<std::vector<flex_table_t>> m_tables =
+        std::make_shared<std::vector<flex_table_t>>();
+
     std::vector<table_connection_t> m_table_connections;
 
     // This is shared between all clones of the output and must only be
     // accessed while protected using the lua_mutex.
-    std::shared_ptr<idset_t> m_stage2_way_ids;
+    std::shared_ptr<idset_t> m_stage2_way_ids = std::make_shared<idset_t>();
 
     std::shared_ptr<db_copy_thread_t> m_copy_thread;
 
@@ -300,10 +299,10 @@ private:
     relation_cache_t m_relation_cache;
     osmium::Node const *m_context_node = nullptr;
 
-    prepared_lua_function_t m_process_node;
-    prepared_lua_function_t m_process_way;
-    prepared_lua_function_t m_process_relation;
-    prepared_lua_function_t m_select_relation_members;
+    prepared_lua_function_t m_process_node{};
+    prepared_lua_function_t m_process_way{};
+    prepared_lua_function_t m_process_relation{};
+    prepared_lua_function_t m_select_relation_members{};
 
     calling_context m_calling_context = calling_context::main;
 

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -171,7 +171,6 @@ public:
     int table_columns();
 
 private:
-    void init_clone();
     void select_relation_members();
 
     /**

--- a/src/output-gazetteer.cpp
+++ b/src/output-gazetteer.cpp
@@ -21,6 +21,8 @@
 #include <memory>
 #include <string>
 
+output_gazetteer_t::~output_gazetteer_t() = default;
+
 void output_gazetteer_t::delete_unused_classes(char osm_type, osmid_t osm_id)
 {
     if (get_options()->append) {

--- a/src/output-null.cpp
+++ b/src/output-null.cpp
@@ -9,11 +9,11 @@
 
 #include "output-null.hpp"
 
-std::shared_ptr<output_t>
-output_null_t::clone(std::shared_ptr<middle_query_t> const &mid,
-                     std::shared_ptr<db_copy_thread_t> const &) const
+std::shared_ptr<output_t> output_null_t::clone(
+    std::shared_ptr<middle_query_t> const & /*mid*/,
+    std::shared_ptr<db_copy_thread_t> const & /*copy_thread*/) const
 {
-    return std::make_shared<output_null_t>(mid, m_thread_pool, *get_options());
+    return std::make_shared<output_null_t>(*this);
 }
 
 output_null_t::output_null_t(std::shared_ptr<middle_query_t> const &mid,

--- a/src/output-null.hpp
+++ b/src/output-null.hpp
@@ -22,6 +22,12 @@ public:
                   std::shared_ptr<thread_pool_t> thread_pool,
                   options_t const &options);
 
+    output_null_t(output_null_t const &) = default;
+    output_null_t &operator=(output_null_t const &) = default;
+
+    output_null_t(output_null_t &&) = default;
+    output_null_t &operator=(output_null_t &&) = default;
+
     ~output_null_t() override;
 
     std::shared_ptr<output_t>

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -416,8 +416,7 @@ std::shared_ptr<output_t> output_pgsql_t::clone(
     std::shared_ptr<middle_query_t> const &mid,
     std::shared_ptr<db_copy_thread_t> const &copy_thread) const
 {
-    return std::shared_ptr<output_t>(
-        new output_pgsql_t{this, mid, copy_thread});
+    return std::make_shared<output_pgsql_t>(this, mid, copy_thread);
 }
 
 output_pgsql_t::output_pgsql_t(
@@ -481,8 +480,7 @@ output_pgsql_t::output_pgsql_t(
 output_pgsql_t::output_pgsql_t(
     output_pgsql_t const *other, std::shared_ptr<middle_query_t> const &mid,
     std::shared_ptr<db_copy_thread_t> const &copy_thread)
-: output_t(mid, other->m_thread_pool, *other->get_options()),
-  m_tagtransform(other->m_tagtransform->clone()),
+: output_t(other, mid), m_tagtransform(other->m_tagtransform->clone()),
   m_enable_way_area(other->m_enable_way_area),
   m_proj(get_options()->projection),
   m_expire(get_options()->expire_tiles_zoom,

--- a/src/output-pgsql.hpp
+++ b/src/output-pgsql.hpp
@@ -27,10 +27,6 @@
 
 class output_pgsql_t : public output_t
 {
-    output_pgsql_t(output_pgsql_t const *other,
-                   std::shared_ptr<middle_query_t> const &mid,
-                   std::shared_ptr<db_copy_thread_t> const &copy_thread);
-
 public:
     enum table_id
     {
@@ -41,10 +37,22 @@ public:
         t_MAX
     };
 
+    /// Constructor for new objects
     output_pgsql_t(std::shared_ptr<middle_query_t> const &mid,
                    std::shared_ptr<thread_pool_t> thread_pool,
                    options_t const &options,
                    std::shared_ptr<db_copy_thread_t> const &copy_thread);
+
+    /// Constructor for cloned objects
+    output_pgsql_t(output_pgsql_t const *other,
+                   std::shared_ptr<middle_query_t> const &mid,
+                   std::shared_ptr<db_copy_thread_t> const &copy_thread);
+
+    output_pgsql_t(output_pgsql_t const &) = delete;
+    output_pgsql_t &operator=(output_pgsql_t const &) = delete;
+
+    output_pgsql_t(output_pgsql_t &&) = delete;
+    output_pgsql_t &operator=(output_pgsql_t &&) = delete;
 
     ~output_pgsql_t() override;
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -66,7 +66,12 @@ output_t::output_t(std::shared_ptr<middle_query_t> mid,
                    options_t const &options)
 : m_mid(std::move(mid)), m_options(&options),
   m_thread_pool(std::move(thread_pool))
+{}
 
+output_t::output_t(output_t const *other, std::shared_ptr<middle_query_t> mid)
+: m_mid(std::move(mid)), m_options(other->m_options),
+  m_thread_pool(other->m_thread_pool),
+  m_output_requirements(other->m_output_requirements)
 {}
 
 output_t::~output_t() = default;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -76,9 +76,4 @@ output_t::output_t(output_t const *other, std::shared_ptr<middle_query_t> mid)
 
 output_t::~output_t() = default;
 
-void output_t::free_middle_references()
-{
-    m_mid.reset();
-}
-
-void output_t::merge_expire_trees(output_t *) {}
+void output_t::free_middle_references() { m_mid.reset(); }

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -32,17 +32,24 @@ struct middle_query_t;
 class output_t
 {
 public:
+    /// Factory method for creating instances of classes derived from output_t.
     static std::shared_ptr<output_t>
     create_output(std::shared_ptr<middle_query_t> const &mid,
                   std::shared_ptr<thread_pool_t> thread_pool,
                   options_t const &options);
 
-    output_t(std::shared_ptr<middle_query_t> mid,
-             std::shared_ptr<thread_pool_t> thread_pool,
-             options_t const &options);
+    output_t(output_t const &) = default;
+    output_t &operator=(output_t const &) = default;
+
+    output_t(output_t &&) = default;
+    output_t &operator=(output_t &&) = default;
 
     virtual ~output_t();
 
+    /**
+     * This function clones instances of derived classes of output_t, it must
+     * be implemented in derived classes.
+     */
     virtual std::shared_ptr<output_t>
     clone(std::shared_ptr<middle_query_t> const &mid,
           std::shared_ptr<db_copy_thread_t> const &copy_thread) const = 0;
@@ -96,8 +103,23 @@ public:
 private:
     std::shared_ptr<middle_query_t> m_mid;
     options_t const *m_options;
+    std::shared_ptr<thread_pool_t> m_thread_pool;
 
 protected:
+    /**
+     * Constructor used for creating a new object using the create_output()
+     * function.
+     */
+    output_t(std::shared_ptr<middle_query_t> mid,
+             std::shared_ptr<thread_pool_t> thread_pool,
+             options_t const &options);
+
+    /**
+     * Constructor used for cloning an existing output using clone(). It gets
+     * a new middle query pointer, everything else is copied over.
+     */
+    output_t(output_t const *other, std::shared_ptr<middle_query_t> mid);
+
     thread_pool_t &thread_pool() const noexcept
     {
         assert(m_thread_pool);
@@ -112,7 +134,6 @@ protected:
 
     const options_t *get_options() const noexcept { return m_options; };
 
-    std::shared_ptr<thread_pool_t> m_thread_pool;
     output_requirements m_output_requirements{};
 };
 

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -10,14 +10,11 @@
  * For a full list of authors see the git log.
  */
 
-/* Common output layer interface */
-
-/* Each output layer must provide methods for
- * storing:
- * - Nodes (Points of interest etc)
- * - Way geometries
- * Associated tags: name, type etc.
-*/
+/**
+ * \file
+ *
+ * Common output layer interface.
+ */
 
 #include <osmium/index/id_set.hpp>
 
@@ -93,9 +90,9 @@ public:
     virtual void way_delete(osmid_t id) = 0;
     virtual void relation_delete(osmid_t id) = 0;
 
-    virtual void merge_expire_trees(output_t *other);
+    virtual void merge_expire_trees(output_t * /*other*/) {}
 
-    struct output_requirements const &get_requirements() const noexcept
+    output_requirements const &get_requirements() const noexcept
     {
         return m_output_requirements;
     }


### PR DESCRIPTION
This code was a bit of a mess. Now the implementations of the derived classes are more similar and a bit simpler.

We'll use the "rule of five" in `output_t` and derived classes, so copy and move constructors and operators as well as (virtual) destructor are all spelled out.

As far as possible constructors etc. are made private/protected. We only ever create those classes though the  `create_output()` function or the `clone()` function. But we are using `std::make_shared()` internally so some constructors need to be public because, while conceptually the objects are created from inside the class itself, it is the `make_shared` function that actually does this and it can only use the public interface.