### PR TITLE
Remove copy_thread parameter from output constructors

### DIFF
--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1999,12 +1999,13 @@ output_flex_t::clone(std::shared_ptr<middle_query_t> const &mid,
 
 output_flex_t::output_flex_t(std::shared_ptr<middle_query_t> const &mid,
                              std::shared_ptr<thread_pool_t> thread_pool,
-                             options_t const &o)
-: output_t(mid, std::move(thread_pool), o),
-  m_copy_thread(std::make_shared<db_copy_thread_t>(get_options()->conninfo)),
-  m_expire(o.expire_tiles_zoom, o.expire_tiles_max_bbox, o.projection)
+                             options_t const &options)
+: output_t(mid, std::move(thread_pool), options),
+  m_copy_thread(std::make_shared<db_copy_thread_t>(options.conninfo)),
+  m_expire(options.expire_tiles_zoom, options.expire_tiles_max_bbox,
+           options.projection)
 {
-    init_lua(get_options()->style);
+    init_lua(options.style);
 
     // If the osm2pgsql.select_relation_members() Lua function is defined
     // it means we need two-stage processing which in turn means we need

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1997,11 +1997,11 @@ output_flex_t::clone(std::shared_ptr<middle_query_t> const &mid,
     return std::make_shared<output_flex_t>(this, mid, copy_thread);
 }
 
-output_flex_t::output_flex_t(
-    std::shared_ptr<middle_query_t> const &mid,
-    std::shared_ptr<thread_pool_t> thread_pool, options_t const &o,
-    std::shared_ptr<db_copy_thread_t> const &copy_thread)
-: output_t(mid, std::move(thread_pool), o), m_copy_thread(copy_thread),
+output_flex_t::output_flex_t(std::shared_ptr<middle_query_t> const &mid,
+                             std::shared_ptr<thread_pool_t> thread_pool,
+                             options_t const &o)
+: output_t(mid, std::move(thread_pool), o),
+  m_copy_thread(std::make_shared<db_copy_thread_t>(get_options()->conninfo)),
   m_expire(o.expire_tiles_zoom, o.expire_tiles_max_bbox, o.projection)
 {
     init_lua(get_options()->style);

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -99,10 +99,9 @@ class output_flex_t : public output_t
 {
 public:
     /// Constructor for new objects
-    output_flex_t(
-        std::shared_ptr<middle_query_t> const &mid,
-        std::shared_ptr<thread_pool_t> thread_pool, options_t const &options,
-        std::shared_ptr<db_copy_thread_t> const &copy_thread);
+    output_flex_t(std::shared_ptr<middle_query_t> const &mid,
+                  std::shared_ptr<thread_pool_t> thread_pool,
+                  options_t const &options);
 
     /// Constructor for cloned objects
     output_flex_t(output_flex_t const *other,

--- a/src/output-gazetteer.hpp
+++ b/src/output-gazetteer.hpp
@@ -34,7 +34,7 @@ public:
                        std::shared_ptr<thread_pool_t> thread_pool,
                        options_t const &options)
     : output_t(mid, std::move(thread_pool), options),
-      m_copy(std::make_shared<db_copy_thread_t>(get_options()->conninfo)),
+      m_copy(std::make_shared<db_copy_thread_t>(options.conninfo)),
       m_proj(options.projection)
     {
         m_style.load_style(options.style);

--- a/src/output-gazetteer.hpp
+++ b/src/output-gazetteer.hpp
@@ -32,9 +32,9 @@ public:
     /// Constructor for new objects
     output_gazetteer_t(std::shared_ptr<middle_query_t> const &mid,
                        std::shared_ptr<thread_pool_t> thread_pool,
-                       options_t const &options,
-                       std::shared_ptr<db_copy_thread_t> const &copy_thread)
-    : output_t(mid, std::move(thread_pool), options), m_copy(copy_thread),
+                       options_t const &options)
+    : output_t(mid, std::move(thread_pool), options),
+      m_copy(std::make_shared<db_copy_thread_t>(get_options()->conninfo)),
       m_proj(options.projection)
     {
         m_style.load_style(options.style);

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -418,10 +418,9 @@ std::shared_ptr<output_t> output_pgsql_t::clone(
     return std::make_shared<output_pgsql_t>(this, mid, copy_thread);
 }
 
-output_pgsql_t::output_pgsql_t(
-    std::shared_ptr<middle_query_t> const &mid,
-    std::shared_ptr<thread_pool_t> thread_pool, options_t const &o,
-    std::shared_ptr<db_copy_thread_t> const &copy_thread)
+output_pgsql_t::output_pgsql_t(std::shared_ptr<middle_query_t> const &mid,
+                               std::shared_ptr<thread_pool_t> thread_pool,
+                               options_t const &o)
 : output_t(mid, std::move(thread_pool), o), m_proj(o.projection),
   m_expire(o.expire_tiles_zoom, o.expire_tiles_max_bbox, o.projection),
   m_buffer(32768, osmium::memory::Buffer::auto_grow::yes),
@@ -435,6 +434,9 @@ output_pgsql_t::output_pgsql_t(
     m_enable_way_area = read_style_file(get_options()->style, &exlist);
 
     m_tagtransform = tagtransform_t::make_tagtransform(get_options(), exlist);
+
+    auto copy_thread =
+        std::make_shared<db_copy_thread_t>(get_options()->conninfo);
 
     //for each table
     for (size_t i = 0; i < t_MAX; ++i) {

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -420,23 +420,23 @@ std::shared_ptr<output_t> output_pgsql_t::clone(
 
 output_pgsql_t::output_pgsql_t(std::shared_ptr<middle_query_t> const &mid,
                                std::shared_ptr<thread_pool_t> thread_pool,
-                               options_t const &o)
-: output_t(mid, std::move(thread_pool), o), m_proj(o.projection),
-  m_expire(o.expire_tiles_zoom, o.expire_tiles_max_bbox, o.projection),
+                               options_t const &options)
+: output_t(mid, std::move(thread_pool), options), m_proj(options.projection),
+  m_expire(options.expire_tiles_zoom, options.expire_tiles_max_bbox,
+           options.projection),
   m_buffer(32768, osmium::memory::Buffer::auto_grow::yes),
   m_rels_buffer(1024, osmium::memory::Buffer::auto_grow::yes)
 {
-    log_debug("Using projection SRS {} ({})", o.projection->target_srs(),
-              o.projection->target_desc());
+    log_debug("Using projection SRS {} ({})", options.projection->target_srs(),
+              options.projection->target_desc());
 
     export_list exlist;
 
-    m_enable_way_area = read_style_file(get_options()->style, &exlist);
+    m_enable_way_area = read_style_file(options.style, &exlist);
 
-    m_tagtransform = tagtransform_t::make_tagtransform(get_options(), exlist);
+    m_tagtransform = tagtransform_t::make_tagtransform(&options, exlist);
 
-    auto copy_thread =
-        std::make_shared<db_copy_thread_t>(get_options()->conninfo);
+    auto copy_thread = std::make_shared<db_copy_thread_t>(options.conninfo);
 
     //for each table
     for (size_t i = 0; i < t_MAX; ++i) {
@@ -446,7 +446,7 @@ output_pgsql_t::output_pgsql_t(std::shared_ptr<middle_query_t> const &mid,
             (i == t_point) ? osmium::item_type::node : osmium::item_type::way);
 
         //figure out what name we are using for this and what type
-        std::string name = get_options()->prefix;
+        std::string name = options.prefix;
         std::string type;
         switch (i) {
         case t_point:
@@ -471,10 +471,9 @@ output_pgsql_t::output_pgsql_t(std::shared_ptr<middle_query_t> const &mid,
         }
 
         m_tables[i] = std::make_unique<table_t>(
-            name, type, columns, get_options()->hstore_columns,
-            get_options()->projection->target_srs(), get_options()->append,
-            get_options()->hstore_mode, copy_thread,
-            get_options()->output_dbschema);
+            name, type, columns, options.hstore_columns,
+            options.projection->target_srs(), options.append,
+            options.hstore_mode, copy_thread, options.output_dbschema);
     }
 }
 

--- a/src/output-pgsql.hpp
+++ b/src/output-pgsql.hpp
@@ -40,8 +40,7 @@ public:
     /// Constructor for new objects
     output_pgsql_t(std::shared_ptr<middle_query_t> const &mid,
                    std::shared_ptr<thread_pool_t> thread_pool,
-                   options_t const &options,
-                   std::shared_ptr<db_copy_thread_t> const &copy_thread);
+                   options_t const &options);
 
     /// Constructor for cloned objects
     output_pgsql_t(output_pgsql_t const *other,

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -30,23 +30,21 @@ output_t::create_output(std::shared_ptr<middle_query_t> const &mid,
                         std::shared_ptr<thread_pool_t> thread_pool,
                         options_t const &options)
 {
-    auto copy_thread = std::make_shared<db_copy_thread_t>(options.conninfo);
-
     if (options.output_backend == "pgsql") {
         return std::make_shared<output_pgsql_t>(mid, std::move(thread_pool),
-                                                options, copy_thread);
+                                                options);
     }
 
 #ifdef HAVE_LUA
     if (options.output_backend == "flex") {
         return std::make_shared<output_flex_t>(mid, std::move(thread_pool),
-                                               options, copy_thread);
+                                               options);
     }
 #endif
 
     if (options.output_backend == "gazetteer") {
         return std::make_shared<output_gazetteer_t>(mid, std::move(thread_pool),
-                                                    options, copy_thread);
+                                                    options);
     }
 
     if (options.output_backend == "null") {


### PR DESCRIPTION
The output derived classes can create the copy_thread themselves. They just need the options which they have anyway.