### PR TITLE
Force database client encoding to UTF8

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -263,6 +263,8 @@ std::string build_conninfo(database_options_t const &opt)
         return out;
     }
 
+    out += " client_encoding='UTF8'";
+
     if (!opt.db.empty()) {
         out += " dbname='{}'"_format(opt.db);
     }

--- a/tests/test-options-database.cpp
+++ b/tests/test-options-database.cpp
@@ -20,42 +20,43 @@
 TEST_CASE("Connection info parsing with dbname", "[NoDB]")
 {
     database_options_t db;
-    CHECK(build_conninfo(db) == "fallback_application_name='osm2pgsql'");
-    db.db = "foo";
     CHECK(build_conninfo(db) ==
-          "fallback_application_name='osm2pgsql' dbname='foo'");
+          "fallback_application_name='osm2pgsql' client_encoding='UTF8'");
+    db.db = "foo";
+    CHECK(build_conninfo(db) == "fallback_application_name='osm2pgsql' "
+                                "client_encoding='UTF8' dbname='foo'");
 }
 
 TEST_CASE("Connection info parsing with user", "[NoDB]")
 {
     database_options_t db;
     db.username = "bar";
-    CHECK(build_conninfo(db) ==
-          "fallback_application_name='osm2pgsql' user='bar'");
+    CHECK(build_conninfo(db) == "fallback_application_name='osm2pgsql' "
+                                "client_encoding='UTF8' user='bar'");
 }
 
 TEST_CASE("Connection info parsing with password", "[NoDB]")
 {
     database_options_t db;
     db.password = "bar";
-    CHECK(build_conninfo(db) ==
-          "fallback_application_name='osm2pgsql' password='bar'");
+    CHECK(build_conninfo(db) == "fallback_application_name='osm2pgsql' "
+                                "client_encoding='UTF8' password='bar'");
 }
 
 TEST_CASE("Connection info parsing with host", "[NoDB]")
 {
     database_options_t db;
     db.host = "bar";
-    CHECK(build_conninfo(db) ==
-          "fallback_application_name='osm2pgsql' host='bar'");
+    CHECK(build_conninfo(db) == "fallback_application_name='osm2pgsql' "
+                                "client_encoding='UTF8' host='bar'");
 }
 
 TEST_CASE("Connection info parsing with port", "[NoDB]")
 {
     database_options_t db;
     db.port = "bar";
-    CHECK(build_conninfo(db) ==
-          "fallback_application_name='osm2pgsql' port='bar'");
+    CHECK(build_conninfo(db) == "fallback_application_name='osm2pgsql' "
+                                "client_encoding='UTF8' port='bar'");
 }
 
 TEST_CASE("Connection info parsing with complete info", "[NoDB]")
@@ -67,6 +68,7 @@ TEST_CASE("Connection info parsing with complete info", "[NoDB]")
     db.host = "bzz";
     db.port = "123";
     CHECK(build_conninfo(db) ==
-          "fallback_application_name='osm2pgsql' dbname='foo' "
+          "fallback_application_name='osm2pgsql' client_encoding='UTF8' "
+          "dbname='foo' "
           "user='bar' password='baz' host='bzz' port='123'");
 }


### PR DESCRIPTION
Doesn't hurt and might prevent some problems, because osm2pgsql is always dealing with UTF8 data.

Note that, just as with the fallback_application_name, this setting isn't set in all cases, but we don't want to meddle with the user settings too much to not break the connection info.