### PR TITLE
Handle non-normal floating point numbers in JSON writer

### DIFF
--- a/src/json-writer.hpp
+++ b/src/json-writer.hpp
@@ -13,8 +13,10 @@
 #include "format.hpp"
 
 #include <cassert>
+#include <cmath>
 #include <iterator>
 #include <string>
+#include <type_traits>
 
 class json_writer_t
 {
@@ -23,7 +25,18 @@ public:
 
     void boolean(bool value) { m_buffer.append(value ? "true" : "false"); }
 
-    template <typename T>
+    template <typename T,
+              std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
+    void number(T value)
+    {
+        if (std::isfinite(value)) {
+            fmt::format_to(std::back_inserter(m_buffer), "{}"_format(value));
+        } else {
+            null();
+        }
+    }
+
+    template <typename T, std::enable_if_t<std::is_integral_v<T>, bool> = true>
     void number(T value)
     {
         fmt::format_to(std::back_inserter(m_buffer), "{}"_format(value));

--- a/tests/test-json-writer.cpp
+++ b/tests/test-json-writer.cpp
@@ -46,6 +46,20 @@ TEST_CASE("json writer writes real number", "[NoDB]")
     REQUIRE(writer.json() == "3.141");
 }
 
+TEST_CASE("json writer writes invalid real number as null", "[NoDB]")
+{
+    json_writer_t writer;
+    writer.number(INFINITY);
+    REQUIRE(writer.json() == "null");
+}
+
+TEST_CASE("json writer writes NaN as null", "[NoDB]")
+{
+    json_writer_t writer;
+    writer.number(NAN);
+    REQUIRE(writer.json() == "null");
+}
+
 TEST_CASE("json writer writes string", "[NoDB]")
 {
     json_writer_t writer;


### PR DESCRIPTION
JSON doesn't allow pseudo-numbers such as NaN and Inf. They are written out as "null" instead.