### PR TITLE
Flex: Add support for configuring table indexes in the Lua config

### DIFF
--- a/flex-config/indexes.lua
+++ b/flex-config/indexes.lua
@@ -1,0 +1,155 @@
+-- This config example file is released into the Public Domain.
+
+-- This file shows some options around index creation.
+
+local tables = {}
+
+-- When "indexes" is explicitly set to an empty Lua table, there will be no
+-- index on this table. (The index for the id column is still built if
+-- osm2pgsql needs that for updates.)
+tables.pois = osm2pgsql.define_table({
+    name = 'pois',
+    ids = { type = 'node', id_column = 'node_id' },
+    columns = {
+        { column = 'tags', type = 'jsonb' },
+        { column = 'geom', type = 'point', not_null = true },
+    },
+    indexes = {}
+})
+
+-- The "indexes" field is not set at all, you get the default, a GIST index on
+-- the only (or first) geometry column.
+tables.ways = osm2pgsql.define_way_table('ways', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'geom', type = 'linestring', not_null = true },
+})
+
+-- Setting "indexes" explicitly: Two indexes area created, one on the polygon
+-- geometry ("geom"), one on the center point geometry ("center"), both use
+-- the GIST method.
+tables.polygons = osm2pgsql.define_area_table('polygons', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'geom', type = 'geometry', not_null = true },
+    { column = 'center', type = 'point', not_null = true },
+}, { indexes = {
+    { column = 'geom', method = 'gist' },
+    { column = 'center', method = 'gist' }
+}})
+
+-- You can put an index on any column, not just geometry columns, and use any
+-- index method available in your PostgreSQL version. To get a list of methods
+-- use: "SELECT amname FROM pg_catalog.pg_am WHERE amtype = 'i';"
+tables.pubs = osm2pgsql.define_node_table('pubs', {
+    { column = 'name', type = 'text' },
+    { column = 'geom', type = 'geometry', not_null = true },
+}, { indexes = {
+    { column = 'geom', method = 'gist' },
+    { column = 'name', method = 'btree' }
+}})
+
+-- You can also create indexes using multiple columns by specifying an array
+-- as the "column". And you can add a where condition to the index. Note that
+-- the content of the where condition is not checked, but given "as is" to
+-- the database. You have to make sure it makes sense.
+tables.roads = osm2pgsql.define_way_table('roads', {
+    { column = 'name', type = 'text' },
+    { column = 'type', type = 'text' },
+    { column = 'ref', type = 'text' },
+    { column = 'geom', type = 'linestring', not_null = true },
+}, { indexes = {
+    { column = { 'name', 'ref' }, method = 'btree' },
+    { column = { 'geom' }, method = 'gist', where = "type='primary'" }
+}})
+
+-- Instead of on a column (or columns) you can define an index on an expression.
+tables.postboxes = osm2pgsql.define_node_table('postboxes', {
+    { column = 'operator', type = 'text' },
+    { column = 'geom', type = 'point', not_null = true },
+}, { indexes = {
+    { expression = 'lower(operator)', method = 'btree' },
+}})
+
+-- Helper function that looks at the tags and decides if this is possibly
+-- an area.
+function has_area_tags(tags)
+    if tags.area == 'yes' then
+        return true
+    end
+    if tags.area == 'no' then
+        return false
+    end
+
+    return tags.aeroway
+        or tags.amenity
+        or tags.building
+        or tags.harbour
+        or tags.historic
+        or tags.landuse
+        or tags.leisure
+        or tags.man_made
+        or tags.military
+        or tags.natural
+        or tags.office
+        or tags.place
+        or tags.power
+        or tags.public_transport
+        or tags.shop
+        or tags.sport
+        or tags.tourism
+        or tags.water
+        or tags.waterway
+        or tags.wetland
+        or tags['abandoned:aeroway']
+        or tags['abandoned:amenity']
+        or tags['abandoned:building']
+        or tags['abandoned:landuse']
+        or tags['abandoned:power']
+        or tags['area:highway']
+end
+
+function osm2pgsql.process_node(object)
+    local geom = object:as_point()
+
+    tables.pois:insert({
+        tags = object.tags,
+        geom = geom
+    })
+
+    if object.tags.amenity == 'pub' then
+        tables.pubs:insert({
+            name = object.tags.name,
+            geom = geom
+        })
+    elseif object.tags.amenity == 'post_box' then
+        tables.postboxes:insert({
+            operator = object.tags.operator,
+            geom = geom
+        })
+    end
+end
+
+function osm2pgsql.process_way(object)
+    if object.is_closed and has_area_tags(object.tags) then
+        local geom = object:as_polygon()
+        tables.polygons:insert({
+            tags = object.tags,
+            geom = geom,
+            center = geom:centroid()
+        })
+    else
+        tables.ways:insert({
+            tags = object.tags,
+            geom = object:as_linestring()
+        })
+    end
+
+    if object.tags.highway then
+        tables.roads:insert({
+            type = object.tags.highway,
+            name = object.tags.name,
+            ref = object.tags.ref,
+            geom = object:as_linestring()
+        })
+    end
+end
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,7 @@ if (WITH_LUA)
     file(READ "${CMAKE_CURRENT_SOURCE_DIR}/init.lua" LUA_INIT_CODE)
     configure_file(lua-init.cpp.in lua-init.cpp @ONLY)
     target_sources(osm2pgsql_lib PRIVATE
+        flex-index.cpp
         flex-table.cpp
         flex-table-column.cpp
         flex-lua-geom.cpp

--- a/src/flex-index.cpp
+++ b/src/flex-index.cpp
@@ -1,0 +1,66 @@
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2022 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+#include "flex-index.hpp"
+#include "util.hpp"
+
+std::string flex_index_t::columns() const
+{
+    return util::join(m_columns, ',', '"', '(', ')');
+}
+
+std::string flex_index_t::include_columns() const
+{
+    return util::join(m_include_columns, ',', '"', '(', ')');
+}
+
+std::string
+flex_index_t::create_index(std::string const &qualified_table_name) const
+{
+    util::string_joiner_t joiner{' '};
+    joiner.add("CREATE");
+
+    if (m_is_unique) {
+        joiner.add("UNIQUE");
+    }
+
+    joiner.add("INDEX ON");
+    joiner.add(qualified_table_name);
+
+    joiner.add("USING");
+    joiner.add(m_method);
+
+    if (m_expression.empty()) {
+        joiner.add(columns());
+    } else {
+        joiner.add('(' + m_expression + ')');
+    }
+
+    if (!m_include_columns.empty()) {
+        joiner.add("INCLUDE");
+        joiner.add(include_columns());
+    }
+
+    if (m_fillfactor != 0) {
+        joiner.add("WITH");
+        joiner.add("(fillfactor = {})"_format(m_fillfactor));
+    }
+
+    if (!m_tablespace.empty()) {
+        joiner.add("TABLESPACE");
+        joiner.add("\"" + m_tablespace + "\"");
+    }
+
+    if (!m_where_condition.empty()) {
+        joiner.add("WHERE");
+        joiner.add(m_where_condition);
+    }
+
+    return joiner();
+}

--- a/src/flex-index.hpp
+++ b/src/flex-index.hpp
@@ -1,0 +1,100 @@
+#ifndef OSM2PGSQL_FLEX_INDEX_HPP
+#define OSM2PGSQL_FLEX_INDEX_HPP
+
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2022 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+#include <cassert>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+/**
+ * This class represents a database index.
+ */
+class flex_index_t
+{
+public:
+    explicit flex_index_t(std::string method) : m_method(std::move(method)) {}
+
+    std::string const &method() const noexcept { return m_method; }
+
+    std::string columns() const;
+
+    /// Set columns (single-column version)
+    void set_columns(std::string const &columns)
+    {
+        assert(m_columns.empty());
+        m_columns.push_back(columns);
+    }
+
+    /// Set columns (multi-column version)
+    void set_columns(std::vector<std::string> const &columns)
+    {
+        m_columns = columns;
+    }
+
+    std::string include_columns() const;
+
+    void set_include_columns(std::vector<std::string> const &columns)
+    {
+        m_include_columns = columns;
+    }
+
+    std::string const &expression() const noexcept { return m_expression; }
+
+    void set_expression(std::string expression)
+    {
+        m_expression = std::move(expression);
+    }
+
+    std::string const &tablespace() const noexcept { return m_tablespace; }
+
+    void set_tablespace(std::string tablespace)
+    {
+        m_tablespace = std::move(tablespace);
+    }
+
+    std::string const &where_condition() const noexcept
+    {
+        return m_where_condition;
+    }
+
+    void set_where_condition(std::string where_condition)
+    {
+        m_where_condition = std::move(where_condition);
+    }
+
+    void set_fillfactor(uint8_t fillfactor)
+    {
+        if (fillfactor < 10 || fillfactor > 100) {
+            throw std::runtime_error{"Fillfactor must be between 10 and 100."};
+        }
+        m_fillfactor = fillfactor;
+    }
+
+    bool is_unique() const noexcept { return m_is_unique; }
+
+    void set_is_unique(bool unique) noexcept { m_is_unique = unique; }
+
+    std::string create_index(std::string const &qualified_table_name) const;
+
+private:
+    std::vector<std::string> m_columns;
+    std::vector<std::string> m_include_columns;
+    std::string m_method;
+    std::string m_expression;
+    std::string m_tablespace;
+    std::string m_where_condition;
+    uint8_t m_fillfactor = 0;
+    bool m_is_unique = false;
+
+}; // class flex_index_t
+
+#endif // OSM2PGSQL_FLEX_INDEX_HPP

--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -11,6 +11,7 @@
  */
 
 #include "db-copy-mgr.hpp"
+#include "flex-index.hpp"
 #include "flex-table-column.hpp"
 #include "pgsql.hpp"
 #include "reprojection.hpp"
@@ -146,6 +147,13 @@ public:
         return m_has_multiple_geom_columns;
     }
 
+    std::vector<flex_index_t> const &indexes() const noexcept
+    {
+        return m_indexes;
+    }
+
+    flex_index_t &add_index(std::string method);
+
 private:
     /// The name of the table
     std::string m_name;
@@ -167,6 +175,11 @@ private:
      * the id columns).
      */
     std::vector<flex_table_column_t> m_columns;
+
+    /**
+     * The indexes defined on this table. Does not include the id index.
+     */
+    std::vector<flex_index_t> m_indexes;
 
     /**
      * Index of the (first) geometry column in m_columns. Default means no

--- a/src/lua-utils.cpp
+++ b/src/lua-utils.cpp
@@ -138,7 +138,7 @@ char const *luaX_get_table_string(lua_State *lua_state, char const *key,
     }
     if (ltype != LUA_TSTRING) {
         throw std::runtime_error{
-            "{} must contain a '{}' string field."_format(error_msg, key)};
+            "{} field '{}' must be a string field."_format(error_msg, key)};
     }
     return lua_tostring(lua_state, -1);
 }
@@ -161,7 +161,7 @@ bool luaX_get_table_bool(lua_State *lua_state, char const *key, int table_index,
     }
 
     throw std::runtime_error{
-        "{} must contain a '{}' boolean field."_format(error_msg, key)};
+        "{} field '{}' must be a boolean field."_format(error_msg, key)};
 }
 
 

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -188,6 +188,7 @@ private:
     flex_table_t &create_flex_table();
     void setup_id_columns(flex_table_t *table);
     void setup_flex_table_columns(flex_table_t *table);
+    void setup_indexes(flex_table_t *table);
 
     flex_table_t const &get_table_from_param();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,7 +98,7 @@ if (WITH_LUA)
     set_test(test-output-flex-validgeom)
 
     set_test(test-output-flex-example-configs)
-    set(FLEX_EXAMPLE_CONFIGS "addresses,attributes,bbox,compatible,data-types,generic,geometries,places,route-relations,simple,unitable")
+    set(FLEX_EXAMPLE_CONFIGS "addresses,attributes,bbox,compatible,data-types,generic,geometries,indexes,places,route-relations,simple,unitable")
     # with-schema.lua is not tested because it needs the schema created in the database
     set_tests_properties(test-output-flex-example-configs PROPERTIES ENVIRONMENT "EXAMPLE_FILES=${FLEX_EXAMPLE_CONFIGS}")
 endif()

--- a/tests/bdd/flex/lua-index-definitions.feature
+++ b/tests/bdd/flex/lua-index-definitions.feature
@@ -1,0 +1,478 @@
+Feature: Index definitions in Lua file
+
+    Scenario: Indexes field in table definition must be an array
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = true
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            The 'indexes' field in definition of table 'mytable' is not an array.
+            """
+
+    Scenario: No indexes field in table definition gets you a default index
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                }
+            })
+            """
+        When running osm2pgsql flex
+        Then SELECT schemaname, tablename FROM pg_catalog.pg_indexes WHERE tablename = 'mytable' AND indexdef LIKE '%USING gist (geom)%'
+            | schemaname | tablename |
+            | public     | mytable   |
+
+    Scenario: Empty indexes field in table definition gets you no index
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {}
+            })
+            """
+        When running osm2pgsql flex
+        Then SELECT schemaname, tablename FROM pg_catalog.pg_indexes WHERE tablename = 'mytable'
+            | schemaname | tablename |
+
+    Scenario: Explicitly setting an index column works
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name', method = 'btree' }
+                }
+            })
+            """
+        When running osm2pgsql flex
+        Then SELECT schemaname, tablename FROM pg_catalog.pg_indexes WHERE tablename = 'mytable' AND indexdef LIKE '%USING btree (name)%'
+            | schemaname | tablename |
+            | public     | mytable   |
+
+    Scenario: Explicitly setting multiple indexes
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name', method = 'btree' },
+                    { column = 'geom', method = 'gist' },
+                    { column = { 'name', 'tags' }, method = 'btree' }
+                }
+            })
+            """
+        When running osm2pgsql flex
+        Then SELECT schemaname, tablename FROM pg_catalog.pg_indexes WHERE tablename = 'mytable' AND indexdef LIKE '%USING btree (name)%'
+            | schemaname | tablename |
+            | public     | mytable   |
+        And SELECT schemaname, tablename FROM pg_catalog.pg_indexes WHERE tablename = 'mytable' AND indexdef LIKE '%USING gist (geom)%'
+            | schemaname | tablename |
+            | public     | mytable   |
+        And SELECT schemaname, tablename FROM pg_catalog.pg_indexes WHERE tablename = 'mytable' AND indexdef LIKE '%USING btree (name, tags)%'
+            | schemaname | tablename |
+            | public     | mytable   |
+
+    Scenario: Method can not be missing
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name' }
+                }
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Index definition must contain a 'method' string field.
+            """
+
+    Scenario: Method must be valid
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name', method = 'ERROR' }
+                }
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Unknown index method 'ERROR'.
+            """
+
+    Scenario: Column can not be missing
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { method = 'btree' }
+                }
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            You must set either the 'column' or the 'expression' field in index definition.
+            """
+
+    Scenario: Column must exist
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'foo', method = 'btree' }
+                }
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Unknown column 'foo' in table 'mytable'.
+            """
+
+    Scenario: Column and expression together doesn't work
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name', expression = 'lower(name)', method = 'btree' }
+                }
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            You must set either the 'column' or the 'expression' field in index definition.
+            """
+
+    Scenario: Expression indexes work
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { expression = 'lower(name)', method = 'btree' },
+                }
+            })
+            """
+        When running osm2pgsql flex
+        Then SELECT schemaname, tablename FROM pg_catalog.pg_indexes WHERE tablename = 'mytable' AND indexdef LIKE '%USING btree (lower(name))%'
+            | schemaname | tablename |
+            | public     | mytable   |
+
+    @needs-pg-index-includes
+    Scenario: Include field must be a string or array
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name', method = 'btree', include = true }
+                }
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            The 'include' field in an index definition must contain a string or an array.
+            """
+
+    @needs-pg-index-includes
+    Scenario: Include field must contain a valid column
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name', method = 'btree', include = 'foo' }
+                }
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Unknown column 'foo' in table 'mytable'.
+            """
+
+    @needs-pg-index-includes
+    Scenario: Include field works with string
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name', method = 'btree', include = 'tags' }
+                }
+            })
+            """
+        When running osm2pgsql flex
+        Then SELECT schemaname, tablename FROM pg_catalog.pg_indexes WHERE tablename = 'mytable' AND indexdef LIKE '%USING btree (name)%' AND indexdef LIKE '%INCLUDE (tags)%'
+            | schemaname | tablename |
+            | public     | mytable   |
+
+    @needs-pg-index-includes
+    Scenario: Include field works with array
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name', method = 'btree', include = { 'tags' } }
+                }
+            })
+            """
+        When running osm2pgsql flex
+        Then SELECT schemaname, tablename FROM pg_catalog.pg_indexes WHERE tablename = 'mytable' AND indexdef LIKE '%USING btree (name)%' AND indexdef LIKE '%INCLUDE (tags)%'
+            | schemaname | tablename |
+            | public     | mytable   |
+
+    Scenario: Tablespace needs a string
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name', method = 'btree', tablespace = true }
+                }
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Index definition field 'tablespace' must be a string field.
+            """
+
+    Scenario: Empty tablespace is okay
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name', method = 'btree', tablespace = '' }
+                }
+            })
+            """
+        When running osm2pgsql flex
+        Then SELECT schemaname, tablename FROM pg_catalog.pg_indexes WHERE tablename = 'mytable' AND indexdef LIKE '%USING btree (name)%'
+            | schemaname | tablename |
+            | public     | mytable   |
+
+    Scenario: Unique needs a boolean
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name', method = 'btree', unique = 'foo' }
+                }
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Index definition field 'unique' must be a boolean field.
+            """
+
+    Scenario: Unique index works
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name', method = 'btree', unique = true }
+                }
+            })
+            """
+        When running osm2pgsql flex
+        Then SELECT schemaname, tablename FROM pg_catalog.pg_indexes WHERE tablename = 'mytable' AND indexdef LIKE '%USING btree (name)%' AND indexdef LIKE '%UNIQUE%'
+            | schemaname | tablename |
+            | public     | mytable   |
+
+    Scenario: Where condition needs a string
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name', method = 'btree', where = true }
+                }
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Index definition field 'where' must be a string field.
+            """
+
+    Scenario: Where condition works
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local t = osm2pgsql.define_table({
+                name = 'mytable',
+                ids = { type = 'node', id_column = 'node_id' },
+                columns = {
+                    { column = 'name', type = 'text' },
+                    { column = 'tags', type = 'jsonb' },
+                    { column = 'geom', type = 'geometry' },
+                },
+                indexes = {
+                    { column = 'name', method = 'btree', where = 'name = lower(name)' }
+                }
+            })
+            """
+        When running osm2pgsql flex
+        Then SELECT schemaname, tablename FROM pg_catalog.pg_indexes WHERE tablename = 'mytable' AND indexdef LIKE '%USING btree (name)%' AND indexdef LIKE '%WHERE (name = lower(name))%'
+            | schemaname | tablename |
+            | public     | mytable   |


### PR DESCRIPTION
The table definitions have a new (optional) field called "indexes" now which takes a list of index definitions. If the field is not there, we fall back to what we did before, a GIST index on the only/first geometry column of table is created. To disable indexes, set to an empty array.

See the flex-config/indexes.lua Lua config for some usage examples.

See #1780