### PR TITLE
Various small fixes for problems found by clang-tidy

### DIFF
--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -681,7 +681,7 @@ int output_flex_t::app_define_table()
     setup_indexes(&new_table);
 
     void *ptr = lua_newuserdata(lua_state(), sizeof(std::size_t));
-    std::size_t *num = new (ptr) std::size_t{};
+    auto *num = new (ptr) std::size_t{};
     *num = m_tables->size() - 1;
     luaL_getmetatable(lua_state(), osm2pgsql_table_name);
     lua_setmetatable(lua_state(), -2);

--- a/tests/test-expire-from-geometry.cpp
+++ b/tests/test-expire-from-geometry.cpp
@@ -103,18 +103,22 @@ TEST_CASE("expire linestring away from tile boundary", "[NoDB]")
 {
     expire_tiles et{zoom, 20000, defproj};
 
-    geom::linestring_t line{{5000.0, 4000.0}, {5100.0, 4200.0}};
-
-    SECTION("line") { et.from_geometry(line); }
+    SECTION("line")
+    {
+        geom::linestring_t line{{5000.0, 4000.0}, {5100.0, 4200.0}};
+        et.from_geometry(line);
+    }
 
     SECTION("geom")
     {
+        geom::linestring_t line{{5000.0, 4000.0}, {5100.0, 4200.0}};
         geom::geometry_t geom{std::move(line)};
         et.from_geometry(geom);
     }
 
     SECTION("geom with check")
     {
+        geom::linestring_t line{{5000.0, 4000.0}, {5100.0, 4200.0}};
         geom::geometry_t geom{std::move(line)};
         geom.set_srid(3857);
         et.from_geometry_if_3857(geom);
@@ -129,18 +133,22 @@ TEST_CASE("expire linestring crossing tile boundary", "[NoDB]")
 {
     expire_tiles et{zoom, 20000, defproj};
 
-    geom::linestring_t line{{5000.0, 5000.0}, {5000.0, 15000.0}};
-
-    SECTION("line") { et.from_geometry(line); }
+    SECTION("line")
+    {
+        geom::linestring_t line{{5000.0, 5000.0}, {5000.0, 15000.0}};
+        et.from_geometry(line);
+    }
 
     SECTION("geom")
     {
+        geom::linestring_t line{{5000.0, 5000.0}, {5000.0, 15000.0}};
         geom::geometry_t geom{std::move(line)};
         et.from_geometry(geom);
     }
 
     SECTION("geom with check")
     {
+        geom::linestring_t line{{5000.0, 5000.0}, {5000.0, 15000.0}};
         geom::geometry_t geom{std::move(line)};
         geom.set_srid(3857);
         et.from_geometry_if_3857(geom);
@@ -156,22 +164,34 @@ TEST_CASE("expire small polygon", "[NoDB]")
 {
     expire_tiles et{zoom, 20000, defproj};
 
-    geom::polygon_t poly{{{5000.0, 5000.0},
-                          {5100.0, 5000.0},
-                          {5100.0, 5100.0},
-                          {5000.0, 5100.0},
-                          {5000.0, 5000.0}}};
-
-    SECTION("polygon") { et.from_geometry(poly); }
+    SECTION("polygon")
+    {
+        geom::polygon_t poly{{{5000.0, 5000.0},
+                              {5100.0, 5000.0},
+                              {5100.0, 5100.0},
+                              {5000.0, 5100.0},
+                              {5000.0, 5000.0}}};
+        et.from_geometry(poly);
+    }
 
     SECTION("geom")
     {
+        geom::polygon_t poly{{{5000.0, 5000.0},
+                              {5100.0, 5000.0},
+                              {5100.0, 5100.0},
+                              {5000.0, 5100.0},
+                              {5000.0, 5000.0}}};
         geom::geometry_t geom{std::move(poly)};
         et.from_geometry(geom);
     }
 
     SECTION("geom with check")
     {
+        geom::polygon_t poly{{{5000.0, 5000.0},
+                              {5100.0, 5000.0},
+                              {5100.0, 5100.0},
+                              {5000.0, 5100.0},
+                              {5000.0, 5000.0}}};
         geom::geometry_t geom{std::move(poly)};
         geom.set_srid(3857);
         et.from_geometry_if_3857(geom);
@@ -186,22 +206,34 @@ TEST_CASE("expire large polygon as bbox", "[NoDB]")
 {
     expire_tiles et{zoom, 40000, defproj};
 
-    geom::polygon_t poly{{{5000.0, 5000.0},
-                          {25000.0, 5000.0},
-                          {25000.0, 25000.0},
-                          {5000.0, 25000.0},
-                          {5000.0, 5000.0}}};
-
-    SECTION("polygon") { et.from_geometry(poly); }
+    SECTION("polygon")
+    {
+        geom::polygon_t poly{{{5000.0, 5000.0},
+                              {25000.0, 5000.0},
+                              {25000.0, 25000.0},
+                              {5000.0, 25000.0},
+                              {5000.0, 5000.0}}};
+        et.from_geometry(poly);
+    }
 
     SECTION("geom")
     {
+        geom::polygon_t poly{{{5000.0, 5000.0},
+                              {25000.0, 5000.0},
+                              {25000.0, 25000.0},
+                              {5000.0, 25000.0},
+                              {5000.0, 5000.0}}};
         geom::geometry_t geom{std::move(poly)};
         et.from_geometry(geom);
     }
 
     SECTION("geom with check")
     {
+        geom::polygon_t poly{{{5000.0, 5000.0},
+                              {25000.0, 5000.0},
+                              {25000.0, 25000.0},
+                              {5000.0, 25000.0},
+                              {5000.0, 5000.0}}};
         geom::geometry_t geom{std::move(poly)};
         geom.set_srid(3857);
         et.from_geometry_if_3857(geom);
@@ -226,24 +258,44 @@ TEST_CASE("expire large polygon as boundary", "[NoDB]")
 {
     expire_tiles et{zoom, 10000, defproj};
 
-    geom::polygon_t poly{{{5000.0, 5000.0},
-                          {25000.0, 5000.0},
-                          {25000.0, 25000.0},
-                          {5000.0, 25000.0},
-                          {5000.0, 5000.0}}};
+    SECTION("polygon")
+    {
+        geom::polygon_t poly{{{5000.0, 5000.0},
+                              {25000.0, 5000.0},
+                              {25000.0, 25000.0},
+                              {5000.0, 25000.0},
+                              {5000.0, 5000.0}}};
+        et.from_geometry(poly);
+    }
 
-    SECTION("polygon") { et.from_geometry(poly); }
-
-    SECTION("polygon boundary") { et.from_polygon_boundary(poly); }
+    SECTION("polygon boundary")
+    {
+        geom::polygon_t poly{{{5000.0, 5000.0},
+                              {25000.0, 5000.0},
+                              {25000.0, 25000.0},
+                              {5000.0, 25000.0},
+                              {5000.0, 5000.0}}};
+        et.from_polygon_boundary(poly);
+    }
 
     SECTION("geom")
     {
+        geom::polygon_t poly{{{5000.0, 5000.0},
+                              {25000.0, 5000.0},
+                              {25000.0, 25000.0},
+                              {5000.0, 25000.0},
+                              {5000.0, 5000.0}}};
         geom::geometry_t geom{std::move(poly)};
         et.from_geometry(geom);
     }
 
     SECTION("geom with check")
     {
+        geom::polygon_t poly{{{5000.0, 5000.0},
+                              {25000.0, 5000.0},
+                              {25000.0, 25000.0},
+                              {5000.0, 25000.0},
+                              {5000.0, 5000.0}}};
         geom::geometry_t geom{std::move(poly)};
         geom.set_srid(3857);
         et.from_geometry_if_3857(geom);
@@ -269,20 +321,29 @@ TEST_CASE("expire multipoint geometry", "[NoDB]")
 
     geom::point_t p1{0.0, 0.0};
     geom::point_t p2{15000.0, 15000.0};
-    geom::multipoint_t mpt;
-    mpt.add_geometry(std::move(p1));
-    mpt.add_geometry(std::move(p2));
 
-    SECTION("multipoint") { et.from_geometry(mpt); }
+    SECTION("multipoint")
+    {
+        geom::multipoint_t mpt;
+        mpt.add_geometry(std::move(p1));
+        mpt.add_geometry(std::move(p2));
+        et.from_geometry(mpt);
+    }
 
     SECTION("geom")
     {
+        geom::multipoint_t mpt;
+        mpt.add_geometry(std::move(p1));
+        mpt.add_geometry(std::move(p2));
         geom::geometry_t geom{std::move(mpt)};
         et.from_geometry(geom);
     }
 
     SECTION("geom with check")
     {
+        geom::multipoint_t mpt;
+        mpt.add_geometry(std::move(p1));
+        mpt.add_geometry(std::move(p2));
         geom::geometry_t geom{std::move(mpt)};
         geom.set_srid(3857);
         et.from_geometry_if_3857(geom);

--- a/tests/test-flex-indexes.cpp
+++ b/tests/test-flex-indexes.cpp
@@ -34,7 +34,7 @@ public:
 
     lua_State *lua_state() const noexcept { return m_lua_state.get(); }
 
-    bool run_lua(char const *code)
+    bool run_lua(char const *code) const
     {
         return luaL_dostring(lua_state(), code) == 0;
     }
@@ -168,7 +168,7 @@ TEST_CASE("check index with expression and where clause", "[NoDB]")
     REQUIRE(table.indexes().size() == 1);
     auto const &idx = table.indexes()[0];
     REQUIRE(idx.method() == "btree");
-    REQUIRE(idx.columns() == "");
+    REQUIRE(idx.columns().empty());
     REQUIRE_FALSE(idx.is_unique());
     REQUIRE(idx.tablespace().empty());
     REQUIRE(idx.expression() == "lower(col)");

--- a/tests/test-parse-osmium.cpp
+++ b/tests/test-parse-osmium.cpp
@@ -123,7 +123,7 @@ struct counting_output_t : public output_null_t
     void relation_delete(osmid_t) override { ++relation.deleted; }
 
     type_stats_t node, way, relation;
-    long long sum_ids = 0;
+    uint64_t sum_ids = 0;
     std::size_t sum_nds = 0;
     std::size_t sum_members = 0;
 };


### PR DESCRIPTION
Biggest problem here are the warnings for access of objects after std::move() in the SECTIONs in the tests. Those are not valid, because for each test only one section is ever run, but it was easiest to silence the warning this way.