### PR TITLE
Remove extra _format() in log statements

### DIFF
--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -376,8 +376,8 @@ void table_connection_t::stop(bool updateable, bool append)
         log_info("No indexes to create on table '{}'.", table().name());
     } else {
         for (auto const &index : table().indexes()) {
-            log_info("Creating index on table '{}' {}..."_format(
-                table().name(), index.columns()));
+            log_info("Creating index on table '{}' {}...", table().name(),
+                     index.columns());
             auto const sql = index.create_index(
                 qualified_name(table().schema(), table().name()));
             m_db_connection->exec(sql);

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -303,15 +303,15 @@ private:
         if (ids_queued < 100) {
             // Worker startup is quite expensive. Run the processing directly
             // when only few items need to be processed.
-            log_info("Going over {} pending {}s"_format(ids_queued, type));
+            log_info("Going over {} pending {}s", ids_queued, type);
 
             for (auto const oid : list) {
                 (m_clones[0].get()->*function)(oid);
             }
             m_clones[0]->sync();
         } else {
-            log_info("Going over {} pending {}s (using {} threads)"_format(
-                ids_queued, type, m_clones.size()));
+            log_info("Going over {} pending {}s (using {} threads)", ids_queued,
+                     type, m_clones.size());
 
             std::vector<std::future<void>> workers;
 

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1430,8 +1430,7 @@ output_flex_t::output_flex_t(std::shared_ptr<middle_query_t> const &mid,
 
     log_debug("Tables:");
     for (auto const &table : *m_tables) {
-        log_debug(
-            "- TABLE {}"_format(qualified_name(table.schema(), table.name())));
+        log_debug("- TABLE {}", qualified_name(table.schema(), table.name()));
         log_debug("  - columns:");
         for (auto const &column : table) {
             log_debug("    - \"{}\" {} ({}) not_null={} create_only={}",
@@ -1586,8 +1585,8 @@ idset_t const &output_flex_t::get_marked_way_ids()
     if (m_stage2_way_ids->empty()) {
         log_info("Skipping stage 1c (no marked ways).");
     } else {
-        log_info("Entering stage 1c processing of {} ways..."_format(
-            m_stage2_way_ids->size()));
+        log_info("Entering stage 1c processing of {} ways...",
+                 m_stage2_way_ids->size());
         m_stage2_way_ids->sort_unique();
     }
 
@@ -1614,8 +1613,8 @@ void output_flex_t::reprocess_marked()
             }
         }
 
-        log_info("Creating id indexes took {}"_format(
-            util::human_readable_duration(timer.stop())));
+        log_info("Creating id indexes took {}",
+                 util::human_readable_duration(timer.stop()));
     }
 
     lua_gc(lua_state(), LUA_GCCOLLECT, 0);
@@ -1629,8 +1628,7 @@ void output_flex_t::reprocess_marked()
 
     m_stage2_way_ids->sort_unique();
 
-    log_info(
-        "There are {} ways to reprocess..."_format(m_stage2_way_ids->size()));
+    log_info("There are {} ways to reprocess...", m_stage2_way_ids->size());
 
     for (osmid_t const id : *m_stage2_way_ids) {
         if (!m_way_cache.init(middle(), id)) {


### PR DESCRIPTION
These are not needed, because the `log_*()` functions already do the formatting for us.