### PR TITLE
Add fmt_error() function that uses fmt lib to format error message

### DIFF
--- a/src/expire-tiles.cpp
+++ b/src/expire-tiles.cpp
@@ -251,9 +251,9 @@ quadkey_list_t expire_tiles::get_tiles()
 void expire_tiles::merge_and_destroy(expire_tiles *other)
 {
     if (m_map_width != other->m_map_width) {
-        throw std::runtime_error{"Unable to merge tile expiry sets when "
-                                 "map_width does not match: {} != {}."_format(
-                                     m_map_width, other->m_map_width)};
+        throw fmt_error("Unable to merge tile expiry sets when "
+                        "map_width does not match: {} != {}.",
+                        m_map_width, other->m_map_width);
     }
 
     if (m_dirty_tiles.empty()) {

--- a/src/flex-lua-index.cpp
+++ b/src/flex-lua-index.cpp
@@ -22,8 +22,8 @@ static void check_and_add_column(flex_table_t const &table,
 {
     auto const *column = util::find_by_name(table, column_name);
     if (!column) {
-        throw std::runtime_error{"Unknown column '{}' in table '{}'."_format(
-            column_name, table.name())};
+        throw fmt_error("Unknown column '{}' in table '{}'.", column_name,
+                        table.name());
     }
     columns->push_back(column_name);
 }
@@ -53,7 +53,7 @@ void flex_lua_setup_index(lua_State *lua_state, flex_table_t *table)
     char const *const method =
         luaX_get_table_string(lua_state, "method", -1, "Index definition");
     if (!has_index_method(method)) {
-        throw std::runtime_error{"Unknown index method '{}'."_format(method)};
+        throw fmt_error("Unknown index method '{}'.", method);
     }
     lua_pop(lua_state, 1);
     auto &index = table->add_index(method);
@@ -105,9 +105,9 @@ void flex_lua_setup_index(lua_State *lua_state, flex_table_t *table)
         }
         index.set_include_columns(include_columns);
     } else if (!lua_isnil(lua_state, -1)) {
-        throw std::runtime_error{
-            "Database version ({}) doesn't support"
-            " include columns in indexes."_format(get_database_version())};
+        throw fmt_error("Database version ({}) doesn't support"
+                        " include columns in indexes.",
+                        get_database_version());
     }
     lua_pop(lua_state, 1);
 
@@ -117,7 +117,7 @@ void flex_lua_setup_index(lua_State *lua_state, flex_table_t *table)
     lua_pop(lua_state, 1);
     check_identifier(tablespace, "tablespace");
     if (!has_tablespace(tablespace)) {
-        throw std::runtime_error{"Unknown tablespace '{}'."_format(tablespace)};
+        throw fmt_error("Unknown tablespace '{}'.", tablespace);
     }
     index.set_tablespace(tablespace.empty() ? table->index_tablespace()
                                             : tablespace);

--- a/src/flex-table-column.cpp
+++ b/src/flex-table-column.cpp
@@ -58,7 +58,7 @@ static table_column_type get_column_type_from_string(std::string const &type)
 {
     auto const *column_type = util::find_by_name(column_types, type);
     if (!column_type) {
-        throw std::runtime_error{"Unknown column type '{}'."_format(type)};
+        throw fmt_error("Unknown column type '{}'.", type);
     }
 
     return column_type->type;
@@ -106,8 +106,7 @@ void flex_table_column_t::set_projection(char const *projection)
     m_srid = static_cast<int>(std::strtoul(projection, &end, 10));
 
     if (*end != '\0') {
-        throw std::runtime_error{
-            "Unknown projection: '{}'."_format(projection)};
+        throw fmt_error("Unknown projection: '{}'.", projection);
     }
 }
 

--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -261,19 +261,18 @@ void table_connection_t::start(bool append)
     assert(m_db_connection);
 
     if (!has_schema(table().schema())) {
-        throw std::runtime_error{
-            "Schema '{0}' not available. "
-            "Use 'CREATE SCHEMA \"{0}\";' to create it."_format(
-                table().schema())};
+        throw fmt_error("Schema '{0}' not available."
+                        " Use 'CREATE SCHEMA \"{0}\";' to create it.",
+                        table().schema());
     }
 
     for (auto const &ts :
          {table().data_tablespace(), table().index_tablespace()}) {
         if (!has_tablespace(ts)) {
-            throw std::runtime_error{
-                "Tablespace '{0}' not available. "
-                "Use 'CREATE TABLESPACE \"{0}\" ...;' to create it."_format(
-                    ts)};
+            throw fmt_error(
+                "Tablespace '{0}' not available."
+                " Use 'CREATE TABLESPACE \"{0}\" ...;' to create it.",
+                ts);
         }
     }
 

--- a/src/flex-write.cpp
+++ b/src/flex-write.cpp
@@ -201,9 +201,8 @@ static void write_json_table(json_writer_t *writer, lua_State *lua_state,
         while (lua_next(lua_state, -2) != 0) {
             int const ltype_key = lua_type(lua_state, -2);
             if (ltype_key != LUA_TSTRING) {
-                throw std::runtime_error{
-                    "Incorrect data type '{}' as key."_format(
-                        lua_typename(lua_state, ltype_key))};
+                throw fmt_error("Incorrect data type '{}' as key.",
+                                lua_typename(lua_state, ltype_key));
             }
             char const *const key = lua_tostring(lua_state, -2);
             writer->key(key);
@@ -260,9 +259,8 @@ static void write_json(json_writer_t *writer, lua_State *lua_state,
         write_json_table(writer, lua_state, tables);
         break;
     default:
-        throw std::runtime_error{
-            "Invalid type '{}' for json/jsonb column."_format(
-                lua_typename(lua_state, ltype))};
+        throw fmt_error("Invalid type '{}' for json/jsonb column.",
+                        lua_typename(lua_state, ltype));
     }
 }
 
@@ -323,9 +321,8 @@ void flex_write_column(lua_State *lua_state,
     if (column.type() == table_column_type::text) {
         auto const *const str = lua_tolstring(lua_state, -1, nullptr);
         if (!str) {
-            throw std::runtime_error{
-                "Invalid type '{}' for text column."_format(
-                    lua_typename(lua_state, ltype))};
+            throw fmt_error("Invalid type '{}' for text column.",
+                            lua_typename(lua_state, ltype));
         }
         copy_mgr->add_column(str);
     } else if (column.type() == table_column_type::boolean) {
@@ -341,9 +338,8 @@ void flex_write_column(lua_State *lua_state,
                           lua_tolstring(lua_state, -1, nullptr));
             break;
         default:
-            throw std::runtime_error{
-                "Invalid type '{}' for boolean column."_format(
-                    lua_typename(lua_state, ltype))};
+            throw fmt_error("Invalid type '{}' for boolean column.",
+                            lua_typename(lua_state, ltype));
         }
     } else if (column.type() == table_column_type::int2) {
         if (ltype == LUA_TNUMBER) {
@@ -360,9 +356,8 @@ void flex_write_column(lua_State *lua_state,
         } else if (ltype == LUA_TBOOLEAN) {
             copy_mgr->add_column(lua_toboolean(lua_state, -1));
         } else {
-            throw std::runtime_error{
-                "Invalid type '{}' for int2 column."_format(
-                    lua_typename(lua_state, ltype))};
+            throw fmt_error("Invalid type '{}' for int2 column.",
+                            lua_typename(lua_state, ltype));
         }
     } else if (column.type() == table_column_type::int4) {
         if (ltype == LUA_TNUMBER) {
@@ -379,9 +374,8 @@ void flex_write_column(lua_State *lua_state,
         } else if (ltype == LUA_TBOOLEAN) {
             copy_mgr->add_column(lua_toboolean(lua_state, -1));
         } else {
-            throw std::runtime_error{
-                "Invalid type '{}' for int4 column."_format(
-                    lua_typename(lua_state, ltype))};
+            throw fmt_error("Invalid type '{}' for int4 column.",
+                            lua_typename(lua_state, ltype));
         }
     } else if (column.type() == table_column_type::int8) {
         if (ltype == LUA_TNUMBER) {
@@ -392,9 +386,8 @@ void flex_write_column(lua_State *lua_state,
         } else if (ltype == LUA_TBOOLEAN) {
             copy_mgr->add_column(lua_toboolean(lua_state, -1));
         } else {
-            throw std::runtime_error{
-                "Invalid type '{}' for int8 column."_format(
-                    lua_typename(lua_state, ltype))};
+            throw fmt_error("Invalid type '{}' for int8 column.",
+                            lua_typename(lua_state, ltype));
         }
     } else if (column.type() == table_column_type::real) {
         if (ltype == LUA_TNUMBER) {
@@ -403,9 +396,8 @@ void flex_write_column(lua_State *lua_state,
             write_double(copy_mgr, column,
                          lua_tolstring(lua_state, -1, nullptr));
         } else {
-            throw std::runtime_error{
-                "Invalid type '{}' for real column."_format(
-                    lua_typename(lua_state, ltype))};
+            throw fmt_error("Invalid type '{}' for real column.",
+                            lua_typename(lua_state, ltype));
         }
     } else if (column.type() == table_column_type::hstore) {
         if (ltype == LUA_TTABLE) {
@@ -417,17 +409,17 @@ void flex_write_column(lua_State *lua_state,
                 char const *const val = lua_tostring(lua_state, -1);
                 if (key == nullptr) {
                     int const ltype_key = lua_type(lua_state, -2);
-                    throw std::runtime_error{
+                    throw fmt_error(
                         "NULL key for hstore. Possibly this is due to"
-                        " an incorrect data type '{}' as key."_format(
-                            lua_typename(lua_state, ltype_key))};
+                        " an incorrect data type '{}' as key.",
+                        lua_typename(lua_state, ltype_key));
                 }
                 if (val == nullptr) {
                     int const ltype_value = lua_type(lua_state, -1);
-                    throw std::runtime_error{
+                    throw fmt_error(
                         "NULL value for hstore. Possibly this is due to"
-                        " an incorrect data type '{}' for key '{}'."_format(
-                            lua_typename(lua_state, ltype_value), key)};
+                        " an incorrect data type '{}' for key '{}'.",
+                        lua_typename(lua_state, ltype_value), key);
                 }
                 copy_mgr->add_hash_elem(key, val);
                 lua_pop(lua_state, 1);
@@ -435,9 +427,8 @@ void flex_write_column(lua_State *lua_state,
 
             copy_mgr->finish_hash();
         } else {
-            throw std::runtime_error{
-                "Invalid type '{}' for hstore column."_format(
-                    lua_typename(lua_state, ltype))};
+            throw fmt_error("Invalid type '{}' for hstore column.",
+                            lua_typename(lua_state, ltype));
         }
     } else if ((column.type() == table_column_type::json) ||
                (column.type() == table_column_type::jsonb)) {
@@ -458,9 +449,8 @@ void flex_write_column(lua_State *lua_state,
                             lua_tolstring(lua_state, -1, nullptr));
             break;
         default:
-            throw std::runtime_error{
-                "Invalid type '{}' for direction column."_format(
-                    lua_typename(lua_state, ltype))};
+            throw fmt_error("Invalid type '{}' for direction column.",
+                            lua_typename(lua_state, ltype));
         }
     } else if (column.is_geometry_column()) {
         // If this is a geometry column, the Lua function 'insert()' was
@@ -471,10 +461,9 @@ void flex_write_column(lua_State *lua_state,
             if (geom && !geom->is_null()) {
                 auto const type = column.type();
                 if (!is_compatible(*geom, type)) {
-                    throw std::runtime_error{
-                        "Geometry data for geometry column '{}'"
-                        " has the wrong type ({})."_format(
-                            column.name(), geometry_type(*geom))};
+                    throw fmt_error("Geometry data for geometry column '{}'"
+                                    " has the wrong type ({}).",
+                                    column.name(), geometry_type(*geom));
                 }
                 bool const wrap_multi =
                     (type == table_column_type::multipoint ||
@@ -494,9 +483,8 @@ void flex_write_column(lua_State *lua_state,
                 write_null(copy_mgr, column);
             }
         } else {
-            throw std::runtime_error{
-                "Need geometry data for geometry column '{}'."_format(
-                    column.name())};
+            throw fmt_error("Need geometry data for geometry column '{}'.",
+                            column.name());
         }
     } else if (column.type() == table_column_type::area) {
         // If this is an area column, the Lua function 'insert()' was
@@ -505,8 +493,8 @@ void flex_write_column(lua_State *lua_state,
         throw std::runtime_error{"Column type 'area' not allowed with "
                                  "'insert()'. Maybe use 'real'?"};
     } else {
-        throw std::runtime_error{"Column type {} not implemented."_format(
-            static_cast<uint8_t>(column.type()))};
+        throw fmt_error("Column type {} not implemented.",
+                        static_cast<uint8_t>(column.type()));
     }
 
     lua_pop(lua_state, 1);

--- a/src/format.hpp
+++ b/src/format.hpp
@@ -13,7 +13,16 @@
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 
+#include <stdexcept>
+
 // NOLINTNEXTLINE(google-global-names-in-headers,google-build-using-namespace)
 using namespace fmt::literals;
+
+template <typename S, typename... TArgs>
+std::runtime_error fmt_error(S const &format_str, TArgs &&...args)
+{
+    return std::runtime_error{
+        fmt::format(format_str, std::forward<TArgs>(args)...)};
+}
 
 #endif // OSM2PGSQL_FORMAT_HPP

--- a/src/geom-transform.cpp
+++ b/src/geom-transform.cpp
@@ -102,8 +102,9 @@ bool geom_transform_area_t::set_param(char const *name, lua_State *lua_state)
         return true;
     }
 
-    throw std::runtime_error{"Unknown value for 'split_at' field in a geometry"
-                             " transformation: '{}'"_format(val)};
+    throw fmt_error("Unknown value for 'split_at' field in a geometry"
+                    " transformation: '{}'",
+                    val);
 }
 
 bool geom_transform_area_t::is_compatible_with(
@@ -142,8 +143,7 @@ std::unique_ptr<geom_transform_t> create_geom_transform(char const *type)
         return std::make_unique<geom_transform_area_t>();
     }
 
-    throw std::runtime_error{
-        "Unknown geometry transformation '{}'."_format(type)};
+    throw fmt_error("Unknown geometry transformation '{}'.", type);
 }
 
 void init_geom_transform(geom_transform_t *transform, lua_State *lua_state)
@@ -194,26 +194,24 @@ get_transform(lua_State *lua_state, flex_table_column_t const &column)
     // Field set to anything but a Lua table is not allowed
     if (ltype != LUA_TTABLE) {
         lua_pop(lua_state, 1); // geom field
-        throw std::runtime_error{
-            "Invalid geometry transformation for column '{}'."_format(
-                column.name())};
+        throw fmt_error("Invalid geometry transformation for column '{}'.",
+                        column.name());
     }
 
     lua_getfield(lua_state, -1, "create");
     char const *create_type = lua_tostring(lua_state, -1);
     if (create_type == nullptr) {
-        throw std::runtime_error{
-            "Missing geometry transformation for column '{}'."_format(
-                column.name())};
+        throw fmt_error("Missing geometry transformation for column '{}'.",
+                        column.name());
     }
 
     transform = create_geom_transform(create_type);
     lua_pop(lua_state, 1); // 'create' field
     init_geom_transform(transform.get(), lua_state);
     if (!transform->is_compatible_with(column.type())) {
-        throw std::runtime_error{
-            "Geometry transformation is not compatible "
-            "with column type '{}'."_format(column.type_name())};
+        throw fmt_error("Geometry transformation is not compatible"
+                        " with column type '{}'.",
+                        column.type_name());
     }
 
     lua_pop(lua_state, 1); // geom field
@@ -246,7 +244,6 @@ geom_transform_t const *get_default_transform(flex_table_column_t const &column,
         break;
     }
 
-    throw std::runtime_error{
-        "Missing geometry transformation for column '{}'."_format(
-            column.name())};
+    throw fmt_error("Missing geometry transformation for column '{}'.",
+                    column.name());
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -24,9 +24,8 @@
 type_id check_input(type_id const &last, type_id curr)
 {
     if (curr.id < 0) {
-        throw std::runtime_error{
-            "Negative OSM object ids are not allowed: {} id {}."_format(
-                osmium::item_type_to_name(curr.type), curr.id)};
+        throw fmt_error("Negative OSM object ids are not allowed: {} id {}.",
+                        osmium::item_type_to_name(curr.type), curr.id);
     }
 
     if (last.type == curr.type) {
@@ -35,15 +34,14 @@ type_id check_input(type_id const &last, type_id curr)
         }
 
         if (last.id > curr.id) {
-            throw std::runtime_error{
-                "Input data is not ordered: {} id {} after {}."_format(
-                    osmium::item_type_to_name(last.type), curr.id, last.id)};
+            throw fmt_error("Input data is not ordered: {} id {} after {}.",
+                            osmium::item_type_to_name(last.type), curr.id,
+                            last.id);
         }
 
-        throw std::runtime_error{
-            "Input data is not ordered:"
-            " {} id {} appears more than once."_format(
-                osmium::item_type_to_name(last.type), curr.id)};
+        throw fmt_error("Input data is not ordered:"
+                        " {} id {} appears more than once.",
+                        osmium::item_type_to_name(last.type), curr.id);
     }
 
     if (item_type_to_nwr_index(last.type) <=
@@ -51,9 +49,9 @@ type_id check_input(type_id const &last, type_id curr)
         return curr;
     }
 
-    throw std::runtime_error{"Input data is not ordered: {} after {}."_format(
-        osmium::item_type_to_name(curr.type),
-        osmium::item_type_to_name(last.type))};
+    throw fmt_error("Input data is not ordered: {} after {}.",
+                    osmium::item_type_to_name(curr.type),
+                    osmium::item_type_to_name(last.type));
 }
 
 type_id check_input(type_id const &last, osmium::OSMObject const &object)
@@ -186,12 +184,11 @@ prepare_input_files(std::vector<std::string> const &input_files,
 
         if (file.format() == osmium::io::file_format::unknown) {
             if (input_format.empty()) {
-                throw std::runtime_error{
-                    "Cannot detect file format for '{}'. Try using -r."_format(
-                        filename)};
+                throw fmt_error("Cannot detect file format for '{}'."
+                                " Try using -r.",
+                                filename);
             }
-            throw std::runtime_error{
-                "Unknown file format '{}'."_format(input_format)};
+            throw fmt_error("Unknown file format '{}'.", input_format);
         }
 
         if (!append && file.has_multiple_object_versions()) {

--- a/src/lua-utils.cpp
+++ b/src/lua-utils.cpp
@@ -119,8 +119,7 @@ char const *luaX_get_table_string(lua_State *lua_state, char const *key,
     assert(error_msg);
     lua_getfield(lua_state, table_index, key);
     if (!lua_isstring(lua_state, -1)) {
-        throw std::runtime_error{
-            "{} must contain a '{}' string field."_format(error_msg, key)};
+        throw fmt_error("{} must contain a '{}' string field.", error_msg, key);
     }
     return lua_tostring(lua_state, -1);
 }
@@ -137,8 +136,8 @@ char const *luaX_get_table_string(lua_State *lua_state, char const *key,
         return default_value;
     }
     if (ltype != LUA_TSTRING) {
-        throw std::runtime_error{
-            "{} field '{}' must be a string field."_format(error_msg, key)};
+        throw fmt_error("{} field '{}' must be a string field.", error_msg,
+                        key);
     }
     return lua_tostring(lua_state, -1);
 }
@@ -160,8 +159,7 @@ bool luaX_get_table_bool(lua_State *lua_state, char const *key, int table_index,
         return lua_toboolean(lua_state, -1);
     }
 
-    throw std::runtime_error{
-        "{} field '{}' must be a boolean field."_format(error_msg, key)};
+    throw fmt_error("{} field '{}' must be a boolean field.", error_msg, key);
 }
 
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -401,8 +401,7 @@ static void parse_log_level_param(char const *arg)
     } else if (std::strcmp(arg, "error") == 0) {
         get_logger().set_level(log_level::error);
     } else {
-        throw std::runtime_error{
-            "Unknown value for --log-level option: {}"_format(arg)};
+        throw fmt_error("Unknown value for --log-level option: {}", arg);
     }
 }
 
@@ -415,8 +414,7 @@ static void parse_log_progress_param(char const *arg)
     } else if (std::strcmp(arg, "auto") == 0) {
         get_logger().auto_progress();
     } else {
-        throw std::runtime_error{
-            "Unknown value for --log-progress option: {}"_format(arg)};
+        throw fmt_error("Unknown value for --log-progress option: {}", arg);
     }
 }
 
@@ -430,9 +428,8 @@ static bool parse_with_forward_dependencies_param(char const *arg)
         return true;
     }
 
-    throw std::runtime_error{
-        "Unknown value for --with-forward-dependencies option: {}\n"_format(
-            arg)};
+    throw fmt_error("Unknown value for --with-forward-dependencies option: {}",
+                    arg);
 }
 
 static void print_version()

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -52,10 +52,9 @@ output_t::create_output(std::shared_ptr<middle_query_t> const &mid,
                                                options);
     }
 
-    throw std::runtime_error{
-        "Output backend '{}' not recognised. Should be one "
-        "of [pgsql, {}gazetteer, null]."_format(options.output_backend,
-                                                flex_backend)};
+    throw fmt_error("Output backend '{}' not recognised. Should be one of"
+                    " [pgsql, {}gazetteer, null].",
+                    options.output_backend, flex_backend);
 }
 
 output_t::output_t(std::shared_ptr<middle_query_t> mid,

--- a/src/pgsql-capabilities.cpp
+++ b/src/pgsql-capabilities.cpp
@@ -69,11 +69,11 @@ static void init_postgis_version(pg_conn_t const &db_connection)
         " pg_extension WHERE extname='postgis'");
 
     if (res.num_tuples() == 0) {
-        throw std::runtime_error{
+        throw fmt_error(
             "The postgis extension is not enabled on the database '{}'."
             " Are you using the correct database?"
-            " Enable with 'CREATE EXTENSION postgis;'"_format(
-                capabilities().database_name)};
+            " Enable with 'CREATE EXTENSION postgis;'",
+            capabilities().database_name);
     }
 
     capabilities().postgis = {std::stoi(std::string{res.get(0, 0)}),
@@ -98,9 +98,9 @@ void init_database_capabilities(pg_conn_t const &db_connection)
             std::strtoul(version_str.c_str(), nullptr, 10);
         if (capabilities().database_version <
             get_minimum_postgresql_server_version_num()) {
-            throw std::runtime_error{
-                "Your database version is too old (need at least {})."_format(
-                    get_minimum_postgresql_server_version())};
+            throw fmt_error(
+                "Your database version is too old (need at least {}).",
+                get_minimum_postgresql_server_version());
         }
 
         if (capabilities().settings.at("server_encoding") != "UTF8") {

--- a/src/reprojection-generic-proj6.cpp
+++ b/src/reprojection-generic-proj6.cpp
@@ -67,18 +67,16 @@ private:
             m_context.get(), source.c_str(), target.c_str(), nullptr)};
 
         if (!trans) {
-            throw std::runtime_error{
-                "Invalid projection from {} to {}: {}"_format(from, to,
-                                                              errormsg())};
+            throw fmt_error("Invalid projection from {} to {}: {}", from, to,
+                            errormsg());
         }
 
         std::unique_ptr<PJ, pj_deleter_t> trans_vis{
             proj_normalize_for_visualization(m_context.get(), trans.get())};
 
         if (!trans_vis) {
-            throw std::runtime_error{
-                "Invalid projection from {} to {}: {}"_format(from, to,
-                                                              errormsg())};
+            throw fmt_error("Invalid projection from {} to {}: {}", from, to,
+                            errormsg());
         }
 
         return trans_vis;

--- a/src/reprojection.cpp
+++ b/src/reprojection.cpp
@@ -81,7 +81,7 @@ std::shared_ptr<reprojection> reprojection::create_projection(int srs)
     }
 
     if (srs <= 0) {
-        throw std::runtime_error{"Invalid projection SRID '{}'."_format(srs)};
+        throw fmt_error("Invalid projection SRID '{}'.", srs);
     }
 
     return make_generic_projection(srs);

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -38,8 +38,7 @@ table_t::table_t(std::string const &name, std::string type, columns_t columns,
 
     // if we dont have any columns
     if (m_columns.empty() && m_hstore_mode != hstore_column::all) {
-        throw std::runtime_error{
-            "No columns provided for table {}."_format(name)};
+        throw fmt_error("No columns provided for table {}.", name);
     }
 
     generate_copy_column_list();
@@ -76,8 +75,8 @@ void table_t::connect()
 void table_t::start(std::string const &conninfo, std::string const &table_space)
 {
     if (m_sql_conn) {
-        throw std::runtime_error{m_target->name +
-                                 " cannot start, its already started."};
+        throw fmt_error("{} cannot start, its already started.",
+                        m_target->name);
     }
 
     m_conninfo = conninfo;

--- a/src/taginfo.cpp
+++ b/src/taginfo.cpp
@@ -120,9 +120,8 @@ bool read_style_file(std::string const &filename, export_list *exlist)
 
         if (fields < 3) {
             std::fclose(in);
-            throw std::runtime_error{
-                "Error reading style file line {} (fields={})."_format(lineno,
-                                                                       fields)};
+            throw fmt_error("Error reading style file line {} (fields={}).",
+                            lineno, fields);
         }
 
         //place to keep info about this tag
@@ -144,8 +143,8 @@ bool read_style_file(std::string const &filename, export_list *exlist)
             ((temp.name.find('?') != std::string::npos) ||
              (temp.name.find('*') != std::string::npos))) {
             std::fclose(in);
-            throw std::runtime_error{
-                "Wildcard '{}' in non-delete style entry."_format(temp.name)};
+            throw fmt_error("Wildcard '{}' in non-delete style entry.",
+                            temp.name);
         }
 
         if ((temp.name == "way_area") && (temp.flags == FLAG_DELETE)) {
@@ -169,8 +168,7 @@ bool read_style_file(std::string const &filename, export_list *exlist)
         //do we really want to completely quit on an unusable line?
         if (!kept) {
             std::fclose(in);
-            throw std::runtime_error{
-                "Weird style line {}:{}."_format(filename, lineno)};
+            throw fmt_error("Weird style line {}:{}.", filename, lineno);
         }
 
         read_valid_column = true;

--- a/src/tagtransform-lua.cpp
+++ b/src/tagtransform-lua.cpp
@@ -25,8 +25,8 @@ lua_tagtransform_t::lua_tagtransform_t(std::string const *tag_transform_script,
     m_lua_state.reset(luaL_newstate());
     luaL_openlibs(lua_state());
     if (luaL_dofile(lua_state(), m_lua_file->c_str())) {
-        throw std::runtime_error{"Lua tag transform style error: {}."_format(
-            lua_tostring(lua_state(), -1))};
+        throw fmt_error("Lua tag transform style error: {}.",
+                        lua_tostring(lua_state(), -1));
     }
 
     check_lua_function_exists(node_func);
@@ -44,9 +44,8 @@ void lua_tagtransform_t::check_lua_function_exists(char const *func_name)
 {
     lua_getglobal(lua_state(), func_name);
     if (!lua_isfunction(lua_state(), -1)) {
-        throw std::runtime_error{
-            "Tag transform style does not contain a function {}."_format(
-                func_name)};
+        throw fmt_error("Tag transform style does not contain a function {}.",
+                        func_name);
     }
     lua_pop(lua_state(), 1);
 }
@@ -63,20 +62,18 @@ static void get_out_tags(lua_State *lua_state, taglist_t *out_tags)
         // below will change it to a string and the lua_next() iteration will
         // break.
         if (key_type != LUA_TSTRING) {
-            throw std::runtime_error{
-                "Basic tag processing found incorrect data type"
-                "'{}', use a string."_format(
-                    lua_typename(lua_state, key_type))};
+            throw fmt_error("Basic tag processing found incorrect data type"
+                            " '{}', use a string.",
+                            lua_typename(lua_state, key_type));
         }
 
         auto const value_type = lua_type(lua_state, -1);
         // They key must be a string or number (which will automatically be
         // converted to a string).
         if (value_type != LUA_TSTRING && value_type != LUA_TNUMBER) {
-            throw std::runtime_error{
-                "Basic tag processing found incorrect data type"
-                "'{}', use a string."_format(
-                    lua_typename(lua_state, value_type))};
+            throw fmt_error("Basic tag processing found incorrect data type"
+                            " '{}', use a string.",
+                            lua_typename(lua_state, value_type));
         }
 
         char const *const key = lua_tostring(lua_state, -2);
@@ -129,9 +126,9 @@ bool lua_tagtransform_t::filter_tags(osmium::OSMObject const &o, bool *polygon,
     if (lua_pcall(lua_state(), 2, (o.type() == osmium::item_type::way) ? 4 : 2,
                   0)) {
         /* lua function failed */
-        throw std::runtime_error{
-            "Failed to execute lua function for basic tag "
-            "processing: {}."_format(lua_tostring(lua_state(), -1))};
+        throw fmt_error("Failed to execute lua function for"
+                        " basic tag processing: {}.",
+                        lua_tostring(lua_state(), -1));
     }
 
     if (o.type() == osmium::item_type::way) {
@@ -195,9 +192,9 @@ bool lua_tagtransform_t::filter_rel_member_tags(
 
     if (lua_pcall(lua_state(), 4, 6, 0)) {
         /* lua function failed */
-        throw std::runtime_error{
-            "Failed to execute lua function for relation tag "
-            "processing: {}."_format(lua_tostring(lua_state(), -1))};
+        throw fmt_error("Failed to execute lua function for"
+                        " relation tag processing: {}.",
+                        lua_tostring(lua_state(), -1));
     }
 
     *roads = (int)lua_tointeger(lua_state(), -1);

--- a/src/wkb.cpp
+++ b/src/wkb.cpp
@@ -346,8 +346,8 @@ public:
             parse_collection(&geom);
             break;
         default:
-            throw std::runtime_error{
-                "Invalid WKB geometry: Unknown geometry type {}"_format(type)};
+            throw fmt_error("Invalid WKB geometry: Unknown geometry type {}",
+                            type);
         }
 
         return geom;
@@ -440,10 +440,9 @@ private:
     {
         auto const num_points = parse_length();
         if (num_points < min_points) {
-            throw std::runtime_error{
-                "Invalid WKB geometry: {} are not"
-                " enough points (must be at least {})"_format(num_points,
-                                                              min_points)};
+            throw fmt_error("Invalid WKB geometry: {} are not"
+                            " enough points (must be at least {})",
+                            num_points, min_points);
         }
         points->reserve(num_points);
         for (uint32_t i = 0; i < num_points; ++i) {
@@ -480,9 +479,9 @@ private:
             auto &point = multipoint.add_geometry();
             uint32_t const type = parse_header();
             if (type != geometry_type::wkb_point) {
-                throw std::runtime_error{
-                    "Invalid WKB geometry: Multipoint containing"
-                    " something other than point: {}"_format(type)};
+                throw fmt_error("Invalid WKB geometry: Multipoint containing"
+                                " something other than point: {}",
+                                type);
             }
             parse_point(&point);
         }
@@ -502,9 +501,10 @@ private:
             auto &linestring = multilinestring.add_geometry();
             uint32_t const type = parse_header();
             if (type != geometry_type::wkb_line) {
-                throw std::runtime_error{
+                throw fmt_error(
                     "Invalid WKB geometry: Multilinestring containing"
-                    " something other than linestring: {}"_format(type)};
+                    " something other than linestring: {}",
+                    type);
             }
             parse_point_list(&linestring, 2);
         }
@@ -524,9 +524,9 @@ private:
             auto &polygon = multipolygon.add_geometry();
             uint32_t const type = parse_header();
             if (type != geometry_type::wkb_polygon) {
-                throw std::runtime_error{
-                    "Invalid WKB geometry: Multipolygon containing"
-                    " something other than polygon: {}"_format(type)};
+                throw fmt_error("Invalid WKB geometry: Multipolygon containing"
+                                " something other than polygon: {}",
+                                type);
             }
             parse_polygon(&polygon);
         }


### PR DESCRIPTION
This adds the fmt_error() function as a convenient wrapper that creates std::runtime_errors from a formatted error message.

See also #1859

I am not totally happy with the function name `fmt_error()`, because is looks a bit like the error is about formatting in some way, when it only means "format the error message using the `fmt` library". But I can't think of a better name.