### PR TITLE
Use fmt::format() function instead of ""_format literal

### DIFF
--- a/src/flex-index.cpp
+++ b/src/flex-index.cpp
@@ -49,7 +49,7 @@ flex_index_t::create_index(std::string const &qualified_table_name) const
 
     if (m_fillfactor != 0) {
         joiner.add("WITH");
-        joiner.add("(fillfactor = {})"_format(m_fillfactor));
+        joiner.add(fmt::format("(fillfactor = {})", m_fillfactor));
     }
 
     if (!m_tablespace.empty()) {

--- a/src/flex-table-column.cpp
+++ b/src/flex-table-column.cpp
@@ -146,21 +146,21 @@ std::string flex_table_column_t::sql_type_name() const
     case table_column_type::direction:
         return "int2";
     case table_column_type::geometry:
-        return "Geometry(GEOMETRY, {})"_format(m_srid);
+        return fmt::format("Geometry(GEOMETRY, {})", m_srid);
     case table_column_type::point:
-        return "Geometry(POINT, {})"_format(m_srid);
+        return fmt::format("Geometry(POINT, {})", m_srid);
     case table_column_type::linestring:
-        return "Geometry(LINESTRING, {})"_format(m_srid);
+        return fmt::format("Geometry(LINESTRING, {})", m_srid);
     case table_column_type::polygon:
-        return "Geometry(POLYGON, {})"_format(m_srid);
+        return fmt::format("Geometry(POLYGON, {})", m_srid);
     case table_column_type::multipoint:
-        return "Geometry(MULTIPOINT, {})"_format(m_srid);
+        return fmt::format("Geometry(MULTIPOINT, {})", m_srid);
     case table_column_type::multilinestring:
-        return "Geometry(MULTILINESTRING, {})"_format(m_srid);
+        return fmt::format("Geometry(MULTILINESTRING, {})", m_srid);
     case table_column_type::multipolygon:
-        return "Geometry(MULTIPOLYGON, {})"_format(m_srid);
+        return fmt::format("Geometry(MULTIPOLYGON, {})", m_srid);
     case table_column_type::geometrycollection:
-        return "Geometry(GEOMETRYCOLLECTION, {})"_format(m_srid);
+        return fmt::format("Geometry(GEOMETRYCOLLECTION, {})", m_srid);
     case table_column_type::area:
         return "real";
     case table_column_type::id_type:
@@ -188,5 +188,6 @@ std::string flex_table_column_t::sql_modifiers() const
 
 std::string flex_table_column_t::sql_create() const
 {
-    return R"("{}" {} {})"_format(m_name, sql_type_name(), sql_modifiers());
+    return fmt::format(R"("{}" {} {})", m_name, sql_type_name(),
+                       sql_modifiers());
 }

--- a/src/flex-write.cpp
+++ b/src/flex-write.cpp
@@ -36,8 +36,8 @@ static void write_null(db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
 {
     if (column.not_null()) {
         throw not_null_exception{
-            "Can not add NULL to column '{}' declared NOT NULL."_format(
-                column.name()),
+            fmt::format("Can not add NULL to column '{}' declared NOT NULL.",
+                        column.name()),
             &column};
     }
     copy_mgr->add_null_column();

--- a/src/node-persistent-cache.cpp
+++ b/src/node-persistent-cache.cpp
@@ -38,7 +38,7 @@ node_persistent_cache::node_persistent_cache(std::string file_name,
     if (m_fd < 0) {
         throw std::system_error{
             errno, std::system_category(),
-            "Unable to open flatnode file '{}'"_format(m_file_name)};
+            fmt::format("Unable to open flatnode file '{}'", m_file_name)};
     }
 
     m_index = std::make_unique<index_t>(m_fd);

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -739,7 +739,7 @@ int output_flex_t::table_tostring()
 {
     auto const &table = get_table_from_param();
 
-    std::string const str{"osm2pgsql.Table[{}]"_format(table.name())};
+    std::string const str{fmt::format("osm2pgsql.Table[{}]", table.name())};
     lua_pushstring(lua_state(), str.c_str());
 
     return 1;

--- a/src/output-gazetteer.cpp
+++ b/src/output-gazetteer.cpp
@@ -57,16 +57,17 @@ void output_gazetteer_t::start()
         /* Create the new table */
 
         std::string const sql =
-            "CREATE TABLE place ("
-            "  osm_id int8 NOT NULL,"
-            "  osm_type char(1) NOT NULL,"
-            "  class text NOT NULL,"
-            "  type text NOT NULL,"
-            "  name hstore,"
-            "  admin_level smallint,"
-            "  address hstore,"
-            "  extratags hstore," +
-            "  geometry Geometry(Geometry,{}) NOT NULL"_format(srid) + ")" +
+            fmt::format("CREATE TABLE place ("
+                        "  osm_id int8 NOT NULL,"
+                        "  osm_type char(1) NOT NULL,"
+                        "  class text NOT NULL,"
+                        "  type text NOT NULL,"
+                        "  name hstore,"
+                        "  admin_level smallint,"
+                        "  address hstore,"
+                        "  extratags hstore,"
+                        "  geometry Geometry(Geometry,{}) NOT NULL)",
+                        srid) +
             tablespace_clause(get_options()->tblsmain_data);
 
         conn.exec(sql);

--- a/src/pgsql-capabilities.cpp
+++ b/src/pgsql-capabilities.cpp
@@ -32,8 +32,8 @@ static void init_set_from_query(std::set<std::string> *set,
                                 char const *table, char const *column,
                                 char const *condition = "true")
 {
-    auto const res = db_connection.exec(
-        "SELECT {} FROM {} WHERE {}"_format(column, table, condition));
+    auto const res = db_connection.exec("SELECT {} FROM {} WHERE {}", column,
+                                        table, condition);
     for (int i = 0; i < res.num_tuples(); ++i) {
         set->emplace(res.get(i, 0));
     }

--- a/src/pgsql-helper.cpp
+++ b/src/pgsql-helper.cpp
@@ -82,9 +82,9 @@ void analyze_table(pg_conn_t const &db_connection, std::string const &schema,
 bool has_table(pg_conn_t const &db_connection, std::string const &schema,
                std::string const &table)
 {
-    auto const sql = "SELECT count(*) FROM pg_tables"
-                     "  WHERE schemaname='{}' AND tablename='{}'"_format(
-                         schema.empty() ? "public" : schema, table);
+    auto const sql = fmt::format("SELECT count(*) FROM pg_tables"
+                                 " WHERE schemaname='{}' AND tablename='{}'",
+                                 schema.empty() ? "public" : schema, table);
     auto const res = db_connection.exec(sql);
     char const *const num = res.get_value(0, 0);
 

--- a/src/progress-display.cpp
+++ b/src/progress-display.cpp
@@ -30,9 +30,9 @@ static std::string cps_display(std::size_t count, uint64_t elapsed)
     double const cps = count_per_second(count, elapsed);
 
     if (cps >= 1000.0) {
-        return "{:.0f}k/s"_format(cps / 1000);
+        return fmt::format("{:.0f}k/s", cps / 1000);
     }
-    return "{:.0f}/s"_format(cps);
+    return fmt::format("{:.0f}/s", cps);
 }
 
 void progress_display_t::print_summary() const

--- a/src/reprojection-generic-proj4.cpp
+++ b/src/reprojection-generic-proj4.cpp
@@ -71,5 +71,7 @@ std::shared_ptr<reprojection> reprojection::make_generic_projection(int srs)
     return std::make_shared<generic_reprojection_t>(srs);
 }
 
-std::string get_proj_version() { return "[API 4] {}"_format(pj_get_release()); }
-
+std::string get_proj_version()
+{
+    return fmt::format("[API 4] {}", pj_get_release());
+}

--- a/src/reprojection-generic-proj6.cpp
+++ b/src/reprojection-generic-proj6.cpp
@@ -60,8 +60,8 @@ private:
     {
         assert(m_context);
 
-        std::string const source = "epsg:{}"_format(from);
-        std::string const target = "epsg:{}"_format(to);
+        std::string const source = fmt::format("epsg:{}", from);
+        std::string const target = fmt::format("epsg:{}", to);
 
         std::unique_ptr<PJ, pj_deleter_t> trans{proj_create_crs_to_crs(
             m_context.get(), source.c_str(), target.c_str(), nullptr)};
@@ -119,6 +119,6 @@ std::shared_ptr<reprojection> reprojection::make_generic_projection(int srs)
 
 std::string get_proj_version()
 {
-    return "[API 6] {}"_format(proj_info().version);
+    return fmt::format("[API 6] {}", proj_info().version);
 }
 

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -102,19 +102,19 @@ void table_t::start(std::string const &conninfo, std::string const &table_space)
     if (!m_append) {
         //define the new table
         auto sql =
-            "CREATE UNLOGGED TABLE {} (osm_id int8,"_format(qual_name);
+            fmt::format("CREATE UNLOGGED TABLE {} (osm_id int8,", qual_name);
 
         //first with the regular columns
         for (auto const &column : m_columns) {
             check_identifier(column.name, "column names");
             check_identifier(column.type_name, "column types");
-            sql += R"("{}" {},)"_format(column.name, column.type_name);
+            sql += fmt::format(R"("{}" {},)", column.name, column.type_name);
         }
 
         //then with the hstore columns
         for (auto const &hcolumn : m_hstore_columns) {
             check_identifier(hcolumn, "column names");
-            sql += R"("{}" hstore,)"_format(hcolumn);
+            sql += fmt::format(R"("{}" hstore,)", hcolumn);
         }
 
         //add tags column
@@ -122,7 +122,7 @@ void table_t::start(std::string const &conninfo, std::string const &table_space)
             sql += "\"tags\" hstore,";
         }
 
-        sql += "way geometry({},{}) )"_format(m_type, m_srid);
+        sql += fmt::format("way geometry({},{}) )", m_type, m_srid);
 
         // The final tables are created with CREATE TABLE AS ... SELECT * FROM ...
         // This means that they won't get this autovacuum setting, so it doesn't
@@ -201,9 +201,8 @@ void table_t::stop(bool updateable, bool enable_hstore_index,
         // because they say nothing about the validity of the geometry in OSM.
         m_sql_conn->exec("SET client_min_messages = WARNING");
 
-        std::string sql =
-            "CREATE TABLE {} {} AS SELECT * FROM {}"_format(
-                qual_tmp_name, m_table_space, qual_name);
+        std::string sql = fmt::format("CREATE TABLE {} {} AS SELECT * FROM {}",
+                                      qual_tmp_name, m_table_space, qual_name);
 
         auto const postgis_version = get_postgis_version();
 

--- a/src/taginfo.cpp
+++ b/src/taginfo.cpp
@@ -91,7 +91,7 @@ bool read_style_file(std::string const &filename, export_list *exlist)
     if (!in) {
         throw std::system_error{
             errno, std::system_category(),
-            "Couldn't open style file '{}'"_format(filename)};
+            fmt::format("Couldn't open style file '{}'", filename)};
     }
 
     char buffer[1024];
@@ -179,7 +179,7 @@ bool read_style_file(std::string const &filename, export_list *exlist)
         std::fclose(in);
         throw std::system_error{
             err, std::system_category(),
-            "Error reading style file '{}'"_format(filename)};
+            fmt::format("Error reading style file '{}'", filename)};
     }
 
     std::fclose(in);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -36,16 +36,18 @@ std::string const &string_id_list_t::get()
 std::string human_readable_duration(uint64_t seconds)
 {
     if (seconds < 60) {
-        return "{}s"_format(seconds);
+        return fmt::format("{}s", seconds);
     }
 
     if (seconds < (60 * 60)) {
-        return "{}s ({}m {}s)"_format(seconds, seconds / 60, seconds % 60);
+        return fmt::format("{}s ({}m {}s)", seconds, seconds / 60,
+                           seconds % 60);
     }
 
     auto const secs = seconds % 60;
     auto const mins = seconds / 60;
-    return "{}s ({}h {}m {}s)"_format(seconds, mins / 60, mins % 60, secs);
+    return fmt::format("{}s ({}h {}m {}s)", seconds, mins / 60, mins % 60,
+                       secs);
 }
 
 std::string human_readable_duration(std::chrono::microseconds duration)

--- a/tests/common-buffer.hpp
+++ b/tests/common-buffer.hpp
@@ -44,12 +44,12 @@ public:
         std::string nodes;
 
         for (auto const id : ids) {
-            nodes += "n{},"_format(id);
+            nodes += fmt::format("n{},", id);
         }
 
         nodes.resize(nodes.size() - 1);
 
-        return add_way("w{} N{}"_format(wid, nodes));
+        return add_way(fmt::format("w{} N{}", wid, nodes));
     }
 
     osmium::Relation const &add_relation(std::string const &data)

--- a/tests/common-pg.hpp
+++ b/tests/common-pg.hpp
@@ -78,15 +78,16 @@ public:
 
     int get_count(char const *table_name, std::string const &where = "") const
     {
-        auto const query = "SELECT count(*) FROM {} {} {}"_format(
-            table_name, (where.empty() ? "" : "WHERE"), where);
+        auto const query =
+            fmt::format("SELECT count(*) FROM {} {} {}", table_name,
+                        (where.empty() ? "" : "WHERE"), where);
 
         return result_as_int(query);
     }
 
     void require_has_table(char const *table_name) const
     {
-        auto const where = "oid = '{}'::regclass"_format(table_name);
+        auto const where = fmt::format("oid = '{}'::regclass", table_name);
 
         REQUIRE(get_count("pg_catalog.pg_class", where) == 1);
     }
@@ -100,7 +101,8 @@ public:
         try {
             conn_t conn{"dbname=postgres"};
 
-            m_db_name = "osm2pgsql-test-{}-{}"_format(getpid(), time(nullptr));
+            m_db_name =
+                fmt::format("osm2pgsql-test-{}-{}", getpid(), time(nullptr));
             conn.exec(R"(DROP DATABASE IF EXISTS "{}")", m_db_name);
             conn.exec(R"(CREATE DATABASE "{}" WITH ENCODING 'UTF8')",
                       m_db_name);

--- a/tests/test-db-copy-mgr.cpp
+++ b/tests/test-db-copy-mgr.cpp
@@ -192,7 +192,7 @@ TEST_CASE("copy_mgr_t")
 
         for (auto const &[k, v] : values) {
             auto const res = c.result_as_string(
-                "SELECT h->'{}' FROM test_copy_mgr"_format(k));
+                fmt::format("SELECT h->'{}' FROM test_copy_mgr", k));
             CHECK(res == v);
         }
     }

--- a/tests/test-middle.cpp
+++ b/tests/test-middle.cpp
@@ -160,8 +160,8 @@ TEMPLATE_TEST_CASE("middle import", "", options_slim_default,
         // set nodes
         for (osmid_t i = 1; i <= 10; ++i) {
             nds.push_back(i);
-            auto const &node = buffer.add_node("n{} x{:.7f} y{:.7f}"_format(
-                i, lon - i * 0.003, lat + i * 0.001));
+            auto const &node = buffer.add_node(fmt::format(
+                "n{} x{:.7f} y{:.7f}", i, lon - i * 0.003, lat + i * 0.001));
             mid->node(node);
         }
         mid->after_nodes();

--- a/tests/test-output-gazetteer.cpp
+++ b/tests/test-output-gazetteer.cpp
@@ -217,10 +217,10 @@ public:
     int obj_count(testing::pg::conn_t const &conn, osmid_t id, char const *cls)
     {
         char const tchar = m_opl_factory.type();
-        return conn.get_count("place",
-                              "osm_type = '{}' "
-                              "AND osm_id = {} "
-                              "AND class = '{}'"_format(tchar, id, cls));
+        return conn.get_count("place", fmt::format("osm_type = '{}' AND"
+                                                   " osm_id = {} AND"
+                                                   " class = '{}'",
+                                                   tchar, id, cls));
     }
 
     void obj_names(testing::pg::conn_t const &conn, osmid_t id, char const *cls,
@@ -245,9 +245,10 @@ public:
                           char const *cls, char const *column)
     {
         char const tchar = m_opl_factory.type();
-        return conn.result_as_string(
+        return conn.result_as_string(fmt::format(
             "SELECT {} FROM place WHERE osm_type = '{}' AND osm_id = {}"
-            " AND class = '{}'"_format(column, tchar, id, cls));
+            " AND class = '{}'",
+            column, tchar, id, cls));
     }
 
 private:
@@ -256,11 +257,10 @@ private:
                         hstore_list const &names)
     {
         char const tchar = m_opl_factory.type();
-        auto const sql =
-            "SELECT skeys({}), svals({}) FROM place"
-            " WHERE osm_type = '{}' AND osm_id = {}"
-            " AND class = '{}'"_format(column, column, tchar, id, cls);
-        auto const res = conn.exec(sql);
+        auto const res = conn.exec("SELECT skeys({}), svals({}) FROM place"
+                                   " WHERE osm_type = '{}' AND "
+                                   " osm_id = {} AND class = '{}'",
+                                   column, column, tchar, id, cls);
 
         hstore_list actual;
         for (int i = 0; i < res.num_tuples(); ++i) {
@@ -279,7 +279,7 @@ struct StringMaker<hstore_item>
 {
     static std::string convert(hstore_item const &value)
     {
-        return "({}, {})"_format(std::get<0>(value), std::get<1>(value));
+        return fmt::format("({}, {})", std::get<0>(value), std::get<1>(value));
     }
 };
 } // namespace Catch

--- a/tests/test-output-pgsql-z_order.cpp
+++ b/tests/test-output-pgsql-z_order.cpp
@@ -27,9 +27,12 @@ TEST_CASE("compute Z order")
         "motorway", "trunk", "primary", "secondary", "tertiary"};
 
     for (unsigned i = 0; i < 5; ++i) {
-        auto const sql = "SELECT highway FROM osm2pgsql_test_line"
-                         " WHERE layer IS NULL ORDER BY z_order DESC"
-                         " LIMIT 1 OFFSET {}"_format(i);
+        auto const sql = fmt::format("SELECT highway"
+                                     " FROM osm2pgsql_test_line"
+                                     " WHERE layer IS NULL"
+                                     " ORDER BY z_order DESC"
+                                     " LIMIT 1 OFFSET {}",
+                                     i);
         REQUIRE(expected[i] == conn.result_as_string(sql));
     }
 


### PR DESCRIPTION
This replaces most uses of the ""_format literal with function calls to fmt::format(). The latter form is available in all versions of the fmt library, while the ""_format literal is deprecated in version 8 and removed in version 9.

This might cost us some performance and early error detection, because in at least some versions of the fmt library the _format() construct was used to compile the format patterns at run time. That's why there are some uses of the literal left in places where performance might be more critical, they need a closer look.

See #1859