### PR TITLE
Various fixes and clang-tidy configuration changes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: '*,-altera-*,-android-cloexec-*,-cert-err58-cpp,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-owning-memory,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-cstyle-cast,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-static-cast-downcast,-cppcoreguidelines-pro-type-vararg,-fuchsia-*,-google-readability-casting,-google-readability-todo,-hicpp-named-parameter,-hicpp-no-array-decay,-hicpp-vararg,-llvm-include-order,-llvm-header-guard,-llvmlibc-*,-misc-no-recursion,-modernize-use-nodiscard,-modernize-use-trailing-return-type,-readability-identifier-length,-readability-implicit-bool-conversion,-readability-named-parameter,-readability-magic-numbers'
+Checks: '*,-abseil-*,-altera-*,-android-cloexec-*,-bugprone-easily-swappable-parameters,-cert-err58-cpp,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-owning-memory,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-cstyle-cast,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-static-cast-downcast,-cppcoreguidelines-pro-type-vararg,-fuchsia-*,-google-readability-casting,-google-readability-todo,-hicpp-named-parameter,-hicpp-no-array-decay,-hicpp-vararg,-llvm-include-order,-llvm-header-guard,-llvmlibc-*,-misc-no-recursion,-modernize-use-nodiscard,-modernize-use-trailing-return-type,-readability-identifier-length,-readability-implicit-bool-conversion,-readability-named-parameter,-readability-magic-numbers'
 #
 #  cppcoreguidelines-pro-type-cstyle-cast
 #  google-build-using-namespace
@@ -10,11 +10,17 @@ Checks: '*,-altera-*,-android-cloexec-*,-cert-err58-cpp,-cppcoreguidelines-avoid
 #  readability-named-parameter
 #    Differ from our style guidelines
 #
+#  abseil-*
+#    Not applicable.
+#
 #  altera-*
 #    Not applicable.
 #
 #  android-cloexec-*
 #    O_CLOEXEC isn't available on Windows
+#
+#  bugprone-easily-swappable-parameters
+#    Can't always be avoided.
 #
 #  cert-err58-cpp
 #    There are many of these in the test code, most of them from the Catch

--- a/src/expire-tiles.cpp
+++ b/src/expire-tiles.cpp
@@ -281,7 +281,7 @@ std::size_t output_tiles_to_file(quadkey_list_t const &tiles_maxzoom,
             fmt::print(outfile, "{}/{}/{}\n", tile.zoom(), tile.x(), tile.y());
         });
 
-    std::fclose(outfile);
+    (void)std::fclose(outfile);
 
     return count;
 }

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -55,7 +55,9 @@ public:
         str += fmt::format(ts, format_str, std::forward<TArgs>(args)...);
         str += '\n';
 
-        std::fputs(str.c_str(), stderr);
+        if (std::fputs(str.c_str(), stderr) < 0) {
+            throw std::runtime_error{"Can not write to log"};
+        }
     }
 
     bool log_sql() const noexcept { return m_log_sql; }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -106,12 +106,12 @@ void long_usage(char const *arg0, bool verbose)
     char const *const name = program_name(arg0);
 
     fmt::print(stdout, "\nUsage: {} [OPTIONS] OSM-FILE...\n", name);
-    std::fputs(
+    (void)std::fputs(
         "\nImport data from the OSM file(s) into a PostgreSQL database.\n\n\
 Full documentation is available at https://osm2pgsql.org/\n\n",
         stdout);
 
-    std::fputs("\
+    (void)std::fputs("\
 Common options:\n\
     -a|--append     Update existing osm2pgsql database with data from file.\n\
     -c|--create     Import OSM data from file into database. This is the\n\
@@ -127,12 +127,12 @@ Common options:\n\
     -k|--hstore     Add tags without column to an additional hstore column.\n",
                stdout);
 #ifdef HAVE_LUA
-    std::fputs("\
+    (void)std::fputs("\
        --tag-transform-script=SCRIPT  Specify a Lua script to handle tag\n\
                     filtering and normalisation (pgsql output only).\n",
                stdout);
 #endif
-    std::fputs("\
+    (void)std::fputs("\
     -s|--slim       Store temporary data in the database. This switch is\n\
                     required if you want to update with --append later.\n\
         --drop      Only with --slim: drop temporary tables after import\n\
@@ -153,7 +153,7 @@ Database options:\n\
                stdout);
 
     if (verbose) {
-        std::fputs("\n\
+        (void)std::fputs("\n\
 Logging options:\n\
        --log-level=LEVEL  Set log level ('debug', 'info' (default), 'warn',\n\
                     or 'error').\n\
@@ -470,6 +470,7 @@ options_t::options_t(int argc, char *argv[]) : options_t()
     // errors - setting it to zero seems to work, though. see
     // http://stackoverflow.com/questions/15179963/is-it-possible-to-repeat-getopt#15179990
     optind = 0;
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
     while (-1 != (c = getopt_long(argc, argv, short_options, long_options,
                                   nullptr))) {
 
@@ -621,7 +622,7 @@ options_t::options_t(int argc, char *argv[]) : options_t()
             break;
         case 'V': // --version
             print_version();
-            exit(EXIT_SUCCESS);
+            std::exit(EXIT_SUCCESS); // NOLINT(concurrency-mt-unsafe)
             break;
         case 215: // --middle-schema
             middle_dbschema = optarg;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -81,6 +81,7 @@ public:
     /**
      * Constructor parsing the options from the command line.
      */
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
     options_t(int argc, char *argv[]);
 
     /**

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -314,7 +314,7 @@ private:
                      type, m_clones.size());
 
             std::vector<std::future<void>> workers;
-
+            workers.reserve(m_clones.size() + 1);
             for (auto const &clone : m_clones) {
                 workers.push_back(std::async(std::launch::async, run,
                                              std::cref(clone), &list, &m_mutex,

--- a/src/osmtypes.hpp
+++ b/src/osmtypes.hpp
@@ -192,7 +192,7 @@ public:
     template <typename T>
     void add_tag(char const *key, T&& value)
     {
-        m_tags.emplace_back(key, std::move(value));
+        m_tags.emplace_back(key, std::forward<T>(value));
     }
 
     /// Add tag to list if there is no tag with that key yet

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -57,6 +57,7 @@ static std::mutex lua_mutex;
 // C "trampoline" functions which are called from Lua which get the current
 // context (the output_flex_t object) and call the respective function on the
 // context object.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define TRAMPOLINE(func_name, lua_name)                                        \
     static int lua_trampoline_##func_name(lua_State *lua_state)                \
     {                                                                          \

--- a/src/reprojection-generic-proj6.cpp
+++ b/src/reprojection-generic-proj6.cpp
@@ -82,8 +82,8 @@ private:
         return trans_vis;
     }
 
-    geom::point_t transform(PJ *transformation,
-                            geom::point_t point) const noexcept
+    static geom::point_t transform(PJ *transformation,
+                                   geom::point_t point) noexcept
     {
         PJ_COORD c_in;
         c_in.lpzt.z = 0.0;

--- a/src/taginfo.cpp
+++ b/src/taginfo.cpp
@@ -119,7 +119,7 @@ bool read_style_file(std::string const &filename, export_list *exlist)
         }
 
         if (fields < 3) {
-            std::fclose(in);
+            (void)std::fclose(in);
             throw fmt_error("Error reading style file line {} (fields={}).",
                             lineno, fields);
         }
@@ -142,7 +142,7 @@ bool read_style_file(std::string const &filename, export_list *exlist)
         if ((temp.flags != FLAG_DELETE) &&
             ((temp.name.find('?') != std::string::npos) ||
              (temp.name.find('*') != std::string::npos))) {
-            std::fclose(in);
+            (void)std::fclose(in);
             throw fmt_error("Wildcard '{}' in non-delete style entry.",
                             temp.name);
         }
@@ -167,7 +167,7 @@ bool read_style_file(std::string const &filename, export_list *exlist)
 
         //do we really want to completely quit on an unusable line?
         if (!kept) {
-            std::fclose(in);
+            (void)std::fclose(in);
             throw fmt_error("Weird style line {}:{}.", filename, lineno);
         }
 
@@ -176,13 +176,13 @@ bool read_style_file(std::string const &filename, export_list *exlist)
 
     if (std::ferror(in)) {
         int const err = errno;
-        std::fclose(in);
+        (void)std::fclose(in);
         throw std::system_error{
             err, std::system_category(),
             fmt::format("Error reading style file '{}'", filename)};
     }
 
-    std::fclose(in);
+    (void)std::fclose(in);
 
     if (!read_valid_column) {
         throw std::runtime_error{"Unable to parse any valid columns from "

--- a/tests/test-output-flex-example-configs.cpp
+++ b/tests/test-output-flex-example-configs.cpp
@@ -24,7 +24,9 @@ static testing::db::import_t db;
 static char const *const data_file = "liechtenstein-2013-08-03.osm.pbf";
 
 std::vector<std::string> get_files() {
+    // NOLINTNEXTLINE(concurrency-mt-unsafe)
     char const *env = std::getenv("EXAMPLE_FILES");
+    REQUIRE(env);
     return osmium::split_string(env, ',', true);
 }
 


### PR DESCRIPTION
Some function results have been casted to void to silence a clang-tidy warning. We are ignoring the results from IO operations because we can't do anything useful in those cases anyway.