### PR TITLE
Add option to always build id index

### DIFF
--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -359,7 +359,8 @@ void table_connection_t::stop(bool updateable, bool append)
         }
     }
 
-    if (updateable && table().has_id_column()) {
+    if (table().always_build_id_index() ||
+        (updateable && table().has_id_column())) {
         create_id_index();
     }
 

--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -155,6 +155,16 @@ public:
 
     flex_index_t &add_index(std::string method);
 
+    void set_always_build_id_index() noexcept
+    {
+        m_always_build_id_index = true;
+    }
+
+    bool always_build_id_index() const noexcept
+    {
+        return m_always_build_id_index;
+    }
+
 private:
     /// The name of the table
     std::string m_name;
@@ -199,6 +209,9 @@ private:
 
     /// Does this table have more than one geometry column?
     bool m_has_multiple_geom_columns = false;
+
+    /// Always build the id index, not only when it is needed for updates?
+    bool m_always_build_id_index = false;
 
 }; // class flex_table_t
 

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -566,6 +566,16 @@ void output_flex_t::setup_id_columns(flex_table_t *table)
     lua_pop(lua_state(), 1); // "id_column"
     check_identifier(name, "column names");
 
+    std::string const create_index = luaX_get_table_string(
+        lua_state(), "create_index", -1, "The ids field", "auto");
+    lua_pop(lua_state(), 1); // "create_index"
+    if (create_index == "always") {
+        table->set_always_build_id_index();
+    } else if (create_index != "auto") {
+        throw fmt_error("Unknown value '{}' for 'create_index' field of ids",
+                        create_index);
+    }
+
     auto &column = table->add_column(name, "id_num", "");
     column.set_not_null();
     lua_pop(lua_state(), 1); // "ids"

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -534,6 +534,7 @@ void output_flex_t::setup_id_columns(flex_table_t *table)
 
     std::string const type{
         luaX_get_table_string(lua_state(), "type", -1, "The ids field")};
+    lua_pop(lua_state(), 1); // "type"
 
     if (type == "node") {
         table->set_id_type(osmium::item_type::node);
@@ -545,7 +546,7 @@ void output_flex_t::setup_id_columns(flex_table_t *table)
         table->set_id_type(osmium::item_type::area);
     } else if (type == "any") {
         table->set_id_type(osmium::item_type::undefined);
-        lua_getfield(lua_state(), -2, "type_column");
+        lua_getfield(lua_state(), -1, "type_column");
         if (lua_isstring(lua_state(), -1)) {
             std::string const column_name =
                 lua_tolstring(lua_state(), -1, nullptr);
@@ -555,18 +556,19 @@ void output_flex_t::setup_id_columns(flex_table_t *table)
         } else if (!lua_isnil(lua_state(), -1)) {
             throw std::runtime_error{"type_column must be a string or nil."};
         }
-        lua_pop(lua_state(), 1); // type_column
+        lua_pop(lua_state(), 1); // "type_column"
     } else {
         throw fmt_error("Unknown ids type: {}.", type);
     }
 
     std::string const name =
-        luaX_get_table_string(lua_state(), "id_column", -2, "The ids field");
+        luaX_get_table_string(lua_state(), "id_column", -1, "The ids field");
+    lua_pop(lua_state(), 1); // "id_column"
     check_identifier(name, "column names");
 
     auto &column = table->add_column(name, "id_num", "");
     column.set_not_null();
-    lua_pop(lua_state(), 3); // id_column, type, ids
+    lua_pop(lua_state(), 1); // "ids"
 }
 
 void output_flex_t::setup_flex_table_columns(flex_table_t *table)

--- a/tests/bdd/steps/steps_db.py
+++ b/tests/bdd/steps/steps_db.py
@@ -121,6 +121,12 @@ def table_exists(conn, table):
     num = scalar(conn, """SELECT count(*) FROM pg_tables
                           WHERE tablename = %s AND schemaname = %s""",
                 (tablename, schema))
+    if num == 1:
+        return True
+
+    num = scalar(conn, """SELECT count(*) FROM pg_views
+                          WHERE viewname = %s AND schemaname = %s""",
+                (tablename, schema))
     return num == 1
 
 


### PR DESCRIPTION
If the user always needs the id index, they can force the index build even in non-slim (or slim+drop) mode by setting the `create_index` option of the `ids` setting in the define_table() Lua command to `always`. The default is `autpo` which means: Only build the index in slim mode.

See #1854

The test runner (`steps_db.py`) has been extended so that the table_exists() check also checks for views, so that we can access the data in the `pg_catalog.pg_indexes` view.