### PR TITLE
Correctly apply middle-schema parameter in replication script

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -6,6 +6,17 @@ jobs:
   ubuntu-test-install:
     runs-on: ubuntu-20.04
 
+    strategy:
+      matrix:
+        flavour: [public, middle_schema]
+        include:
+          - flavour: public
+            options: ""
+            schema: ""
+          - flavour: middle_schema
+            options: "--middle-schema=myschema"
+            schema: "myschema"
+
     env:
       LUA_VERSION: 5.3
       POSTGRESQL_VERSION: 12
@@ -75,8 +86,16 @@ jobs:
           sudo systemctl start postgresql
           sudo -u postgres createuser runner
           sudo -u postgres createdb -O runner o2ptest
-          sudo -u postgres psql o2ptest -c "CREATE EXTENSION postgis;"
-          sudo -u postgres psql o2ptest -c "CREATE EXTENSION hstore;"
+          sudo -u postgres psql o2ptest -c "CREATE EXTENSION postgis"
+          sudo -u postgres psql o2ptest -c "CREATE EXTENSION hstore"
+
+      - name: Set up schema
+        run: |
+          sudo -u postgres psql o2ptest -c "CREATE SCHEMA $SCHEMANAME"
+          sudo -u postgres psql o2ptest -c "GRANT ALL ON SCHEMA $SCHEMANAME TO runner"
+        if: ${{ matrix.schema }}
+        env:
+          SCHEMANAME: ${{ matrix.schema }}
 
       - name: Remove repository
         # Remove contents of workspace to be sure the install runs independently
@@ -92,15 +111,18 @@ jobs:
         run: wget --quiet $OSMURL
         working-directory: /tmp
 
-      - name: Test run of osm2pgsql
-        run: $PREFIX/bin/osm2pgsql -d o2ptest --slim $OSMFILE
+      - name: Test run of osm2pgsql (no schema)
+        run: $PREFIX/bin/osm2pgsql $EXTRAOPTS -d o2ptest --slim $OSMFILE
         working-directory: /tmp
+        env:
+          EXTRAOPTS: ${{ matrix.options }}
 
-      - name: Test run osm2pgsql-replication
+      - name: Test run osm2pgsql-replication (no schema)
         run: |
-          $PREFIX/bin/osm2pgsql-replication init -v -d o2ptest
-          $PREFIX/bin/osm2pgsql-replication status -v -d o2ptest
-          $PREFIX/bin/osm2pgsql-replication update -v -d o2ptest --once --max-diff-size=1
-          $PREFIX/bin/osm2pgsql-replication status -v -d o2ptest --json
+          $PREFIX/bin/osm2pgsql-replication init $EXTRAOPTS -v -d o2ptest
+          $PREFIX/bin/osm2pgsql-replication status $EXTRAOPTS -v -d o2ptest
+          $PREFIX/bin/osm2pgsql-replication update $EXTRAOPTS -v -d o2ptest --once --max-diff-size=1
+          $PREFIX/bin/osm2pgsql-replication status $EXTRAOPTS -v -d o2ptest --json
         working-directory: /tmp
-
+        env:
+          EXTRAOPTS: ${{ matrix.options }}

--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -383,6 +383,8 @@ def update(conn, args):
 
     osm2pgsql = [args.osm2pgsql_cmd, '--append', '--slim', '--prefix', args.prefix]
     osm2pgsql.extend(args.extra_params)
+    if args.middle_schema != 'public':
+        osm2pgsql.extend(('--middle-schema', args.middle_schema))
     if args.database:
         osm2pgsql.extend(('-d', args.database))
     if args.username:

--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -95,14 +95,14 @@ def table_exists(conn, table_name, schema_name=None):
         return cur.rowcount > 0
 
 
-def compute_database_date(conn, prefix):
+def compute_database_date(conn, schema, prefix):
     """ Determine the date of the database from the newest object in the
         database.
     """
     # First, find the way with the highest ID in the database
     # Using nodes would be more reliable but those are not cached by osm2pgsql.
     with conn.cursor() as cur:
-        table = sql.Identifier(f'{prefix}_ways')
+        table = sql.Identifier(schema, f'{prefix}_ways')
         cur.execute(sql.SQL("SELECT max(id) FROM {}").format(table))
         osmid = cur.fetchone()[0] if cur.rowcount == 1 else None
 
@@ -290,7 +290,7 @@ def init(conn, args):
     this with the `--server` parameter.
     """
     if args.osm_file is None:
-        date = compute_database_date(conn, args.prefix)
+        date = compute_database_date(conn, args.middle_schema, args.prefix)
         if date is None:
             return 1
 


### PR DESCRIPTION
The parameter needs to be used, when querying the middle way table and needs to be forwarded to osm2pgsql when updating.

Adds a test installation with middle schema to the CI.

Fixes #1818.
