### PR TITLE
Add row insert and not-null error counter to tables

### DIFF
--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -421,4 +421,7 @@ void table_connection_t::task_wait()
     auto const run_time = m_task_result.wait();
     log_info("All postprocessing on table '{}' done in {}.", table().name(),
              util::human_readable_duration(run_time));
+    log_debug("Inserted {} rows into table '{}' ({} not inserted due to"
+              " NOT NULL constraints).",
+              m_count_insert, table().name(), m_count_not_null_error);
 }

--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -273,6 +273,13 @@ public:
 
     void task_wait();
 
+    void increment_insert_counter() noexcept { ++m_count_insert; }
+
+    void increment_not_null_error_counter() noexcept
+    {
+        ++m_count_not_null_error;
+    }
+
 private:
     std::shared_ptr<reprojection> m_proj;
 
@@ -290,6 +297,9 @@ private:
     std::unique_ptr<pg_conn_t> m_db_connection;
 
     task_result_t m_task_result;
+
+    std::size_t m_count_insert = 0;
+    std::size_t m_count_not_null_error = 0;
 
     /// Has the Id index already been created?
     bool m_id_index_created = false;

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -693,6 +693,7 @@ int output_flex_t::table_insert()
                 flex_write_column(lua_state(), copy_mgr, column, &m_expire);
             }
         }
+        table_connection.increment_insert_counter();
     } catch (not_null_exception const &e) {
         copy_mgr->rollback_line();
         lua_pushboolean(lua_state(), false);
@@ -700,6 +701,7 @@ int output_flex_t::table_insert()
         lua_pushstring(lua_state(), e.column().name().c_str());
         push_osm_object_to_lua_stack(lua_state(), object,
                                      get_options()->extra_attributes);
+        table_connection.increment_not_null_error_counter();
         return 4;
     }
 


### PR DESCRIPTION
Count for each table how many rows were inserted and how many were not inserted due to a NOT NULL constraint. Write out those counters to the debug log.