### PR TITLE
Don't process objects without tags in pgsql/flex output in append mode

### DIFF
--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -61,9 +61,15 @@ void osmdata_t::node(osmium::Node const &node)
         return;
     }
 
+    bool const has_tags_or_attrs = m_with_extra_attrs || !node.tags().empty();
     if (m_append) {
-        node_modify(node);
-    } else if (m_with_extra_attrs || !node.tags().empty()) {
+        if (has_tags_or_attrs) {
+            m_output->node_modify(node);
+        } else {
+            m_output->node_delete(node.id());
+        }
+        m_dependency_manager->node_changed(node.id());
+    } else if (has_tags_or_attrs) {
         m_output->node_add(node);
     }
 }
@@ -83,9 +89,15 @@ void osmdata_t::way(osmium::Way &way)
         return;
     }
 
+    bool const has_tags_or_attrs = m_with_extra_attrs || !way.tags().empty();
     if (m_append) {
-        way_modify(&way);
-    } else if (m_with_extra_attrs || !way.tags().empty()) {
+        if (has_tags_or_attrs) {
+            m_output->way_modify(&way);
+        } else {
+            m_output->way_delete(way.id());
+        }
+        m_dependency_manager->way_changed(way.id());
+    } else if (has_tags_or_attrs) {
         m_output->way_add(&way);
     }
 }
@@ -115,43 +127,20 @@ void osmdata_t::relation(osmium::Relation const &rel)
         m_output->relation_delete(rel.id());
         return;
     }
+
+    bool const has_tags_or_attrs = m_with_extra_attrs || !rel.tags().empty();
     if (m_append) {
-        relation_modify(rel);
-    } else if (m_with_extra_attrs || !rel.tags().empty()) {
+        if (has_tags_or_attrs) {
+            m_output->relation_modify(rel);
+        } else {
+            m_output->relation_delete(rel.id());
+        }
+    } else if (has_tags_or_attrs) {
         m_output->relation_add(rel);
     }
 }
 
 void osmdata_t::after_relations() { m_mid->after_relations(); }
-
-void osmdata_t::node_modify(osmium::Node const &node) const
-{
-    if (m_with_extra_attrs || !node.tags().empty()) {
-        m_output->node_modify(node);
-    } else {
-        m_output->node_delete(node.id());
-    }
-    m_dependency_manager->node_changed(node.id());
-}
-
-void osmdata_t::way_modify(osmium::Way *way) const
-{
-    if (m_with_extra_attrs || !way->tags().empty()) {
-        m_output->way_modify(way);
-    } else {
-        m_output->way_delete(way->id());
-    }
-    m_dependency_manager->way_changed(way->id());
-}
-
-void osmdata_t::relation_modify(osmium::Relation const &rel) const
-{
-    if (m_with_extra_attrs || !rel.tags().empty()) {
-        m_output->relation_modify(rel);
-    } else {
-        m_output->relation_delete(rel.id());
-    }
-}
 
 void osmdata_t::start() const
 {

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -145,19 +145,31 @@ void osmdata_t::relation_add(osmium::Relation const &rel) const
 
 void osmdata_t::node_modify(osmium::Node const &node) const
 {
-    m_output->node_modify(node);
+    if (m_with_extra_attrs || !node.tags().empty()) {
+        m_output->node_modify(node);
+    } else {
+        m_output->node_delete(node.id());
+    }
     m_dependency_manager->node_changed(node.id());
 }
 
 void osmdata_t::way_modify(osmium::Way *way) const
 {
-    m_output->way_modify(way);
+    if (m_with_extra_attrs || !way->tags().empty()) {
+        m_output->way_modify(way);
+    } else {
+        m_output->way_delete(way->id());
+    }
     m_dependency_manager->way_changed(way->id());
 }
 
 void osmdata_t::relation_modify(osmium::Relation const &rel) const
 {
-    m_output->relation_modify(rel);
+    if (m_with_extra_attrs || !rel.tags().empty()) {
+        m_output->relation_modify(rel);
+    } else {
+        m_output->relation_delete(rel.id());
+    }
 }
 
 void osmdata_t::node_delete(osmid_t id) const

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -58,12 +58,13 @@ void osmdata_t::node(osmium::Node const &node)
 
     if (node.deleted()) {
         m_output->node_delete(node.id());
-    } else {
-        if (m_append) {
-            node_modify(node);
-        } else {
-            node_add(node);
-        }
+        return;
+    }
+
+    if (m_append) {
+        node_modify(node);
+    } else if (m_with_extra_attrs || !node.tags().empty()) {
+        m_output->node_add(node);
     }
 }
 
@@ -79,12 +80,13 @@ void osmdata_t::way(osmium::Way &way)
 
     if (way.deleted()) {
         m_output->way_delete(way.id());
-    } else {
-        if (m_append) {
-            way_modify(&way);
-        } else {
-            way_add(&way);
-        }
+        return;
+    }
+
+    if (m_append) {
+        way_modify(&way);
+    } else if (m_with_extra_attrs || !way.tags().empty()) {
+        m_output->way_add(&way);
     }
 }
 
@@ -111,37 +113,16 @@ void osmdata_t::relation(osmium::Relation const &rel)
 
     if (rel.deleted()) {
         m_output->relation_delete(rel.id());
-    } else {
-        if (m_append) {
-            relation_modify(rel);
-        } else {
-            relation_add(rel);
-        }
+        return;
+    }
+    if (m_append) {
+        relation_modify(rel);
+    } else if (m_with_extra_attrs || !rel.tags().empty()) {
+        m_output->relation_add(rel);
     }
 }
 
 void osmdata_t::after_relations() { m_mid->after_relations(); }
-
-void osmdata_t::node_add(osmium::Node const &node) const
-{
-    if (m_with_extra_attrs || !node.tags().empty()) {
-        m_output->node_add(node);
-    }
-}
-
-void osmdata_t::way_add(osmium::Way *way) const
-{
-    if (m_with_extra_attrs || !way->tags().empty()) {
-        m_output->way_add(way);
-    }
-}
-
-void osmdata_t::relation_add(osmium::Relation const &rel) const
-{
-    if (m_with_extra_attrs || !rel.tags().empty()) {
-        m_output->relation_add(rel);
-    }
-}
 
 void osmdata_t::node_modify(osmium::Node const &node) const
 {

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -57,7 +57,7 @@ void osmdata_t::node(osmium::Node const &node)
     m_mid->node(node);
 
     if (node.deleted()) {
-        node_delete(node.id());
+        m_output->node_delete(node.id());
     } else {
         if (m_append) {
             node_modify(node);
@@ -78,7 +78,7 @@ void osmdata_t::way(osmium::Way &way)
     m_mid->way(way);
 
     if (way.deleted()) {
-        way_delete(way.id());
+        m_output->way_delete(way.id());
     } else {
         if (m_append) {
             way_modify(&way);
@@ -110,7 +110,7 @@ void osmdata_t::relation(osmium::Relation const &rel)
     m_mid->relation(rel);
 
     if (rel.deleted()) {
-        relation_delete(rel.id());
+        m_output->relation_delete(rel.id());
     } else {
         if (m_append) {
             relation_modify(rel);
@@ -170,21 +170,6 @@ void osmdata_t::relation_modify(osmium::Relation const &rel) const
     } else {
         m_output->relation_delete(rel.id());
     }
-}
-
-void osmdata_t::node_delete(osmid_t id) const
-{
-    m_output->node_delete(id);
-}
-
-void osmdata_t::way_delete(osmid_t id) const
-{
-    m_output->way_delete(id);
-}
-
-void osmdata_t::relation_delete(osmid_t id) const
-{
-    m_output->relation_delete(id);
 }
 
 void osmdata_t::start() const

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -69,10 +69,6 @@ private:
     void way_modify(osmium::Way *way) const;
     void relation_modify(osmium::Relation const &rel) const;
 
-    void node_delete(osmid_t id) const;
-    void way_delete(osmid_t id) const;
-    void relation_delete(osmid_t id) const;
-
     /**
      * Run stage 1b and stage 1c processing: Process dependent objects in
      * append mode.

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -61,10 +61,6 @@ public:
     void stop() const;
 
 private:
-    void node_add(osmium::Node const &node) const;
-    void way_add(osmium::Way *way) const;
-    void relation_add(osmium::Relation const &rel) const;
-
     void node_modify(osmium::Node const &node) const;
     void way_modify(osmium::Way *way) const;
     void relation_modify(osmium::Relation const &rel) const;

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -61,10 +61,6 @@ public:
     void stop() const;
 
 private:
-    void node_modify(osmium::Node const &node) const;
-    void way_modify(osmium::Way *way) const;
-    void relation_modify(osmium::Relation const &rel) const;
-
     /**
      * Run stage 1b and stage 1c processing: Process dependent objects in
      * append mode.

--- a/tests/test-parse-osmium.cpp
+++ b/tests/test-parse-osmium.cpp
@@ -205,8 +205,8 @@ TEST_CASE("parse diff file")
                         output, "008-ch.osc.gz", false);
 
     REQUIRE(output->node.added == 0);
-    REQUIRE(output->node.modified == 1176);
-    REQUIRE(output->node.deleted == 16773);
+    REQUIRE(output->node.modified == 153);
+    REQUIRE(output->node.deleted == 17796);
     REQUIRE(output->way.added == 0);
     REQUIRE(output->way.modified == 161);
     REQUIRE(output->way.deleted == 4);


### PR DESCRIPTION
These were already not processed in create mode. In append mode we do need to remove any rows with those ids in the output tables, but we don't have to create new rows in any tables.