### PR TITLE
Remove input file from BDD test context when reading inline OSM data

### DIFF
--- a/tests/bdd/steps/steps_osm_data.py
+++ b/tests/bdd/steps/steps_osm_data.py
@@ -31,6 +31,7 @@ def osm_define_node_grid(context, step, origin_x, origin_y):
 
 @given("the (?P<formatted>python-formatted )?OSM data")
 def osm_define_data(context, formatted):
+    context.import_file = None
     data = context.text
     if formatted:
         data = eval('f"""' + data + '"""')


### PR DESCRIPTION
If an input file was read first and in another step inline OSM data, the context still knew about the file and re-read it.