### PR TITLE
Add tilesets to flex output allowing more flexible expire configuration

### DIFF
--- a/flex-config/tilesets.lua
+++ b/flex-config/tilesets.lua
@@ -1,0 +1,168 @@
+-- This config example file is released into the Public Domain.
+--
+-- This examples shows how to use tilesets for expire.
+
+local tilesets = {}
+
+tilesets.pois = osm2pgsql.define_tileset({
+    -- Every tileset must have a name. The name is independent of the table
+    -- names although this example file uses the same name for simplicity.
+    name = 'pois',
+    -- The zoom level at which we calculate the tiles. This must always be set.
+    maxzoom = 14,
+    -- The filename where tile list should be written to.
+    filename = 'pois.tiles'
+})
+
+tilesets.lines = osm2pgsql.define_tileset({
+    name = 'lines',
+    maxzoom = 14,
+    -- Instead of writing the tile list to a file, it can be written to a table.
+    -- The table will be created if it isn't there already.
+    table = 'lines_tiles',
+--    schema = 'myschema', -- You can also set a database schema.
+})
+
+tilesets.polygons = osm2pgsql.define_tileset({
+    name = 'polygons',
+    -- You can also set a minimum zoom level in addition to the maximum zoom
+    -- level. Tiles in all zoom levels between those two will be written out.
+    minzoom = 10,
+    maxzoom = 14,
+    table = 'polygons_tiles'
+})
+
+print("Tilesets:(")
+for name, ts in pairs(tilesets) do
+    print("  " .. name
+          .. ": name=".. ts:name()
+          .. " minzoom=" .. ts:minzoom()
+          .. " maxzoom=" .. ts:maxzoom()
+          .. " filename=" .. ts:filename()
+          .. " schema=" .. ts:schema()
+          .. " table=" .. ts:table()
+          .. " (" .. tostring(ts) .. ")")
+end
+print(")")
+
+local tables = {}
+
+tables.pois = osm2pgsql.define_node_table('pois', {
+    { column = 'tags', type = 'jsonb' },
+    -- Zero, one or more tilesets are referenced in an `expire` field in
+    -- the definition of any geometry column using the Web Mercator (3857)
+    -- projection.
+    { column = 'geom', type = 'point', not_null = true, expire = { { tileset = 'pois' } } },
+})
+
+tables.lines = osm2pgsql.define_way_table('lines', {
+    { column = 'tags', type = 'jsonb' },
+    { column = 'geom', type = 'linestring', not_null = true, expire = { { tileset = 'lines' } } },
+})
+
+tables.polygons = osm2pgsql.define_area_table('polygons', {
+    { column = 'tags', type = 'jsonb' },
+    -- In this configuration the `mode` of the expiry is set to `boundary-only`.
+    -- Other modes are `full-area` (default) and `hybrid`. If set to `hybrid`
+    -- you can set `full_area_limit` to a value in Web Mercator units. For
+    -- polygons where the width and height of the bounding box is below this
+    -- limit the full area is expired, for larger polygons only the boundary.
+    -- This setting doesn't have any effect on point or linestring geometries.
+    { column = 'geom', type = 'geometry', not_null = true, expire = { { tileset = 'polygons', mode = 'boundary-only' } } },
+})
+
+tables.boundaries = osm2pgsql.define_relation_table('boundaries', {
+    { column = 'type', type = 'text' },
+    { column = 'tags', type = 'jsonb' },
+    -- This geometry column doesn't have an `expire` field, so no expiry is
+    -- done.
+    { column = 'geom', type = 'multilinestring', not_null = true },
+})
+
+print("Tables:(")
+for name, ts in pairs(tables) do
+    print("  " .. name .. ": name=" .. ts:name() .. " (" .. tostring(ts) .. ")")
+end
+print(")")
+
+-- Helper function that looks at the tags and decides if this is possibly
+-- an area.
+function has_area_tags(tags)
+    if tags.area == 'yes' then
+        return true
+    end
+    if tags.area == 'no' then
+        return false
+    end
+
+    return tags.aeroway
+        or tags.amenity
+        or tags.building
+        or tags.harbour
+        or tags.historic
+        or tags.landuse
+        or tags.leisure
+        or tags.man_made
+        or tags.military
+        or tags.natural
+        or tags.office
+        or tags.place
+        or tags.power
+        or tags.public_transport
+        or tags.shop
+        or tags.sport
+        or tags.tourism
+        or tags.water
+        or tags.waterway
+        or tags.wetland
+        or tags['abandoned:aeroway']
+        or tags['abandoned:amenity']
+        or tags['abandoned:building']
+        or tags['abandoned:landuse']
+        or tags['abandoned:power']
+        or tags['area:highway']
+end
+
+function osm2pgsql.process_node(object)
+    tables.pois:insert({
+        tags = object.tags,
+        geom = object:as_point()
+    })
+end
+
+function osm2pgsql.process_way(object)
+    if object.is_closed and has_area_tags(object.tags) then
+        tables.polygons:insert({
+            tags = object.tags,
+            geom = object:as_polygon()
+        })
+    else
+        tables.lines:insert({
+            tags = object.tags,
+            geom = object:as_linestring()
+        })
+    end
+end
+
+function osm2pgsql.process_relation(object)
+    local relation_type = object:grab_tag('type')
+
+    -- Store boundary relations as multilinestrings
+    if relation_type == 'boundary' then
+        tables.boundaries:insert({
+            type = object:grab_tag('boundary'),
+            tags = object.tags,
+            geom = object:as_multilinestring():line_merge()
+        })
+        return
+    end
+
+    -- Store multipolygon relations as polygons
+    if relation_type == 'multipolygon' then
+        tables.polygons:insert({
+            tags = object.tags,
+            geom = object:as_multipolygon()
+        })
+    end
+end
+

--- a/flex-config/tilesets.lua
+++ b/flex-config/tilesets.lua
@@ -57,7 +57,9 @@ tables.pois = osm2pgsql.define_node_table('pois', {
 
 tables.lines = osm2pgsql.define_way_table('lines', {
     { column = 'tags', type = 'jsonb' },
-    { column = 'geom', type = 'linestring', not_null = true, expire = { { tileset = 'lines' } } },
+    -- If you only have a single tileset you want to expire into and with
+    -- the defalt parameters, you can specify it directly.
+    { column = 'geom', type = 'linestring', not_null = true, expire = 'lines' },
 })
 
 tables.polygons = osm2pgsql.define_area_table('polygons', {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,9 +50,11 @@ if (WITH_LUA)
         flex-index.cpp
         flex-table.cpp
         flex-table-column.cpp
+        flex-tileset.cpp
         flex-lua-geom.cpp
         flex-lua-index.cpp
         flex-lua-table.cpp
+        flex-lua-tileset.cpp
         flex-write.cpp
         geom-transform.cpp
         lua-utils.cpp

--- a/src/expire-config.hpp
+++ b/src/expire-config.hpp
@@ -14,7 +14,7 @@
 
 enum class expire_mode
 {
-    full_area, // Expire all tiles covered by polygon.
+    full_area,     // Expire all tiles covered by polygon.
     boundary_only, // Expire only tiles covered by polygon boundary.
     hybrid // "full_area" or "boundary_only" mode depending on full_area_limit.
 };
@@ -24,6 +24,12 @@ enum class expire_mode
  */
 struct expire_config_t
 {
+    /**
+     * The id of the tile set where expired tiles are collected.
+     * Only used in the flex output.
+     */
+    std::size_t tileset = 0;
+
     /// Buffer around expired feature as fraction of the tile size.
     double buffer = 0.1;
 

--- a/src/expire-tiles.cpp
+++ b/src/expire-tiles.cpp
@@ -325,7 +325,8 @@ std::size_t output_tiles_to_table(quadkey_list_t const &tiles_at_maxzoom,
     pg_conn_t connection{conninfo};
 
     connection.exec("PREPARE insert_tiles(int4, int4, int4) AS"
-                    " INSERT INTO {} (zoom, x, y) VALUES ($1, $2, $3)",
+                    " INSERT INTO {} (zoom, x, y) VALUES ($1, $2, $3)"
+                    " ON CONFLICT DO NOTHING",
                     qn);
 
     auto const count = for_each_tile(

--- a/src/expire-tiles.hpp
+++ b/src/expire-tiles.hpp
@@ -31,6 +31,8 @@ class expire_tiles
 public:
     expire_tiles(uint32_t max_zoom, std::shared_ptr<reprojection> projection);
 
+    bool empty() const noexcept { return m_dirty_tiles.empty(); }
+
     bool enabled() const noexcept { return m_maxzoom != 0; }
 
     void from_polygon_boundary(geom::polygon_t const &geom,
@@ -85,7 +87,6 @@ public:
     void merge_and_destroy(expire_tiles *other);
 
 private:
-
     /**
      * Converts from target coordinates to tile coordinates.
      */
@@ -195,5 +196,22 @@ std::size_t for_each_tile(quadkey_list_t const &tiles_at_maxzoom,
 std::size_t output_tiles_to_file(quadkey_list_t const &tiles_at_maxzoom,
                                  uint32_t minzoom, uint32_t maxzoom,
                                  std::string_view filename);
+
+/**
+ * Write the list of tiles to a database table. The table will be created
+ * if it doesn't exist already.
+ *
+ * \param tiles_at_maxzoom The list of tiles at maximum zoom level
+ * \param minzoom Minimum zoom level
+ * \param maxzoom Maximum zoom level
+ * \param conninfo database connection info
+ * \param schema The schema the table is in (empty for public schema)
+ * \param table The table name
+ */
+std::size_t output_tiles_to_table(quadkey_list_t const &tiles_at_maxzoom,
+                                  uint32_t minzoom, uint32_t maxzoom,
+                                  std::string const &conninfo,
+                                  std::string const &schema,
+                                  std::string const &table);
 
 #endif // OSM2PGSQL_EXPIRE_TILES_HPP

--- a/src/flex-lua-table.cpp
+++ b/src/flex-lua-table.cpp
@@ -184,11 +184,23 @@ static void parse_and_set_expire_options(lua_State *lua_state,
                                          std::vector<flex_tileset_t> *tilesets,
                                          bool append_mode)
 {
-    if (lua_isnil(lua_state, -1)) {
+    auto const type = lua_type(lua_state, -1);
+
+    if (type == LUA_TNIL) {
         return;
     }
 
-    if (!lua_istable(lua_state, -1)) {
+    if (type == LUA_TSTRING) {
+        auto ts = find_tileset(*tilesets, lua_tostring(lua_state, -1));
+        expire_config_t config{ts};
+        // Actually add the expire only if we are in append mode.
+        if (append_mode) {
+            column->add_expire(config);
+        }
+        return;
+    }
+
+    if (type != LUA_TTABLE) {
         throw std::runtime_error{"Expire field must be a Lua array table"};
     }
 

--- a/src/flex-lua-table.hpp
+++ b/src/flex-lua-table.hpp
@@ -13,11 +13,13 @@
 #include <vector>
 
 class flex_table_t;
+class flex_tileset_t;
 struct lua_State;
 
 static char const *const osm2pgsql_table_name = "osm2pgsql.Table";
 
 int setup_flex_table(lua_State *lua_state, std::vector<flex_table_t> *tables,
-                     bool updatable);
+                     std::vector<flex_tileset_t> *tilesets, bool updatable,
+                     bool append_mode);
 
 #endif // OSM2PGSQL_FLEX_LUA_TABLE_HPP

--- a/src/flex-lua-tileset.cpp
+++ b/src/flex-lua-tileset.cpp
@@ -68,11 +68,11 @@ create_flex_tileset(lua_State *lua_state, std::vector<flex_tileset_t> *tilesets)
     // optional "minzoom" field
     value = luaX_get_table_optional_uint32(lua_state, "minzoom", -1,
                                            "The 'minzoom' field in a tileset");
-    if (value >= 1 && value <= 20) {
+    if (value >= 1 && value <= new_tileset.maxzoom()) {
         new_tileset.set_minzoom(value);
     } else if (value != 0) {
         throw std::runtime_error{
-            "Value of 'minzoom' field must be between 1 and 20."};
+            "Value of 'minzoom' field must be between 1 and 'maxzoom'."};
     }
     lua_pop(lua_state, 1); // "minzoom"
 

--- a/src/flex-lua-tileset.cpp
+++ b/src/flex-lua-tileset.cpp
@@ -1,0 +1,99 @@
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2023 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+#include "flex-lua-tileset.hpp"
+#include "flex-tileset.hpp"
+#include "format.hpp"
+#include "lua-utils.hpp"
+#include "pgsql.hpp"
+#include "util.hpp"
+
+#include <lua.hpp>
+
+static flex_tileset_t &
+create_flex_tileset(lua_State *lua_state, std::vector<flex_tileset_t> *tilesets)
+{
+    std::string const tileset_name =
+        luaX_get_table_string(lua_state, "name", -1, "The tileset");
+
+    check_identifier(tileset_name, "tileset names");
+
+    if (util::find_by_name(*tilesets, tileset_name)) {
+        throw fmt_error("Tileset with name '{}' already exists.", tileset_name);
+    }
+
+    auto &new_tileset = tilesets->emplace_back(tileset_name);
+
+    lua_pop(lua_state, 1); // "name"
+
+    // optional "filename" field
+    auto const *filename =
+        luaX_get_table_string(lua_state, "filename", -1, "The tileset", "");
+    new_tileset.set_filename(filename);
+    lua_pop(lua_state, 1); // "filename"
+
+    // optional "schema" and "table" fields
+    auto const *schema =
+        luaX_get_table_string(lua_state, "schema", -1, "The tileset", "");
+    check_identifier(schema, "schema field");
+    auto const *table =
+        luaX_get_table_string(lua_state, "table", -2, "The tileset", "");
+    check_identifier(table, "table field");
+    new_tileset.set_schema_and_table(schema, table);
+    lua_pop(lua_state, 2); // "schema" and "table"
+
+    if (new_tileset.filename().empty() && new_tileset.table().empty()) {
+        throw fmt_error("Must set 'filename' and/or 'table' on tileset '{}'.",
+                        new_tileset.name());
+    }
+
+    // required "maxzoom" field
+    auto value = luaX_get_table_optional_uint32(
+        lua_state, "maxzoom", -1, "The 'maxzoom' field in a tileset");
+    if (value >= 1 && value <= 20) {
+        new_tileset.set_minzoom(value);
+        new_tileset.set_maxzoom(value);
+    } else {
+        throw std::runtime_error{
+            "Value of 'maxzoom' field must be between 1 and 20."};
+    }
+    lua_pop(lua_state, 1); // "maxzoom"
+
+    // optional "minzoom" field
+    value = luaX_get_table_optional_uint32(lua_state, "minzoom", -1,
+                                           "The 'minzoom' field in a tileset");
+    if (value >= 1 && value <= 20) {
+        new_tileset.set_minzoom(value);
+    } else if (value != 0) {
+        throw std::runtime_error{
+            "Value of 'minzoom' field must be between 1 and 20."};
+    }
+    lua_pop(lua_state, 1); // "minzoom"
+
+    return new_tileset;
+}
+
+int setup_flex_tileset(lua_State *lua_state,
+                       std::vector<flex_tileset_t> *tilesets)
+{
+    if (lua_type(lua_state, 1) != LUA_TTABLE) {
+        throw std::runtime_error{
+            "Argument #1 to 'define_tileset' must be a Lua table."};
+    }
+
+    create_flex_tileset(lua_state, tilesets);
+
+    void *ptr = lua_newuserdata(lua_state, sizeof(std::size_t));
+    auto *num = new (ptr) std::size_t{};
+    *num = tilesets->size() - 1;
+    luaL_getmetatable(lua_state, osm2pgsql_tileset_name);
+    lua_setmetatable(lua_state, -2);
+
+    return 1;
+}

--- a/src/flex-lua-tileset.hpp
+++ b/src/flex-lua-tileset.hpp
@@ -1,0 +1,22 @@
+#ifndef OSM2PGSQL_FLEX_LUA_TILESET_HPP
+#define OSM2PGSQL_FLEX_LUA_TILESET_HPP
+
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2023 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+#include "flex-tileset.hpp"
+
+struct lua_State;
+
+static char const *const osm2pgsql_tileset_name = "osm2pgsql.Tileset";
+
+int setup_flex_tileset(lua_State *lua_state,
+                       std::vector<flex_tileset_t> *tilesets);
+
+#endif // OSM2PGSQL_FLEX_LUA_TILESET_HPP

--- a/src/flex-table-column.cpp
+++ b/src/flex-table-column.cpp
@@ -191,3 +191,20 @@ std::string flex_table_column_t::sql_create() const
     return fmt::format(R"("{}" {} {})", m_name, sql_type_name(),
                        sql_modifiers());
 }
+
+void flex_table_column_t::add_expire(expire_config_t const &config)
+{
+    assert(is_geometry_column());
+    assert(srid() == 3857);
+    m_expires.push_back(config);
+}
+
+void flex_table_column_t::do_expire(geom::geometry_t const &geom,
+                                    std::vector<expire_tiles> *expire) const
+{
+    assert(expire);
+    for (auto const &expire_config : m_expires) {
+        assert(expire_config.tileset < expire->size());
+        (*expire)[expire_config.tileset].from_geometry(geom, expire_config);
+    }
+}

--- a/src/flex-table-column.hpp
+++ b/src/flex-table-column.hpp
@@ -10,9 +10,14 @@
  * For a full list of authors see the git log.
  */
 
+#include "expire-config.hpp"
+#include "expire-tiles.hpp"
+#include "geom.hpp"
+
 #include <cassert>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 enum class table_column_type : uint8_t
 {
@@ -118,7 +123,21 @@ public:
 
     int srid() const noexcept { return m_srid; }
 
+    void add_expire(expire_config_t const &config);
+
+    bool has_expire() const noexcept { return !m_expires.empty(); }
+
+    std::vector<expire_config_t> const &expire_configs() const noexcept
+    {
+        return m_expires;
+    }
+
+    void do_expire(geom::geometry_t const &geom,
+                   std::vector<expire_tiles> *expire) const;
+
 private:
+    std::vector<expire_config_t> m_expires;
+
     /// The name of the database table column.
     std::string m_name;
 

--- a/src/flex-tileset.cpp
+++ b/src/flex-tileset.cpp
@@ -1,0 +1,26 @@
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2023 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+#include "expire-tiles.hpp"
+#include "flex-tileset.hpp"
+
+std::size_t flex_tileset_t::output(quadkey_list_t const &tile_list,
+                                   std::string const &conninfo) const
+{
+    std::size_t num = 0;
+    if (!m_filename.empty()) {
+        num = output_tiles_to_file(tile_list, m_minzoom, m_maxzoom,
+                                   m_filename.c_str());
+    }
+    if (!m_table.empty()) {
+        num = output_tiles_to_table(tile_list, m_minzoom, m_maxzoom, conninfo,
+                                    m_schema, m_table);
+    }
+    return num;
+}

--- a/src/flex-tileset.hpp
+++ b/src/flex-tileset.hpp
@@ -1,0 +1,76 @@
+#ifndef OSM2PGSQL_FLEX_TILESET_HPP
+#define OSM2PGSQL_FLEX_TILESET_HPP
+
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2023 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+#include "tile.hpp"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+/**
+ * A tileset for the flex output. Used for expire.
+ */
+class flex_tileset_t
+{
+public:
+    explicit flex_tileset_t(std::string name) : m_name(std::move(name)) {}
+
+    std::string const &name() const noexcept { return m_name; }
+
+    std::string filename() const noexcept { return m_filename; }
+
+    void set_filename(std::string filename)
+    {
+        m_filename = std::move(filename);
+    }
+
+    std::string schema() const noexcept { return m_schema; }
+
+    std::string table() const noexcept { return m_table; }
+
+    void set_schema_and_table(std::string schema, std::string table)
+    {
+        m_schema = std::move(schema);
+        m_table = std::move(table);
+    }
+
+    uint32_t minzoom() const noexcept { return m_minzoom; }
+    void set_minzoom(uint32_t minzoom) noexcept { m_minzoom = minzoom; }
+
+    uint32_t maxzoom() const noexcept { return m_maxzoom; }
+    void set_maxzoom(uint32_t maxzoom) noexcept { m_maxzoom = maxzoom; }
+
+    std::size_t output(quadkey_list_t const &tile_list,
+                       std::string const &conninfo) const;
+
+private:
+    /// The name of the tileset
+    std::string m_name;
+
+    /// The filename (if any) for output
+    std::string m_filename;
+
+    /// The schema (if any) for output
+    std::string m_schema;
+
+    /// The table (if any) for output
+    std::string m_table;
+
+    /// Minimum zoom level for output
+    uint32_t m_minzoom = 0;
+
+    /// Zoom level we capture tiles on
+    uint32_t m_maxzoom = 0;
+
+}; // class flex_tileset_t
+
+#endif // OSM2PGSQL_FLEX_TILESET_HPP

--- a/src/flex-write.cpp
+++ b/src/flex-write.cpp
@@ -253,8 +253,8 @@ static bool is_compatible(geom::geometry_t const &geom,
 
 void flex_write_column(lua_State *lua_state,
                        db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
-                       flex_table_column_t const &column, expire_tiles *expire,
-                       expire_config_t const &expire_config)
+                       flex_table_column_t const &column,
+                       std::vector<expire_tiles> *expire)
 {
     // If there is nothing on the Lua stack, then the Lua function add_row()
     // was called without a table parameter. In that case this column will
@@ -430,12 +430,12 @@ void flex_write_column(lua_State *lua_state,
                      type == table_column_type::multilinestring ||
                      type == table_column_type::multipolygon);
                 if (geom->srid() == column.srid()) {
-                    expire->from_geometry_if_3857(*geom, expire_config);
+                    column.do_expire(*geom, expire);
                     copy_mgr->add_hex_geom(geom_to_ewkb(*geom, wrap_multi));
                 } else {
                     auto const &proj = get_projection(column.srid());
                     auto const tgeom = geom::transform(*geom, proj);
-                    expire->from_geometry_if_3857(tgeom, expire_config);
+                    column.do_expire(tgeom, expire);
                     copy_mgr->add_hex_geom(geom_to_ewkb(tgeom, wrap_multi));
                 }
             } else {
@@ -462,7 +462,7 @@ void flex_write_column(lua_State *lua_state,
 void flex_write_row(lua_State *lua_state, table_connection_t *table_connection,
                     osmium::item_type id_type, osmid_t id,
                     geom::geometry_t const &geom, int srid,
-                    expire_tiles *expire, expire_config_t const &expire_config)
+                    std::vector<expire_tiles> *expire)
 {
     assert(table_connection);
     table_connection->new_line();
@@ -507,8 +507,7 @@ void flex_write_row(lua_State *lua_state, table_connection_t *table_connection,
                 copy_mgr->add_column(area);
             }
         } else {
-            flex_write_column(lua_state, copy_mgr, column, expire,
-                              expire_config);
+            flex_write_column(lua_state, copy_mgr, column, expire);
         }
     }
 

--- a/src/flex-write.hpp
+++ b/src/flex-write.hpp
@@ -12,7 +12,8 @@
 
 #include "expire-tiles.hpp"
 #include "flex-table.hpp"
-#include "lua.hpp"
+
+#include <lua.hpp>
 
 #include <stdexcept>
 
@@ -32,12 +33,12 @@ private:
 
 void flex_write_column(lua_State *lua_state,
                        db_copy_mgr_t<db_deleter_by_type_and_id_t> *copy_mgr,
-                       flex_table_column_t const &column, expire_tiles *expire,
-                       expire_config_t const &expire_config);
+                       flex_table_column_t const &column,
+                       std::vector<expire_tiles> *expire);
 
 void flex_write_row(lua_State *lua_state, table_connection_t *table_connection,
                     osmium::item_type id_type, osmid_t id,
                     geom::geometry_t const &geom, int srid,
-                    expire_tiles *expire, expire_config_t const &expire_config);
+                    std::vector<expire_tiles> *expire);
 
 #endif // OSM2PGSQL_FLEX_WRITE_HPP

--- a/src/lua-utils.cpp
+++ b/src/lua-utils.cpp
@@ -136,8 +136,9 @@ char const *luaX_get_table_string(lua_State *lua_state, char const *key,
         return default_value;
     }
     if (ltype != LUA_TSTRING) {
-        throw fmt_error("{} field '{}' must be a string field.", error_msg,
-                        key);
+        throw fmt_error("{} field must contain a '{}' string field "
+                        "(or nil for default: '{}').",
+                        error_msg, key, default_value);
     }
     return lua_tostring(lua_state, -1);
 }
@@ -162,6 +163,21 @@ bool luaX_get_table_bool(lua_State *lua_state, char const *key, int table_index,
     throw fmt_error("{} field '{}' must be a boolean field.", error_msg, key);
 }
 
+uint32_t luaX_get_table_optional_uint32(lua_State *lua_state, char const *key,
+                                        int table_index, char const *error_msg)
+{
+    assert(lua_state);
+    assert(key);
+    assert(error_msg);
+    lua_getfield(lua_state, table_index, key);
+    if (lua_isnil(lua_state, -1)) {
+        return 0;
+    }
+    if (!lua_isnumber(lua_state, -1)) {
+        throw fmt_error("{} must contain an integer.", error_msg);
+    }
+    return lua_tonumber(lua_state, -1);
+}
 
 // Lua 5.1 doesn't support luaL_traceback, unless LuaJIT is used
 #if LUA_VERSION_NUM < 502 && !defined(HAVE_LUAJIT)

--- a/src/lua-utils.hpp
+++ b/src/lua-utils.hpp
@@ -60,6 +60,9 @@ char const *luaX_get_table_string(lua_State *lua_state, char const *key,
                                   int table_index, char const *error_msg,
                                   char const *default_value);
 
+uint32_t luaX_get_table_optional_uint32(lua_State *lua_state, char const *key,
+                                        int table_index, char const *error_msg);
+
 bool luaX_get_table_bool(lua_State *lua_state, char const *key, int table_index,
                          char const *error_msg, bool default_value);
 

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1268,6 +1268,7 @@ static void create_tileset_tables(std::vector<flex_tileset_t> const &tilesets,
     }
 
     pg_conn_t connection{conninfo};
+    connection.exec("SET client_min_messages = WARNING");
     for (auto &tileset : tilesets) {
         if (!tileset.table().empty()) {
             auto const qn = qualified_name(tileset.schema(), tileset.table());

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1341,7 +1341,13 @@ output_flex_t::output_flex_t(std::shared_ptr<middle_query_t> const &mid,
 
         for (auto &table : *m_tables) {
             if (table.has_geom_column() && table.geom_column().srid() == 3857) {
-                table.geom_column().add_expire({m_tilesets->size() - 1});
+                expire_config_t config{};
+                config.tileset = m_tilesets->size() - 1;
+                if (options.expire_tiles_max_bbox > 0.0) {
+                    config.mode = expire_mode::hybrid;
+                    config.full_area_limit = options.expire_tiles_max_bbox;
+                }
+                table.geom_column().add_expire(config);
             }
         }
     }

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1275,7 +1275,8 @@ static void create_tileset_tables(std::vector<flex_tileset_t> const &tilesets,
             connection.exec("CREATE TABLE IF NOT EXISTS {} ("
                             " zoom int4 NOT NULL,"
                             " x int4 NOT NULL,"
-                            " y int4 NOT NULL)",
+                            " y int4 NOT NULL,"
+                            " PRIMARY KEY (zoom, x, y))",
                             qn);
         }
     }

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -14,6 +14,7 @@
 #include "expire-tiles.hpp"
 #include "flex-table-column.hpp"
 #include "flex-table.hpp"
+#include "flex-tileset.hpp"
 #include "geom.hpp"
 #include "output.hpp"
 
@@ -162,6 +163,7 @@ public:
     int app_as_geometrycollection();
 
     int app_define_table();
+    int app_define_tileset();
     int app_get_bbox();
     int app_mark_way();
 
@@ -172,6 +174,14 @@ public:
     int table_schema();
     int table_cluster();
     int table_columns();
+
+    int tileset_tostring();
+    int tileset_name();
+    int tileset_minzoom();
+    int tileset_maxzoom();
+    int tileset_filename();
+    int tileset_schema();
+    int tileset_table();
 
 private:
     void select_relation_members();
@@ -191,6 +201,9 @@ private:
 
     // Get the flex table that is as first parameter on the Lua stack.
     flex_table_t const &get_table_from_param();
+
+    // Get the flex tileset that is as first parameter on the Lua stack.
+    flex_tileset_t const &get_tileset_from_param();
 
     void check_context_and_state(char const *name, char const *context,
                                  bool condition);
@@ -273,6 +286,9 @@ private:
     std::shared_ptr<std::vector<flex_table_t>> m_tables =
         std::make_shared<std::vector<flex_table_t>>();
 
+    std::shared_ptr<std::vector<flex_tileset_t>> m_tilesets =
+        std::make_shared<std::vector<flex_tileset_t>>();
+
     std::vector<table_connection_t> m_table_connections;
 
     // This is shared between all clones of the output and must only be
@@ -285,8 +301,7 @@ private:
     // accessed while protected using the lua_mutex.
     std::shared_ptr<lua_State> m_lua_state;
 
-    expire_config_t m_expire_config;
-    expire_tiles m_expire;
+    std::vector<expire_tiles> m_expire_tiles;
 
     way_cache_t m_way_cache;
     relation_cache_t m_relation_cache;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,7 +101,7 @@ if (WITH_LUA)
     set_test(test-output-flex-validgeom)
 
     set_test(test-output-flex-example-configs)
-    set(FLEX_EXAMPLE_CONFIGS "addresses,attributes,bbox,compatible,data-types,generic,geometries,indexes,places,route-relations,simple,unitable")
+    set(FLEX_EXAMPLE_CONFIGS "addresses,attributes,bbox,compatible,data-types,generic,geometries,indexes,places,route-relations,simple,tilesets,unitable")
     # with-schema.lua is not tested because it needs the schema created in the database
     set_tests_properties(test-output-flex-example-configs PROPERTIES ENVIRONMENT "EXAMPLE_FILES=${FLEX_EXAMPLE_CONFIGS}")
 endif()

--- a/tests/bdd/flex/lua-expire.feature
+++ b/tests/bdd/flex/lua-expire.feature
@@ -10,7 +10,7 @@ Feature: Expire configuration in Lua file
                 maxzoom = 12
             })
             osm2pgsql.define_node_table('bar', {
-                { column = 'some', expire = {{ tilset = 'foo' }} }
+                { column = 'some', expire = {{ tileset = 'foo' }} }
             })
             """
         Then running osm2pgsql flex fails

--- a/tests/bdd/flex/lua-expire.feature
+++ b/tests/bdd/flex/lua-expire.feature
@@ -63,6 +63,28 @@ Feature: Expire configuration in Lua file
         When running osm2pgsql flex
         Then table bar has 1562 rows
 
+    Scenario: Directly specifying tileset name is okay
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                filename = 'bar',
+                maxzoom = 12
+            })
+            local t = osm2pgsql.define_node_table('bar', {
+                { column = 'some',
+                  type = 'geometry',
+                  expire = 'foo' }
+            })
+
+            function osm2pgsql.process_node(object)
+                t:insert({})
+            end
+            """
+        When running osm2pgsql flex
+        Then table bar has 1562 rows
+
     Scenario: Expire with buffer option that's not a number fails
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style

--- a/tests/bdd/flex/lua-expire.feature
+++ b/tests/bdd/flex/lua-expire.feature
@@ -1,0 +1,210 @@
+Feature: Expire configuration in Lua file
+
+    Scenario: Expire on a table must be on geometry column
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                filename = 'bar',
+                maxzoom = 12
+            })
+            osm2pgsql.define_node_table('bar', {
+                { column = 'some', expire = {{ tilset = 'foo' }} }
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Expire only allowed for geometry columns in Web Mercator projection.
+            """
+
+    Scenario: Expire on a table must be on geometry column in 3857
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                filename = 'bar',
+                maxzoom = 12
+            })
+            osm2pgsql.define_node_table('bar', {
+                { column = 'some',
+                  type = 'geometry',
+                  projection = 4326,
+                  expire = {{ tileset = 'foo' }} }
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Expire only allowed for geometry columns in Web Mercator projection.
+            """
+
+    Scenario: Expire on a table with 3857 geometry is okay
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                filename = 'bar',
+                maxzoom = 12
+            })
+            local t = osm2pgsql.define_node_table('bar', {
+                { column = 'some',
+                  type = 'geometry',
+                  expire = {{ tileset = 'foo' }} }
+            })
+
+            function osm2pgsql.process_node(object)
+                t:insert({})
+            end
+            """
+        When running osm2pgsql flex
+        Then table bar has 1562 rows
+
+    Scenario: Expire with buffer option that's not a number fails
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                filename = 'bar',
+                maxzoom = 12
+            })
+            osm2pgsql.define_node_table('bar', {
+                { column = 'some',
+                  type = 'geometry',
+                  expire = {
+                    { tileset = 'foo', buffer = 'notvalid' }
+                }}
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Optional expire field 'buffer' must contain a number.
+            """
+
+    Scenario: Expire with invalid mode setting
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                filename = 'bar',
+                maxzoom = 12
+            })
+            local t = osm2pgsql.define_node_table('bar', {
+                { column = 'some',
+                  type = 'geometry',
+                  expire = {{ tileset = 'foo', mode = 'foo' }} }
+            })
+
+            function osm2pgsql.process_node(object)
+                t:insert({})
+            end
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Unknown expire mode 'foo'.
+            """
+
+    Scenario: Expire with full_area_limit that's not a number fails
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                filename = 'bar',
+                maxzoom = 12
+            })
+            osm2pgsql.define_node_table('bar', {
+                { column = 'some',
+                  type = 'geometry',
+                  expire = {
+                    { tileset = 'foo', full_area_limit = true }
+                }}
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Optional expire field 'full_area_limit' must contain a number.
+            """
+
+    Scenario: Expire with boundary-only options is okay
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                filename = 'bar',
+                maxzoom = 12
+            })
+            local t = osm2pgsql.define_node_table('bar', {
+                { column = 'some',
+                  type = 'geometry',
+                  expire = {
+                    { tileset = 'foo', buffer = 0.2, mode = 'boundary-only' }
+                }}
+            })
+
+            function osm2pgsql.process_node(object)
+                t:insert({})
+            end
+            """
+        When running osm2pgsql flex
+        Then table bar has 1562 rows
+
+    Scenario: Expire with hybrid options is okay
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                filename = 'bar',
+                maxzoom = 12
+            })
+            local t = osm2pgsql.define_node_table('bar', {
+                { column = 'some',
+                  type = 'geometry',
+                  expire = {
+                    { tileset = 'foo', buffer = 0.2,
+                      mode = 'hybrid', full_area_limit = 10000 }
+                }}
+            })
+
+            function osm2pgsql.process_node(object)
+                t:insert({})
+            end
+            """
+        When running osm2pgsql flex
+        Then table bar has 1562 rows
+
+    Scenario: Expire into table
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'tiles',
+                table = 'tiles',
+                maxzoom = 12
+            })
+            local t = osm2pgsql.define_node_table('nodes', {
+                { column = 'geom',
+                  type = 'point',
+                  expire = {
+                    { tileset = 'tiles' }
+                }}
+            })
+
+            function osm2pgsql.process_node(object)
+                t:insert({})
+            end
+            """
+        When running osm2pgsql flex
+        Then table nodes has 1562 rows
+        And table tiles has 0 rows
+

--- a/tests/bdd/flex/lua-index-definitions.feature
+++ b/tests/bdd/flex/lua-index-definitions.feature
@@ -362,7 +362,7 @@ Feature: Index definitions in Lua file
         Then running osm2pgsql flex fails
         And the error output contains
             """
-            Index definition field 'tablespace' must be a string field.
+            Index definition field must contain a 'tablespace' string field (or nil for default: '').
             """
 
     Scenario: Empty tablespace is okay
@@ -452,7 +452,7 @@ Feature: Index definitions in Lua file
         Then running osm2pgsql flex fails
         And the error output contains
             """
-            Index definition field 'where' must be a string field.
+            Index definition field must contain a 'where' string field (or nil for default: '').
             """
 
     Scenario: Where condition works

--- a/tests/bdd/flex/lua-tileset-definitions.feature
+++ b/tests/bdd/flex/lua-tileset-definitions.feature
@@ -1,0 +1,174 @@
+Feature: Tileset definitions in Lua file
+
+    Scenario: Tileset definition needs a Lua table parameter
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset()
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Argument #1 to 'define_tileset' must be a Lua table.
+            """
+
+    Scenario: Tileset definition needs a name
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({})
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            The tileset must contain a 'name' string field.
+            """
+
+    Scenario: Name in tileset definition has to be a string
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = false,
+                filename = 'foo'
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            The tileset must contain a 'name' string field.
+            """
+
+    Scenario: Filename in tileset definition has to be a string
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                filename = false
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            The tileset field must contain a 'filename' string field (or nil for default: '').
+            """
+
+    Scenario: Schema in tileset definition has to be a string
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                table = 'bar',
+                schema = false
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            The tileset field must contain a 'schema' string field (or nil for default: '').
+            """
+
+    Scenario: Table in tileset definition has to be a string
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                table = false
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            The tileset field must contain a 'table' string field (or nil for default: '').
+            """
+
+    Scenario: Maxzoom value in tileset definition has to be an integer
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                maxzoom = 'bar',
+                filename = 'somewhere'
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            The 'maxzoom' field in a tileset must contain an integer.
+            """
+
+    Scenario: Minzoom value in tileset definition has to be an integer
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                maxzoom = 12,
+                minzoom = 'bar',
+                filename = 'somewhere'
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            The 'minzoom' field in a tileset must contain an integer.
+            """
+
+    Scenario: Maxzoom value in tileset definition has to be in range
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                maxzoom = 123,
+                filename = 'somewhere'
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Value of 'maxzoom' field must be between 1 and 20.
+            """
+
+    Scenario: Minzoom value in tileset definition has to be in range
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                maxzoom = 12,
+                minzoom = -3,
+                filename = 'somewhere'
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Value of 'minzoom' field must be between 1 and 20.
+            """
+
+    Scenario: Can not create two tilesets with the same name
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                maxzoom = 12,
+                filename = 'somewhere'
+            })
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                maxzoom = 13,
+                filename = 'somewhereelse'
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Tileset with name 'foo' already exists.
+            """
+

--- a/tests/bdd/flex/lua-tileset-definitions.feature
+++ b/tests/bdd/flex/lua-tileset-definitions.feature
@@ -148,7 +148,24 @@ Feature: Tileset definitions in Lua file
         Then running osm2pgsql flex fails
         And the error output contains
             """
-            Value of 'minzoom' field must be between 1 and 20.
+            Value of 'minzoom' field must be between 1 and 'maxzoom'.
+            """
+
+    Scenario: Minzoom value in tileset definition has to be smaller than maxzoom
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'foo',
+                maxzoom = 12,
+                minzoom = 14,
+                filename = 'somewhere'
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Value of 'minzoom' field must be between 1 and 'maxzoom'.
             """
 
     Scenario: Can not create two tilesets with the same name

--- a/tests/bdd/flex/run-with-expire.feature
+++ b/tests/bdd/flex/run-with-expire.feature
@@ -1,0 +1,41 @@
+Feature: Expire into table
+
+    Background:
+        Given the lua style
+            """
+            osm2pgsql.define_tileset({
+                name = 'tiles',
+                table = 'tiles',
+                maxzoom = 12
+            })
+            local t = osm2pgsql.define_node_table('nodes', {
+                { column = 'geom', type = 'point', expire = { { tileset = 'tiles' } }},
+                { column = 'tags', type = 'jsonb' }
+            })
+
+            function osm2pgsql.process_node(object)
+                if object.tags then
+                    t:insert({
+                        tags = object.tags,
+                        geom = object:as_point()
+                    })
+                end
+            end
+            """
+
+    Scenario: Expire into table in append mode
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        When running osm2pgsql flex with parameters
+            | --slim | -c |
+        Then table nodes has 1562 rows
+        And table tiles has 0 rows
+
+        Given the OSM data
+            """
+            n27 v1 dV x10 y10 Tamenity=restaurant
+            """
+        When running osm2pgsql flex with parameters
+            | --slim | -a |
+        Then table nodes has 1563 rows
+        And table tiles has 1 rows
+


### PR DESCRIPTION
*This should be merged only after the next (bugfix) release.*

Tilesets are defined with `define_tileset()` in the Lua config file. They have a name, min and max zoom levels, and a filename or table name (optionally with schema). The filename or table specify where the contents of the tilesets are written to at the end of an osm2pgsql run.

Tilesets are referenced from geometry columns of database tables. A new `expire` field allows setting any number of tilesets and some additional parameters. In append mode, any geometry written to those columns triggers an entry in the corresponding tileset(s). Deletes also trigger these entries.

For backwards compatibility an expire config set with -e/--expire-tiles and -o/--expire-output is automatically added to all tables. Those command line options (together with --expire-bbox-size) should be marked as deprecated at some point and later removed.