### PR TITLE
Check that expire output name is not empty

### DIFF
--- a/src/flex-lua-expire-output.cpp
+++ b/src/flex-lua-expire-output.cpp
@@ -24,6 +24,10 @@ create_expire_output(lua_State *lua_state,
     std::string const expire_output_name =
         luaX_get_table_string(lua_state, "name", -1, "The expire output");
 
+    if (expire_output_name.empty()) {
+        throw std::runtime_error{"The expire output name can not be empty."};
+    }
+
     check_identifier(expire_output_name, "expire output names");
 
     if (util::find_by_name(*expire_outputs, expire_output_name)) {

--- a/tests/bdd/flex/lua-expire-output-definitions.feature
+++ b/tests/bdd/flex/lua-expire-output-definitions.feature
@@ -39,6 +39,22 @@ Feature: Expire output definitions in Lua file
             The expire output must contain a 'name' string field.
             """
 
+    Scenario: Name in expire output definition can not be empty
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            osm2pgsql.define_expire_output({
+                name = '',
+                filename = 'foo',
+                maxzoom = 14
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            The expire output name can not be empty.
+            """
+
     Scenario: Filename in expire output definition has to be a string
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style


### PR DESCRIPTION
This would clash with the empty name used for the expire output created from the command line options.