### PR TITLE
Reference expire outputs as Lua objects, not as strings with their names

### DIFF
--- a/flex-config/expire.lua
+++ b/flex-config/expire.lua
@@ -5,10 +5,6 @@
 local expire_outputs = {}
 
 expire_outputs.pois = osm2pgsql.define_expire_output({
-    -- Every expire output must have a name. The name is independent of the
-    -- data table names although this example file uses the same name for
-    -- simplicity.
-    name = 'pois',
     -- The zoom level at which we calculate the tiles. This must always be set.
     maxzoom = 14,
     -- The filename where tile list should be written to.
@@ -16,7 +12,6 @@ expire_outputs.pois = osm2pgsql.define_expire_output({
 })
 
 expire_outputs.lines = osm2pgsql.define_expire_output({
-    name = 'lines',
     maxzoom = 14,
     -- Instead of writing the tile list to a file, it can be written to a table.
     -- The table will be created if it isn't there already.
@@ -25,7 +20,6 @@ expire_outputs.lines = osm2pgsql.define_expire_output({
 })
 
 expire_outputs.polygons = osm2pgsql.define_expire_output({
-    name = 'polygons',
     -- You can also set a minimum zoom level in addition to the maximum zoom
     -- level. Tiles in all zoom levels between those two will be written out.
     minzoom = 10,
@@ -36,13 +30,11 @@ expire_outputs.polygons = osm2pgsql.define_expire_output({
 print("Expire outputs:(")
 for name, eo in pairs(expire_outputs) do
     print("  " .. name
-          .. ": name=".. eo:name()
-          .. " minzoom=" .. eo:minzoom()
+          .. ": minzoom=" .. eo:minzoom()
           .. " maxzoom=" .. eo:maxzoom()
           .. " filename=" .. eo:filename()
           .. " schema=" .. eo:schema()
-          .. " table=" .. eo:table()
-          .. " (" .. tostring(eo) .. ")")
+          .. " table=" .. eo:table())
 end
 print(")")
 
@@ -53,14 +45,14 @@ tables.pois = osm2pgsql.define_node_table('pois', {
     -- Zero, one or more expire outputs are referenced in an `expire` field in
     -- the definition of any geometry column using the Web Mercator (3857)
     -- projection.
-    { column = 'geom', type = 'point', not_null = true, expire = { { output = 'pois' } } },
+    { column = 'geom', type = 'point', not_null = true, expire = { { output = expire_outputs.pois } } },
 })
 
 tables.lines = osm2pgsql.define_way_table('lines', {
     { column = 'tags', type = 'jsonb' },
     -- If you only have a single expire output and with the default
     -- parameters, you can specify it directly.
-    { column = 'geom', type = 'linestring', not_null = true, expire = 'lines' },
+    { column = 'geom', type = 'linestring', not_null = true, expire = expire_outputs.lines },
 })
 
 tables.polygons = osm2pgsql.define_area_table('polygons', {
@@ -72,7 +64,7 @@ tables.polygons = osm2pgsql.define_area_table('polygons', {
     -- limit the full area is expired, for larger polygons only the boundary.
     -- This setting doesn't have any effect on point or linestring geometries.
     { column = 'geom', type = 'geometry', not_null = true, expire = {
-        { output = 'polygons', mode = 'boundary-only' }
+        { output = expire_outputs.polygons, mode = 'boundary-only' }
     }}
 })
 

--- a/src/debug-output.cpp
+++ b/src/debug-output.cpp
@@ -19,8 +19,9 @@ void write_expire_output_list_to_debug_log(
     }
 
     log_debug("ExpireOutputs:");
+    std::size_t n = 0;
     for (auto const &expire_output : expire_outputs) {
-        log_debug("- ExpireOutput {}", expire_output.name());
+        log_debug("- ExpireOutput [{}]", n++);
         if (expire_output.minzoom() == expire_output.maxzoom()) {
             log_debug("  - zoom: {}", expire_output.maxzoom());
         } else {
@@ -32,14 +33,12 @@ void write_expire_output_list_to_debug_log(
         }
         if (!expire_output.table().empty()) {
             log_debug("  - table: {}", qualified_name(expire_output.schema(),
-                                                      expire_output.name()));
+                                                      expire_output.table()));
         }
     }
 }
 
-void write_table_list_to_debug_log(
-    std::vector<flex_table_t> const &tables,
-    std::vector<expire_output_t> const &expire_outputs)
+void write_table_list_to_debug_log(std::vector<flex_table_t> const &tables)
 {
     if (!get_logger().debug_enabled()) {
         return;
@@ -54,8 +53,7 @@ void write_table_list_to_debug_log(
                       column.name(), column.type_name(), column.sql_type_name(),
                       column.not_null(), column.create_only());
             for (auto const &ec : column.expire_configs()) {
-                auto const &config = expire_outputs[ec.expire_output];
-                log_debug("      - expire: output={}", config.name());
+                log_debug("      - expire: [{}]", ec.expire_output);
             }
         }
         log_debug("  - data_tablespace={}", table.data_tablespace());

--- a/src/debug-output.hpp
+++ b/src/debug-output.hpp
@@ -16,8 +16,6 @@
 void write_expire_output_list_to_debug_log(
     std::vector<expire_output_t> const &expire_outputs);
 
-void write_table_list_to_debug_log(
-    std::vector<flex_table_t> const &tables,
-    std::vector<expire_output_t> const &expire_outputs);
+void write_table_list_to_debug_log(std::vector<flex_table_t> const &tables);
 
 #endif // OSM2PGSQL_DEBUG_OUTPUT_HPP

--- a/src/expire-output.hpp
+++ b/src/expire-output.hpp
@@ -23,10 +23,6 @@ class expire_output_t
 public:
     expire_output_t() = default;
 
-    explicit expire_output_t(std::string name) : m_name(std::move(name)) {}
-
-    std::string const &name() const noexcept { return m_name; }
-
     std::string filename() const noexcept { return m_filename; }
 
     void set_filename(std::string filename)
@@ -71,9 +67,6 @@ public:
                                       std::string const &conninfo) const;
 
 private:
-    /// The internal (unique) name of the output
-    std::string m_name;
-
     /// The filename (if any) for output
     std::string m_filename;
 

--- a/src/flex-lua-expire-output.cpp
+++ b/src/flex-lua-expire-output.cpp
@@ -21,23 +21,7 @@ static expire_output_t &
 create_expire_output(lua_State *lua_state,
                      std::vector<expire_output_t> *expire_outputs)
 {
-    std::string const expire_output_name =
-        luaX_get_table_string(lua_state, "name", -1, "The expire output");
-
-    if (expire_output_name.empty()) {
-        throw std::runtime_error{"The expire output name can not be empty."};
-    }
-
-    check_identifier(expire_output_name, "expire output names");
-
-    if (util::find_by_name(*expire_outputs, expire_output_name)) {
-        throw fmt_error("Expire output with name '{}' already exists.",
-                        expire_output_name);
-    }
-
-    auto &new_expire_output = expire_outputs->emplace_back(expire_output_name);
-
-    lua_pop(lua_state, 1); // "name"
+    auto &new_expire_output = expire_outputs->emplace_back();
 
     // optional "filename" field
     auto const *filename = luaX_get_table_string(lua_state, "filename", -1,
@@ -57,9 +41,8 @@ create_expire_output(lua_State *lua_state,
 
     if (new_expire_output.filename().empty() &&
         new_expire_output.table().empty()) {
-        throw fmt_error(
-            "Must set 'filename' and/or 'table' on expire output '{}'.",
-            new_expire_output.name());
+        throw std::runtime_error{
+            "Must set 'filename' and/or 'table' on expire output."};
     }
 
     // required "maxzoom" field

--- a/tests/bdd/flex/lua-expire-output-definitions.feature
+++ b/tests/bdd/flex/lua-expire-output-definitions.feature
@@ -12,49 +12,6 @@ Feature: Expire output definitions in Lua file
             Argument #1 to 'define_expire_output' must be a Lua table.
             """
 
-    Scenario: Expire output definition needs a name
-        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
-        And the lua style
-            """
-            osm2pgsql.define_expire_output({})
-            """
-        Then running osm2pgsql flex fails
-        And the error output contains
-            """
-            The expire output must contain a 'name' string field.
-            """
-
-    Scenario: Name in expire output definition has to be a string
-        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
-        And the lua style
-            """
-            osm2pgsql.define_expire_output({
-                name = false,
-                filename = 'foo'
-            })
-            """
-        Then running osm2pgsql flex fails
-        And the error output contains
-            """
-            The expire output must contain a 'name' string field.
-            """
-
-    Scenario: Name in expire output definition can not be empty
-        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
-        And the lua style
-            """
-            osm2pgsql.define_expire_output({
-                name = '',
-                filename = 'foo',
-                maxzoom = 14
-            })
-            """
-        Then running osm2pgsql flex fails
-        And the error output contains
-            """
-            The expire output name can not be empty.
-            """
-
     Scenario: Filename in expire output definition has to be a string
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style
@@ -182,26 +139,5 @@ Feature: Expire output definitions in Lua file
         And the error output contains
             """
             Value of 'minzoom' field must be between 1 and 'maxzoom'.
-            """
-
-    Scenario: Can not define two expire outputs with the same name
-        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
-        And the lua style
-            """
-            osm2pgsql.define_expire_output({
-                name = 'foo',
-                maxzoom = 12,
-                filename = 'somewhere'
-            })
-            osm2pgsql.define_expire_output({
-                name = 'foo',
-                maxzoom = 13,
-                filename = 'somewhereelse'
-            })
-            """
-        Then running osm2pgsql flex fails
-        And the error output contains
-            """
-            Expire output with name 'foo' already exists.
             """
 

--- a/tests/bdd/flex/lua-expire.feature
+++ b/tests/bdd/flex/lua-expire.feature
@@ -4,13 +4,12 @@ Feature: Expire configuration in Lua file
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style
             """
-            osm2pgsql.define_expire_output({
-                name = 'foo',
+            local eo = osm2pgsql.define_expire_output({
                 filename = 'bar',
                 maxzoom = 12
             })
             osm2pgsql.define_node_table('bar', {
-                { column = 'some', expire = {{ output = 'foo' }} }
+                { column = 'some', expire = {{ output = eo }} }
             })
             """
         Then running osm2pgsql flex fails
@@ -23,8 +22,7 @@ Feature: Expire configuration in Lua file
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style
             """
-            osm2pgsql.define_expire_output({
-                name = 'foo',
+            local eo = osm2pgsql.define_expire_output({
                 filename = 'bar',
                 maxzoom = 12
             })
@@ -32,7 +30,7 @@ Feature: Expire configuration in Lua file
                 { column = 'some',
                   type = 'geometry',
                   projection = 4326,
-                  expire = {{ output = 'foo' }} }
+                  expire = {{ output = eo }} }
             })
             """
         Then running osm2pgsql flex fails
@@ -41,19 +39,36 @@ Feature: Expire configuration in Lua file
             Expire only allowed for geometry columns in Web Mercator projection.
             """
 
+    Scenario: Expire reference must be a userdata ExpireOutput object
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the lua style
+            """
+            local eo = osm2pgsql.define_expire_output({
+                filename = 'bar',
+                maxzoom = 12
+            })
+            osm2pgsql.define_node_table('bar', {
+                { column = 'some', type = 'geometry', expire = {{ output = 'abc' }} }
+            })
+            """
+        Then running osm2pgsql flex fails
+        And the error output contains
+            """
+            Expire output must be of type ExpireOutput.
+            """
+
     Scenario: Expire on a table with 3857 geometry is okay
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style
             """
-            osm2pgsql.define_expire_output({
-                name = 'foo',
+            local eo = osm2pgsql.define_expire_output({
                 filename = 'bar',
                 maxzoom = 12
             })
             local t = osm2pgsql.define_node_table('bar', {
                 { column = 'some',
                   type = 'geometry',
-                  expire = {{ output = 'foo' }} }
+                  expire = {{ output = eo }} }
             })
 
             function osm2pgsql.process_node(object)
@@ -63,19 +78,18 @@ Feature: Expire configuration in Lua file
         When running osm2pgsql flex
         Then table bar has 1562 rows
 
-    Scenario: Directly specifying the expire output name is okay
+    Scenario: Directly specifying the expire output is okay
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style
             """
-            osm2pgsql.define_expire_output({
-                name = 'foo',
+            local eo = osm2pgsql.define_expire_output({
                 filename = 'bar',
                 maxzoom = 12
             })
             local t = osm2pgsql.define_node_table('bar', {
                 { column = 'some',
                   type = 'geometry',
-                  expire = 'foo' }
+                  expire = eo }
             })
 
             function osm2pgsql.process_node(object)
@@ -89,8 +103,7 @@ Feature: Expire configuration in Lua file
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style
             """
-            osm2pgsql.define_expire_output({
-                name = 'foo',
+            local eo = osm2pgsql.define_expire_output({
                 filename = 'bar',
                 maxzoom = 12
             })
@@ -98,7 +111,7 @@ Feature: Expire configuration in Lua file
                 { column = 'some',
                   type = 'geometry',
                   expire = {
-                    { output = 'foo', buffer = 'notvalid' }
+                    { output = eo, buffer = 'notvalid' }
                 }}
             })
             """
@@ -108,19 +121,18 @@ Feature: Expire configuration in Lua file
             Optional expire field 'buffer' must contain a number.
             """
 
-    Scenario: Expire with invalid mode setting
+    Scenario: Expire with invalid mode setting fails
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style
             """
-            osm2pgsql.define_expire_output({
-                name = 'foo',
+            local eo = osm2pgsql.define_expire_output({
                 filename = 'bar',
                 maxzoom = 12
             })
             local t = osm2pgsql.define_node_table('bar', {
                 { column = 'some',
                   type = 'geometry',
-                  expire = {{ output = 'foo', mode = 'foo' }} }
+                  expire = {{ output = eo, mode = 'foo' }} }
             })
 
             function osm2pgsql.process_node(object)
@@ -137,8 +149,7 @@ Feature: Expire configuration in Lua file
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style
             """
-            osm2pgsql.define_expire_output({
-                name = 'foo',
+            local eo = osm2pgsql.define_expire_output({
                 filename = 'bar',
                 maxzoom = 12
             })
@@ -146,7 +157,7 @@ Feature: Expire configuration in Lua file
                 { column = 'some',
                   type = 'geometry',
                   expire = {
-                    { output = 'foo', full_area_limit = true }
+                    { output = eo, full_area_limit = true }
                 }}
             })
             """
@@ -160,8 +171,7 @@ Feature: Expire configuration in Lua file
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style
             """
-            osm2pgsql.define_expire_output({
-                name = 'foo',
+            local eo = osm2pgsql.define_expire_output({
                 filename = 'bar',
                 maxzoom = 12
             })
@@ -169,7 +179,7 @@ Feature: Expire configuration in Lua file
                 { column = 'some',
                   type = 'geometry',
                   expire = {
-                    { output = 'foo', buffer = 0.2, mode = 'boundary-only' }
+                    { output = eo, buffer = 0.2, mode = 'boundary-only' }
                 }}
             })
 
@@ -184,8 +194,7 @@ Feature: Expire configuration in Lua file
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style
             """
-            osm2pgsql.define_expire_output({
-                name = 'foo',
+            local eo = osm2pgsql.define_expire_output({
                 filename = 'bar',
                 maxzoom = 12
             })
@@ -193,7 +202,7 @@ Feature: Expire configuration in Lua file
                 { column = 'some',
                   type = 'geometry',
                   expire = {
-                    { output = 'foo', buffer = 0.2,
+                    { output = eo, buffer = 0.2,
                       mode = 'hybrid', full_area_limit = 10000 }
                 }}
             })
@@ -209,8 +218,7 @@ Feature: Expire configuration in Lua file
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the lua style
             """
-            osm2pgsql.define_expire_output({
-                name = 'tiles',
+            local eo = osm2pgsql.define_expire_output({
                 table = 'tiles',
                 maxzoom = 12
             })
@@ -218,7 +226,7 @@ Feature: Expire configuration in Lua file
                 { column = 'geom',
                   type = 'point',
                   expire = {
-                    { output = 'tiles' }
+                    { output = eo }
                 }}
             })
 

--- a/tests/bdd/flex/run-with-expire.feature
+++ b/tests/bdd/flex/run-with-expire.feature
@@ -3,13 +3,13 @@ Feature: Expire into table
     Background:
         Given the lua style
             """
-            osm2pgsql.define_expire_output({
+            local eo = osm2pgsql.define_expire_output({
                 name = 'tiles',
                 table = 'tiles',
                 maxzoom = 12
             })
             local t = osm2pgsql.define_node_table('nodes', {
-                { column = 'geom', type = 'point', expire = 'tiles' },
+                { column = 'geom', type = 'point', expire = eo },
                 { column = 'tags', type = 'jsonb' }
             })
 


### PR DESCRIPTION
Expire outputs are now directly referenced from table column definitions as if they are Lua objects, not by using their name. In fact they don't even have a name any more.