### PR TITLE
Do "SET client_min_messages = WARNING" on all db connections

### DIFF
--- a/src/db-copy.cpp
+++ b/src/db-copy.cpp
@@ -131,10 +131,6 @@ void db_copy_thread_t::thread_t::operator()()
         // Let commits happen faster by delaying when they actually occur.
         m_conn->exec("SET synchronous_commit = off");
 
-        // Do not show messages about invalid geometries (they are removed
-        // by the trigger).
-        m_conn->exec("SET client_min_messages = WARNING");
-
         bool done = false;
         while (!done) {
             std::unique_ptr<db_cmd_t> item;

--- a/src/flex-table.cpp
+++ b/src/flex-table.cpp
@@ -272,8 +272,6 @@ void table_connection_t::start(bool append)
 {
     assert(m_db_connection);
 
-    m_db_connection->exec("SET client_min_messages = WARNING");
-
     if (!append) {
         m_db_connection->exec("DROP TABLE IF EXISTS {} CASCADE",
                               table().full_name());
@@ -281,7 +279,6 @@ void table_connection_t::start(bool append)
 
     // These _tmp tables can be left behind if we run out of disk space.
     m_db_connection->exec("DROP TABLE IF EXISTS {}", table().full_tmp_name());
-    m_db_connection->exec("RESET client_min_messages");
 
     if (!append) {
         m_db_connection->exec(table().build_sql_create_table(
@@ -313,10 +310,6 @@ void table_connection_t::stop(bool updateable, bool append)
         }
 
         log_info("Clustering table '{}' by geometry...", table().name());
-
-        // Notices about invalid geometries are expected and can be ignored
-        // because they say nothing about the validity of the geometry in OSM.
-        m_db_connection->exec("SET client_min_messages = WARNING");
 
         m_db_connection->exec(table().build_sql_create_table(
             flex_table_t::table_type::permanent, table().full_tmp_name()));

--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -663,7 +663,6 @@ void middle_pgsql_t::start()
             }
         }
     } else {
-        m_db_connection.exec("SET client_min_messages = WARNING");
         for (auto const &table : m_tables) {
             log_debug("Setting up table '{}'", table.name());
             auto const qual_name = qualified_name(table.schema(), table.name());

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1265,7 +1265,6 @@ create_expire_tables(std::vector<expire_output_t> const &expire_outputs,
     }
 
     pg_conn_t const connection{conninfo};
-    connection.exec("SET client_min_messages = WARNING");
     for (auto &expire_output : expire_outputs) {
         if (!expire_output.table().empty()) {
             expire_output.create_output_table(connection);

--- a/src/pgsql.cpp
+++ b/src/pgsql.cpp
@@ -43,6 +43,12 @@ pg_conn_t::pg_conn_t(std::string const &conninfo)
         log_sql("(C{}) New database connection (backend_pid={})",
                 m_connection_id, results.get(0, 0));
     }
+
+    // PostgreSQL sends notices in many different contexts which aren't that
+    // useful for the user. So we disable them for all connections.
+    if (!get_logger().debug_enabled()) {
+        exec("SET client_min_messages = WARNING");
+    }
 }
 
 void pg_conn_t::close()

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -84,7 +84,6 @@ void table_t::start(std::string const &conninfo, std::string const &table_space)
 
     connect();
     log_info("Setting up table '{}'", m_target->name);
-    m_sql_conn->exec("SET client_min_messages = WARNING");
     auto const qual_name = qualified_name(m_target->schema, m_target->name);
     auto const qual_tmp_name = qualified_name(
         m_target->schema, m_target->name + "_tmp");
@@ -96,7 +95,6 @@ void table_t::start(std::string const &conninfo, std::string const &table_space)
 
     // These _tmp tables can be left behind if we run out of disk space.
     m_sql_conn->exec("DROP TABLE IF EXISTS {}", qual_tmp_name);
-    m_sql_conn->exec("RESET client_min_messages");
 
     //making a new table
     if (!m_append) {
@@ -196,10 +194,6 @@ void table_t::stop(bool updateable, bool enable_hstore_index,
         }
 
         log_info("Clustering table '{}' by geometry...", m_target->name);
-
-        // Notices about invalid geometries are expected and can be ignored
-        // because they say nothing about the validity of the geometry in OSM.
-        m_sql_conn->exec("SET client_min_messages = WARNING");
 
         std::string sql = fmt::format("CREATE TABLE {} {} AS SELECT * FROM {}",
                                       qual_tmp_name, m_table_space, qual_name);


### PR DESCRIPTION
There are more and more places where we used to change this setting. Instead we do it once on connection for everything and only if not in debug mode.