### PR TITLE
Fix program name substitution in man page

### DIFF
--- a/docs/manpage_from_python.py
+++ b/docs/manpage_from_python.py
@@ -31,6 +31,7 @@ def create_manpage_for(args):
     manpage = re.sub(r'.TH.*',
                      f'.TH "{parser.prog.upper()}" "1" "{args.version}" "" ""',
                      manpage)
+    manpage = manpage.replace('%(prog)s', parser.prog)
     # Correct quoting for single quotes. See groff manpage.
     manpage = manpage.replace('`', '\\(cq')
 

--- a/docs/osm2pgsql-replication.1
+++ b/docs/osm2pgsql-replication.1
@@ -52,7 +52,7 @@ from a file that contains replication source information, then the
 .br
 initialisation process can use this and set up replication from there.
 .br
-Use the command \(cq%(prog)s \-\-osm\-file <filename>\(cq for this.
+Use the command \(cqosm2pgsql-replication \-\-osm\-file <filename>\(cq for this.
 .br
 
 .br


### PR DESCRIPTION
While ArgParse correctly substitutes the program name in help text, argprse-manpage doesn't seem to respect that. Simply do our own replacement.

Fiexes #1946.