### PR TITLE
Add function to check existence of database schema and use it

### DIFF
--- a/src/flex-lua-table.cpp
+++ b/src/flex-lua-table.cpp
@@ -49,11 +49,7 @@ static flex_table_t &create_flex_table(lua_State *lua_state,
     if (lua_isstring(lua_state, -1)) {
         std::string const schema = lua_tostring(lua_state, -1);
         check_identifier(schema, "schema field");
-        if (!has_schema(schema)) {
-            throw fmt_error("Schema '{0}' not available."
-                            " Use 'CREATE SCHEMA \"{0}\";' to create it.",
-                            schema);
-        }
+        check_schema(schema);
         new_table.set_schema(schema);
     }
     lua_pop(lua_state, 1);

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -84,6 +84,9 @@ void check_db(options_t const &options)
 
     init_database_capabilities(db_connection);
 
+    check_schema(options.middle_dbschema);
+    check_schema(options.output_dbschema);
+
     // If we are in append mode and the middle nodes table isn't there,
     // it probably means we used a flat node store when we created this
     // database. Check for that and stop if it looks like we are missing

--- a/src/pgsql-capabilities.cpp
+++ b/src/pgsql-capabilities.cpp
@@ -150,6 +150,17 @@ bool has_index_method(std::string const &value)
     return capabilities().index_methods.count(value);
 }
 
+void check_schema(std::string const &schema)
+{
+    if (has_schema(schema)) {
+        return;
+    }
+
+    throw fmt_error("Schema '{0}' not available."
+                    " Use 'CREATE SCHEMA \"{0}\";' to create it.",
+                    schema);
+}
+
 uint32_t get_database_version() noexcept
 {
     return capabilities().database_version;

--- a/src/pgsql-capabilities.hpp
+++ b/src/pgsql-capabilities.hpp
@@ -22,6 +22,8 @@ bool has_schema(std::string const &value);
 bool has_tablespace(std::string const &value);
 bool has_index_method(std::string const &value);
 
+void check_schema(std::string const &schema);
+
 /// Get PostgreSQL version in the format (major * 10000 + minor).
 uint32_t get_database_version() noexcept;
 


### PR DESCRIPTION
So far we have only been checking schemas used in flex output. This now also checks that the schemas used for middle and pgsql output (if any) are available.