### PR TITLE
Refactor middle: Pull special osm_* tags out of the tag list

### DIFF
--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -153,63 +153,19 @@ static void push_osm_object_to_lua_stack(lua_State *lua_state,
     if (with_attributes) {
         if (object.version() != 0U) {
             luaX_add_table_int(lua_state, "version", object.version());
-        } else {
-            // This is a workaround, because the middle will give us the
-            // attributes as pseudo-tags.
-            char const *const val = object.tags()["osm_version"];
-            if (val) {
-                luaX_add_table_int(lua_state, "version",
-                                   osmium::string_to_object_version(val));
-            }
         }
-
         if (object.timestamp().valid()) {
             luaX_add_table_int(lua_state, "timestamp",
                                object.timestamp().seconds_since_epoch());
-        } else {
-            // This is a workaround, because the middle will give us the
-            // attributes as pseudo-tags.
-            char const *const val = object.tags()["osm_timestamp"];
-            if (val) {
-                auto const timestamp = osmium::Timestamp{val};
-                luaX_add_table_int(lua_state, "timestamp",
-                                   timestamp.seconds_since_epoch());
-            }
         }
-
         if (object.changeset() != 0U) {
             luaX_add_table_int(lua_state, "changeset", object.changeset());
-        } else {
-            char const *const val = object.tags()["osm_changeset"];
-            // This is a workaround, because the middle will give us the
-            // attributes as pseudo-tags.
-            if (val) {
-                luaX_add_table_int(lua_state, "changeset",
-                                   osmium::string_to_changeset_id(val));
-            }
         }
-
         if (object.uid() != 0U) {
             luaX_add_table_int(lua_state, "uid", object.uid());
-        } else {
-            // This is a workaround, because the middle will give us the
-            // attributes as pseudo-tags.
-            char const *const val = object.tags()["osm_uid"];
-            if (val) {
-                luaX_add_table_int(lua_state, "uid",
-                                   osmium::string_to_uid(val));
-            }
         }
-
         if (object.user()[0] != '\0') {
             luaX_add_table_str(lua_state, "user", object.user());
-        } else {
-            // This is a workaround, because the middle will give us the
-            // attributes as pseudo-tags.
-            char const *const val = object.tags()["osm_user"];
-            if (val) {
-                luaX_add_table_str(lua_state, "user", val);
-            }
         }
     }
 

--- a/tests/bdd/flex/extra-attributes.feature
+++ b/tests/bdd/flex/extra-attributes.feature
@@ -1,14 +1,7 @@
 Feature: Tests for including extra attributes
 
     Background:
-        Given the grid
-            | 11 | 12 |
-            | 10 |    |
-        And the OSM data
-            """
-            w20 v1 dV c31 t2020-01-12T12:34:56Z i17 utest Thighway=primary Nn10,n11,n12
-            """
-        And the lua style
+        Given the lua style
             """
             local attr_table = osm2pgsql.define_table{
                 name = 'osm2pgsql_test_attr',
@@ -32,12 +25,19 @@ Feature: Tests for including extra attributes
             """
 
     Scenario: Importing data without extra attributes
+        Given the grid
+            | 11 | 12 |
+            | 10 |    |
+        And the OSM data
+            """
+            w20 v1 dV c31 t2020-01-12T12:34:56Z i17 utest Thighway=primary Nn10,n11,n12
+            """
         When running osm2pgsql flex with parameters
             | --slim |
 
         Then table osm2pgsql_test_attr contains
-            | type | way_id | tags->'highway' | version | changeset | timestamp | uid  | "user" |
-            | way  | 20     | primary         | NULL    | NULL      | NULL      | NULL | NULL   |
+            | type | way_id | tags->'highway' | tags->'osm_version' |  version | changeset | timestamp | uid  | "user" |
+            | way  | 20     | primary         | NULL                |  NULL    | NULL      | NULL      | NULL | NULL   |
 
         Given the grid
             |    |    |
@@ -46,17 +46,24 @@ Feature: Tests for including extra attributes
             | --slim | --append |
 
         Then table osm2pgsql_test_attr contains
-            | type |  way_id | tags->'highway' | version | changeset | timestamp | uid  | "user" |
-            | way  |  20     | primary         | NULL    | NULL      | NULL      | NULL | NULL   |
+            | type |  way_id | tags->'highway' | tags->'osm_version' | version | changeset | timestamp | uid  | "user" |
+            | way  |  20     | primary         | NULL                | NULL    | NULL      | NULL      | NULL | NULL   |
 
 
     Scenario: Importing data with extra attributes
+        Given the grid
+            | 11 | 12 |
+            | 10 |    |
+        And the OSM data
+            """
+            w20 v1 dV c31 t2020-01-12T12:34:56Z i17 utest Thighway=primary Nn10,n11,n12
+            """
         When running osm2pgsql flex with parameters
             | --slim | -x |
 
         Then table osm2pgsql_test_attr contains
-            | type |  way_id | tags->'highway' | version | changeset | timestamp  | uid  | "user" |
-            | way  |  20     | primary         | 1       | 31        | 1578832496 | 17   | test   |
+            | type |  way_id | tags->'highway' | tags->'osm_version' | version | changeset | timestamp  | uid  | "user" |
+            | way  |  20     | primary         | NULL                | 1       | 31        | 1578832496 | 17   | test   |
 
         Given the grid
             |    |    |
@@ -65,6 +72,6 @@ Feature: Tests for including extra attributes
             | --slim | --append | -x |
 
         Then table osm2pgsql_test_attr contains
-            | type |  way_id | tags->'highway' | version | changeset | timestamp  | uid | "user" |
-            | way  |  20     | primary         | 1       | 31        | 1578832496 | 17  | test   |
+            | type |  way_id | tags->'highway' | tags->'osm_version' | version | changeset | timestamp  | uid | "user" |
+            | way  |  20     | primary         | NULL                | 1       | 31        | 1578832496 | 17  | test   |
 

--- a/tests/bdd/regression/extra-attributes.feature
+++ b/tests/bdd/regression/extra-attributes.feature
@@ -1,0 +1,53 @@
+Feature: Tests for including extra attributes
+
+    Scenario: Importing data without extra attributes
+        Given the grid
+            | 11 | 12 |
+            | 10 |    |
+        And the OSM data
+            """
+            w20 v1 dV c31 t2020-01-12T12:34:56Z i17 utest Thighway=primary Nn10,n11,n12
+            """
+        When running osm2pgsql pgsql with parameters
+            | --slim | -j |
+
+        Then table planet_osm_roads contains
+            | osm_id | tags->'highway' | tags->'osm_version' | tags->'osm_changeset' |
+            | 20     | primary         | NULL                | NULL                  |
+
+        Given the grid
+            |    |    |
+            |    | 10 |
+        When running osm2pgsql pgsql with parameters
+            | --slim | -j | --append |
+
+        Then table planet_osm_roads contains
+            |  osm_id | tags->'highway' | tags->'osm_version' | tags->'osm_changeset' |
+            |  20     | primary         | NULL                | NULL                  |
+
+
+    Scenario: Importing data with extra attributes
+        Given the grid
+            | 11 | 12 |
+            | 10 |    |
+        And the OSM data
+            """
+            w20 v1 dV c31 t2020-01-12T12:34:56Z i17 utest Thighway=primary Nn10,n11,n12
+            """
+        When running osm2pgsql pgsql with parameters
+            | --slim | -j | -x |
+
+        Then table planet_osm_roads contains
+            |  osm_id | tags->'highway' | tags->'osm_version' | tags->'osm_changeset' |
+            |  20     | primary         | 1                   | 31                    |
+
+        Given the grid
+            |    |    |
+            |    | 10 |
+        When running osm2pgsql pgsql with parameters
+            | --slim | -j | --append | -x |
+
+        Then table planet_osm_roads contains
+            |  osm_id | tags->'highway' | tags->'osm_version' | tags->'osm_changeset' |
+            |  20     | primary         | 1                   | 31                    |
+


### PR DESCRIPTION
The middle stores OSM attributes (version, timestamp, changeset, uid, user) in "osm_*" pseudo-tags. When we get data back from the middle, we used to just leave them in there. This commit changes that behaviour: We pull the data out and put it into the proper attributes and remove the special tags. This is how the flex output needs the data and this is how a new middle (we are currently working on) will provide the data.

The pgsql output puts the pseudo-tags in already, because it had to do that on import anyway.

This also fixes a problem where the "osm_*" pseudo-tags were visible in the Lua config file of the flex output.