### PR TITLE
If there is a network error when trying to get replication status, print a more useful error message, and then exit

### DIFF
--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -370,6 +370,11 @@ def update(conn, args):
 
     repl = ReplicationServer(base_url)
     current = repl.get_state_info()
+    if current is None:
+        LOG.fatal("Cannot reach the configured replication service '%s'.\n"
+                  "Does the URL point to a directory containing OSM update data?",
+                  base_url)
+        return 1
 
     if seq >= current.sequence:
         LOG.info("Database already up-to-date.")


### PR DESCRIPTION
When doing osm2pgsql-replication, if there's a network error, print that error to stdout & exit with failure code.

Previously, the `osm2pgsql-replication` would do this:

```
$ osm2pgsql-replication update -U osm -d "gis"  -- --multi-geometry  --hstore  --flat-nodes /nvme/flatnodes-tile/flatnodes.dat --style /srv/openstreetmap-carto/openstreetmap-carto.style --tag-transform-script /srv/openstreetmap-carto/openstreetmap-carto.lua  --middle-way-node-index-id-shift 5
2023-06-05 05:47:27 [INFO]: Using replication service 'https://planet.openstreetmap.org/replication/minute/'. Current sequence 5589863 (2023-05-25 10:05:54+02:00).
Traceback (most recent call last):
  File "/usr/bin/osm2pgsql-replication", line 531, in <module>
    sys.exit(main())
  File "/usr/bin/osm2pgsql-replication", line 524, in main
    ret = args.handler(conn, args)
  File "/usr/bin/osm2pgsql-replication", line 359, in update
    if seq >= current.sequence:
AttributeError: 'NoneType' object has no attribute 'sequence'
```

With this patch, it does this:

```
$ osm2pgsql-replication update -U osm -d "gis"  -- --multi-geometry  --hstore  --flat-nodes /nvme/flatnodes-tile/flatnodes.dat --style /srv/openstreetmap-carto/openstreetmap-carto.style --tag-transform-script /srv/openstreetmap-carto/openstreetmap-carto.lua  --middle-way-node-index-id-shift 5
2023-06-05 05:48:59 [INFO]: Using replication service 'https://planet.openstreetmap.org/replication/minute/'. Current sequence 5589863 (2023-05-25 10:05:54+02:00).
2023-06-05 05:49:02 [CRITICAL]: Cannot reach the configured replication service 'https://planet.openstreetmap.org/replication/minute/'.
Does the URL point to a directory containing OSM update data?
```

which is a more helpful error message.