### PR TITLE
Improve the human readility of the `osm2pgsql-replication`

### DIFF
--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -323,7 +323,8 @@ def init(conn, args):
     setup_replication_state(conn, args.table, base_url, seq, date)
 
     LOG.info("Initialised updates for service '%s'.", base_url)
-    LOG.info("Starting at sequence %d (%s).", seq, date)
+    LOG.info("Starting at sequence %d (%s).", seq,
+            date.astimezone(dt.timezone.utc).strftime('%Y-%m-%dT%H:%MZ'))
 
     return 0
 
@@ -365,8 +366,9 @@ def update(conn, args):
             return 1
 
         base_url, seq, ts = cur.fetchone()
-        LOG.info("Using replication service '%s'. Current sequence %d (%s).",
-                 base_url, seq, ts)
+        initial_local_timestamp = ts
+        LOG.info("Using replication service '%s'.", base_url)
+        local_db_age_sec = int((dt.datetime.now(dt.timezone.utc) - ts).total_seconds())
 
     repl = ReplicationServer(base_url)
     current = repl.get_state_info()
@@ -379,6 +381,16 @@ def update(conn, args):
     if seq >= current.sequence:
         LOG.info("Database already up-to-date.")
         return 0
+
+    remote_server_age_sec = int((dt.datetime.now(dt.timezone.utc) - current.timestamp).total_seconds())
+    LOG.debug("Applying %d sequence(s) (%d → %d), covering %s (%s sec) of changes (%s → %s)",
+        current.sequence - seq, current.sequence, seq,
+        pretty_format_timedelta(int((current.timestamp - ts).total_seconds())),
+        int((current.timestamp - ts).total_seconds()),
+        ts.astimezone(dt.timezone.utc).strftime('%Y-%m-%dT%H:%MZ'), current.timestamp.astimezone(dt.timezone.utc).strftime('%Y-%m-%dT%H:%MZ')
+    )
+
+    update_started = dt.datetime.now(dt.timezone.utc)
 
     if args.diff_file is not None:
         outfile = Path(args.diff_file)
@@ -430,11 +442,30 @@ def update(conn, args):
 
         if nextstate is not None:
             LOG.info("Data imported until %s. Backlog remaining: %s",
-                     nextstate.timestamp,
-                     dt.datetime.now(dt.timezone.utc) - nextstate.timestamp)
+                nextstate.timestamp.astimezone(dt.timezone.utc).strftime('%Y-%m-%dT%H:%MZ'),
+                pretty_format_timedelta((dt.datetime.now(dt.timezone.utc) - nextstate.timestamp).total_seconds()),
+            )
+
 
         if args.once:
             break
+
+
+    update_duration_sec = (dt.datetime.now(dt.timezone.utc) - update_started).total_seconds()
+    with conn.cursor() as cur:
+        cur.execute(sql.SQL('SELECT * FROM {}').format(args.table))
+        if cur.rowcount != 1:
+            LOG.fatal("Updates not set up correctly. Run 'osm2pgsql-updates init' first.")
+            return 1
+
+        _base_url, _seq, current_local_timestamp = cur.fetchone()
+
+    total_applied_changes_duration_sec = (current_local_timestamp - initial_local_timestamp).total_seconds()
+    LOG.debug("It took %s (%d sec) to apply %s (%d sec) of changes. This is a speed of ×%.1f.",
+            pretty_format_timedelta(update_duration_sec), int(update_duration_sec),
+            pretty_format_timedelta(total_applied_changes_duration_sec), int(total_applied_changes_duration_sec),
+            total_applied_changes_duration_sec / update_duration_sec
+        )
 
     return 0
 


### PR DESCRIPTION
A handful of minor improvements to the `osm2pgsql-replication` output in this PR.

Here's what the (new) output looks like. changed lines in **bold**:

2023-06-15 11:48:39 [INFO]: Using replication service 'https://planet.openstreetmap.org/replication/minute/'.
**2023-06-15 11:48:39 [INFO]: Local database is at sequence 5619810, which is data up until 5 minute(s) ago (354 seconds ago, 2023-06-15T09:42Z).**
**2023-06-15 11:48:39 [INFO]:  Remote server is at sequence 5619815, which is data up until <1 minute ago (54 seconds ago, 2023-06-15T09:47Z).**
**2023-06-15 11:48:39 [INFO]: There are 5 sequence(s) on the remote server which will be applied locally. This represents 5 minute(s) (300 sec) of changes.**
2023-06-15 11:48:40  osm2pgsql version 1.4.1
2023-06-15 11:48:40  Database version: 12.9 (Ubuntu 12.9-0ubuntu0.20.04.1)
2023-06-15 11:48:40  PostGIS version: 3.0
2023-06-15 11:48:40  Node-cache: cache=800MB, maxblocks=12800*65536, allocation method=11
2023-06-15 11:48:40  Setting up table 'planet_osm_point'
2023-06-15 11:48:40  Setting up table 'planet_osm_line'
2023-06-15 11:48:40  Setting up table 'planet_osm_polygon'
2023-06-15 11:48:40  Setting up table 'planet_osm_roads'
[324B blob data]
2023-06-15 11:48:57    Processed 14086 nodes in 3s - 5k/s
2023-06-15 11:48:57    Processed 1526 ways in 5s - 305/s
2023-06-15 11:48:57    Processed 78 relations in 9s - 9/s
2023-06-15 11:48:58  Going over 725 pending ways (using 4 threads)
[66B blob data]
2023-06-15 11:49:00  Processing 725 pending ways took 2s at a rate of 362.50/s
2023-06-15 11:49:00  Going over 146 pending relations (using 4 threads)
[66B blob data]
2023-06-15 11:49:02  Processing 146 pending relations took 2s at a rate of 73.00/s
2023-06-15 11:49:02  node cache: stored: 13297(100.00%), storage efficiency: 45.84% (dense blocks: 1, sparse nodes: 10408), hit rate: 1.61%
2023-06-15 11:49:02  osm2pgsql took 22s overall.
**2023-06-15 11:49:03 [INFO]: Data imported until 2023-06-15T09:47Z. Backlog remaining: 1 minute(s)**
**2023-06-15 11:49:03 [INFO]: It took <1 minute (23 sec) to apply 5 minute(s) (300 sec) of changes. this is a speed of ×12.9.**
