### PR TITLE
If there's an init error, and no -d option specified, use the actual database name, rather than "None"

### DIFF
--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -550,7 +550,8 @@ def main():
 
     try:
         if not table_exists(conn, f'{args.prefix}_ways'):
-            LOG.fatal(f'osm2pgsql middle table "{args.prefix}_ways" not found in database "{args.database}". '
+            dbname = conn.get_dsn_parameters()['dbname']         # args.database is None when not specified
+            LOG.fatal(f'osm2pgsql middle table "{args.prefix}_ways" not found in database "{dbname}". '
                        'Database needs to be imported in --slim mode.')
             return 1
 


### PR DESCRIPTION
If you do `osm2pgsql` without `--slim`, and `osm2pgsql-replication init` without a `-d` option, this patch will give you this error message:

<code>2023-06-20 13:36:08 [CRITICAL]: osm2pgsql middle table "planet_osm_ways" not found in database <b><u>"amanda"</u></b>. Database needs to be imported in --slim mode.</code>

Previously it gave you `None` as a database name:

<code>2023-06-20 13:36:08 [CRITICAL]: osm2pgsql middle table "planet_osm_ways" not found in database <b><u>"None"</u></b>. Database needs to be imported in --slim mode.</code>