### PR TITLE
Split command line parser code from options

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_library(osm2pgsql_lib STATIC)
 
 target_sources(osm2pgsql_lib PRIVATE
+  command-line-parser.cpp
   db-copy.cpp
   debug-output.cpp
   dependency-manager.cpp
@@ -20,7 +21,6 @@ target_sources(osm2pgsql_lib PRIVATE
   middle-ram.cpp
   node-locations.cpp
   node-persistent-cache.cpp
-  options.cpp
   ordered-index.cpp
   osmdata.cpp
   output-gazetteer.cpp

--- a/src/command-line-parser.hpp
+++ b/src/command-line-parser.hpp
@@ -1,0 +1,20 @@
+#ifndef OSM2PGSQL_COMMAND_LINE_PARSER_HPP
+#define OSM2PGSQL_COMMAND_LINE_PARSER_HPP
+
+/**
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This file is part of osm2pgsql (https://osm2pgsql.org/).
+ *
+ * Copyright (C) 2006-2023 by the osm2pgsql developer community.
+ * For a full list of authors see the git log.
+ */
+
+#include "options.hpp"
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
+options_t parse_command_line(int argc, char *argv[]);
+
+void print_version();
+
+#endif // OSM2PGSQL_COMMAND_LINE_PARSER_HPP

--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -28,7 +28,6 @@
 
 class node_locations_t;
 class node_persistent_cache;
-class options_t;
 
 class middle_query_pgsql_t : public middle_query_t
 {

--- a/src/middle-ram.hpp
+++ b/src/middle-ram.hpp
@@ -24,7 +24,6 @@
 #include <string>
 #include <utility>
 
-class options_t;
 class thread_pool_t;
 
 /**

--- a/src/middle.hpp
+++ b/src/middle.hpp
@@ -18,7 +18,7 @@
 #include "osmtypes.hpp"
 #include "thread-pool.hpp"
 
-class options_t;
+struct options_t;
 struct output_requirements;
 
 /**

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -19,6 +19,13 @@
 
 class reprojection;
 
+enum class command_t
+{
+    help,
+    version,
+    process
+};
+
 /// Variants for generation of hstore column
 enum class hstore_column : char
 {
@@ -70,27 +77,9 @@ struct output_requirements
 /**
  * Structure for storing command-line and other options
  */
-class options_t
+struct options_t
 {
-public:
-    /**
-     * Constructor setting default values for all options. Used for testing.
-     */
-    options_t();
-
-    /**
-     * Constructor parsing the options from the command line.
-     */
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
-    options_t(int argc, char *argv[]);
-
-    /**
-     * Return true if the main program should end directly after the option
-     * parsing. This is true when a help text was printed.
-     */
-    bool early_return() const noexcept {
-        return m_print_help;
-    }
+    command_t command = command_t::process;
 
     std::string conninfo; ///< connection info for database
 
@@ -185,15 +174,6 @@ public:
     bool parallel_indexing = true;
     bool create = false;
     bool pass_prompt = false;
-
-private:
-
-    bool m_print_help = false;
-
-    /**
-     * Check input options for sanity
-     */
-    void check_options();
-};
+}; // struct options_t
 
 #endif // OSM2PGSQL_OPTIONS_HPP

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -7,6 +7,7 @@
  * For a full list of authors see the git log.
  */
 
+#include "command-line-parser.hpp"
 #include "dependency-manager.hpp"
 #include "input.hpp"
 #include "logging.hpp"
@@ -253,8 +254,15 @@ int main(int argc, char *argv[])
     try {
         log_info("osm2pgsql version {}", get_osm2pgsql_version());
 
-        options_t options{argc, argv};
-        if (options.early_return()) {
+        auto options = parse_command_line(argc, argv);
+
+        if (options.command == command_t::help) {
+            // Already handled inside parse_command_line()
+            return 0;
+        }
+
+        if (options.command == command_t::version) {
+            print_version();
             return 0;
         }
 

--- a/src/osmdata.hpp
+++ b/src/osmdata.hpp
@@ -27,8 +27,8 @@
 #include "osmtypes.hpp"
 
 class middle_t;
-class options_t;
 class output_t;
+struct options_t;
 
 /**
  * This class guides the processing of the OSM data through its multiple

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -35,8 +35,8 @@ extern "C"
 class db_copy_thread_t;
 class db_deleter_by_type_and_id_t;
 class geom_transform_t;
-class options_t;
 class thread_pool_t;
+struct options_t;
 
 using idset_t = osmium::index::IdSetSmall<osmid_t>;
 

--- a/src/tagtransform.hpp
+++ b/src/tagtransform.hpp
@@ -17,7 +17,7 @@
 #include "osmtypes.hpp"
 
 class export_list;
-class options_t;
+struct options_t;
 
 class tagtransform_t
 {

--- a/tests/test-options-parse.cpp
+++ b/tests/test-options-parse.cpp
@@ -11,7 +11,7 @@
 
 #include <vector>
 
-#include "options.hpp"
+#include "command-line-parser.hpp"
 #include "taginfo-impl.hpp"
 #include "tagtransform.hpp"
 
@@ -21,22 +21,27 @@ static void bad_opt(std::vector<char const *> opts, char const *msg)
 {
     opts.insert(opts.begin(), "osm2pgsql");
     opts.push_back(TEST_PBF);
-    REQUIRE_THROWS_WITH(options_t((int)opts.size(), (char **)opts.data()),
-                        Catch::Matchers::Contains(msg));
+
+    REQUIRE_THROWS_WITH(
+        parse_command_line((int)opts.size(), (char **)opts.data()),
+        Catch::Matchers::Contains(msg));
 }
 
 static options_t opt(std::vector<char const *> opts)
 {
     opts.insert(opts.begin(), "osm2pgsql");
     opts.push_back(TEST_PBF);
-    return {(int)opts.size(), (char **)opts.data()};
+
+    return parse_command_line((int)opts.size(), (char **)opts.data());
 }
 
 TEST_CASE("Insufficient arguments", "[NoDB]")
 {
     std::vector<char const *> opts = {"osm2pgsql", "-a", "-c", "--slim"};
-    REQUIRE_THROWS_WITH(options_t((int)opts.size(), (char **)opts.data()),
-                        Catch::Matchers::Contains("Missing input"));
+
+    REQUIRE_THROWS_WITH(
+        parse_command_line((int)opts.size(), (char **)opts.data()),
+        Catch::Matchers::Contains("Missing input"));
 }
 
 TEST_CASE("Incompatible arguments", "[NoDB]")

--- a/tests/test-options-projection.cpp
+++ b/tests/test-options-projection.cpp
@@ -12,6 +12,8 @@
 #include <vector>
 
 #include "common-import.hpp"
+
+#include "command-line-parser.hpp"
 #include "reprojection.hpp"
 
 static testing::db::import_t db;
@@ -73,8 +75,8 @@ TEST_CASE("Projection setup")
 
     option_params.push_back("foo");
 
-    options_t const options{(int)option_params.size(),
-                            (char **)option_params.data()};
+    auto const options = parse_command_line((int)option_params.size(),
+                                            (char **)option_params.data());
 
     if (!proj_name.empty()) {
         CHECK(options.projection->target_desc() == proj_name);


### PR DESCRIPTION
Removes all code from the options_t class and makes it into a simple struct. All code parsing and checking the command line is now in command-line-parser.hpp/cpp.