### PR TITLE
Various smaller fixes and cleanups

### DIFF
--- a/src/db-copy.cpp
+++ b/src/db-copy.cpp
@@ -163,7 +163,7 @@ void db_copy_thread_t::thread_t::operator()()
         m_conn.reset();
     } catch (std::runtime_error const &e) {
         log_error("DB copy thread failed: {}", e.what());
-        exit(2);
+        std::exit(2); // NOLINT(concurrency-mt-unsafe)
     }
 }
 

--- a/src/expire-output.cpp
+++ b/src/expire-output.cpp
@@ -14,6 +14,8 @@
 #include "pgsql.hpp"
 #include "tile.hpp"
 
+#include <system_error>
+
 std::size_t expire_output_t::output(quadkey_list_t const &tile_list,
                                     std::string const &conninfo) const
 {
@@ -32,9 +34,10 @@ std::size_t expire_output_t::output_tiles_to_file(
 {
     FILE *outfile = std::fopen(m_filename.data(), "a");
     if (outfile == nullptr) {
+        std::system_error error{errno, std::generic_category()};
         log_warn("Failed to open expired tiles file ({}). Tile expiry "
                  "list will not be written!",
-                 std::strerror(errno));
+                 error.code().message());
         return 0;
     }
 

--- a/src/middle.hpp
+++ b/src/middle.hpp
@@ -26,7 +26,14 @@ struct output_requirements;
  */
 struct middle_query_t : std::enable_shared_from_this<middle_query_t>
 {
+    middle_query_t() noexcept = default;
+
     virtual ~middle_query_t() = 0;
+
+    middle_query_t(middle_query_t const &) = delete;
+    middle_query_t &operator=(middle_query_t const &) = delete;
+    middle_query_t(middle_query_t &&) = delete;
+    middle_query_t &operator=(middle_query_t &&) = delete;
 
     /**
      * Retrieves node location for the given id.
@@ -94,6 +101,11 @@ public:
     {}
 
     virtual ~middle_t() = 0;
+
+    middle_t(middle_t const &) = delete;
+    middle_t &operator=(middle_t const &) = delete;
+    middle_t(middle_t &&) = delete;
+    middle_t &operator=(middle_t &&) = delete;
 
     virtual void start() = 0;
     virtual void stop() = 0;

--- a/src/pgsql.hpp
+++ b/src/pgsql.hpp
@@ -238,11 +238,9 @@ private:
     template <typename T>
     static constexpr std::size_t buffers_needed() noexcept
     {
-        if constexpr (std::is_same_v<T, char const *>) {
-            return 0;
-        } else if constexpr (std::is_same_v<T, std::string>) {
-            return 0;
-        } else if constexpr (std::is_same_v<T, binary_param>) {
+        if constexpr (std::is_same_v<T, char const *> ||
+                      std::is_same_v<T, std::string> ||
+                      std::is_same_v<T, binary_param>) {
             return 0;
         }
         return 1;

--- a/src/pgsql.hpp
+++ b/src/pgsql.hpp
@@ -303,7 +303,8 @@ private:
         std::size_t n = 0;
         std::size_t m = 0;
         std::array<char const *, sizeof...(params)> param_ptrs = {
-            to_str<std::decay_t<TArgs>>(&exec_params, &lengths[n++], &bins[m++],
+            to_str<std::decay_t<TArgs>>(&exec_params, &lengths.at(n++),
+                                        &bins.at(m++),
                                         std::forward<TArgs>(params))...};
 
         return exec_prepared_internal(stmt, sizeof...(params),

--- a/src/tagtransform.hpp
+++ b/src/tagtransform.hpp
@@ -25,7 +25,14 @@ public:
     static std::unique_ptr<tagtransform_t>
     make_tagtransform(options_t const *options, export_list const &exlist);
 
+    tagtransform_t() noexcept = default;
+
     virtual ~tagtransform_t() = 0;
+
+    tagtransform_t(tagtransform_t const &) = delete;
+    tagtransform_t &operator=(tagtransform_t const &) = delete;
+    tagtransform_t(tagtransform_t &&) = delete;
+    tagtransform_t &operator=(tagtransform_t &&) = delete;
 
     virtual std::unique_ptr<tagtransform_t> clone() const = 0;
 

--- a/src/version.cpp.in
+++ b/src/version.cpp.in
@@ -7,6 +7,8 @@
  * For a full list of authors see the git log.
  */
 
+#include "version.hpp"
+
 char const *get_build_type() noexcept
 {
     return "@CMAKE_BUILD_TYPE@";
@@ -27,7 +29,7 @@ char const *get_minimum_postgresql_server_version() noexcept
     return "@MINIMUM_POSTGRESQL_SERVER_VERSION@";
 }
 
-unsigned long get_minimum_postgresql_server_version_num() noexcept
+uint32_t get_minimum_postgresql_server_version_num() noexcept
 {
     return @MINIMUM_POSTGRESQL_SERVER_VERSION_NUM@;
 }

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -10,10 +10,12 @@
  * For a full list of authors see the git log.
  */
 
+#include <cstdint>
+
 char const *get_build_type() noexcept;
 char const *get_osm2pgsql_version() noexcept;
 char const *get_osm2pgsql_short_version() noexcept;
 char const *get_minimum_postgresql_server_version() noexcept;
-unsigned long get_minimum_postgresql_server_version_num() noexcept;
+uint32_t get_minimum_postgresql_server_version_num() noexcept;
 
 #endif // OSM2PGSQL_VERSION_HPP


### PR DESCRIPTION
Fixes clang-tidy warnings

See individual commits.