### PR TITLE
Clean up lua includes

### DIFF
--- a/src/command-line-parser.cpp
+++ b/src/command-line-parser.cpp
@@ -21,25 +21,15 @@
 
 #include <getopt.h>
 
+#ifdef HAVE_LUA
+#include <lua.hpp>
+#endif
+
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <stdexcept>
 #include <thread> // for number of threads
-
-#ifdef HAVE_LUA
-extern "C"
-{
-#include <lua.h>
-}
-#endif
-
-#ifdef HAVE_LUAJIT
-extern "C"
-{
-#include <luajit.h>
-}
-#endif
 
 static char const *program_name(char const *name)
 {

--- a/src/flex-lua-geom.cpp
+++ b/src/flex-lua-geom.cpp
@@ -12,11 +12,7 @@
 #include "geom-pole-of-inaccessibility.hpp"
 #include "lua-utils.hpp"
 
-extern "C"
-{
-#include <lauxlib.h>
-#include <lua.h>
-}
+#include <lua.hpp>
 
 static char const *const osm2pgsql_geometry_class = "osm2pgsql.Geometry";
 

--- a/src/geom-transform.hpp
+++ b/src/geom-transform.hpp
@@ -17,10 +17,7 @@
 #include <osmium/fwd.hpp>
 #include <osmium/memory/buffer.hpp>
 
-extern "C"
-{
-#include <lua.h>
-}
+#include <lua.hpp>
 
 #include <memory>
 

--- a/src/lua-utils.cpp
+++ b/src/lua-utils.cpp
@@ -8,12 +8,8 @@
  */
 
 #include "lua-utils.hpp"
-#include "format.hpp"
 
-extern "C"
-{
-#include <lauxlib.h>
-}
+#include "format.hpp"
 
 #include <cassert>
 #include <stdexcept>

--- a/src/lua-utils.hpp
+++ b/src/lua-utils.hpp
@@ -13,10 +13,7 @@
 // This file contains helper functions for talking to Lua. It is used from
 // the flex output backend. All functions start with "luaX_".
 
-extern "C"
-{
-#include <lua.h>
-}
+#include <lua.hpp>
 
 #include <cassert>
 #include <cstdint>

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -39,12 +39,6 @@
 
 #include <osmium/osm/types_from_string.hpp>
 
-extern "C"
-{
-#include <lauxlib.h>
-#include <lualib.h>
-}
-
 #include <cassert>
 #include <cstdlib>
 #include <cstring>

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -21,10 +21,7 @@
 #include <osmium/index/id_set.hpp>
 #include <osmium/osm/item_type.hpp>
 
-extern "C"
-{
-#include <lua.h>
-}
+#include <lua.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/src/tagtransform-lua.cpp
+++ b/src/tagtransform-lua.cpp
@@ -7,12 +7,6 @@
  * For a full list of authors see the git log.
  */
 
-extern "C"
-{
-#include <lauxlib.h>
-#include <lualib.h>
-}
-
 #include "format.hpp"
 #include "lua-utils.hpp"
 #include "tagtransform-lua.hpp"

--- a/src/tagtransform-lua.hpp
+++ b/src/tagtransform-lua.hpp
@@ -14,10 +14,7 @@
 
 #include "tagtransform.hpp"
 
-extern "C"
-{
-#include <lua.h>
-}
+#include <lua.hpp>
 
 class lua_tagtransform_t : public tagtransform_t
 {

--- a/tests/test-flex-indexes.cpp
+++ b/tests/test-flex-indexes.cpp
@@ -11,8 +11,9 @@
 
 #include "flex-lua-index.hpp"
 #include "flex-table.hpp"
-#include "lua.hpp"
 #include "pgsql-capabilities-int.hpp"
+
+#include <lua.hpp>
 
 class test_framework
 {

--- a/tests/test-lua-utils.cpp
+++ b/tests/test-lua-utils.cpp
@@ -11,10 +11,7 @@
 
 #include "lua-utils.hpp"
 
-extern "C"
-{
-#include <lauxlib.h>
-}
+#include <lua.hpp>
 
 // Run the Lua code in "code" and then execute the function "func".
 template <typename FUNC>


### PR DESCRIPTION
There was a bit of a mess of different (types of) includes. We now only use '#include <lua.hpp>' which includes all Lua C headers correctly and also works for LuaJIT.

Technically it might include more than we need in some cases, because lua.hpp includes several C headers some of which are only needed sometimes, but the largest one (lua.h) is the one we always need, the others are tiny.