### PR TITLE
Remove "area" column in generic.lua example

### DIFF
--- a/flex-config/generic.lua
+++ b/flex-config/generic.lua
@@ -22,7 +22,6 @@ tables.lines = osm2pgsql.define_way_table('lines', {
 tables.polygons = osm2pgsql.define_area_table('polygons', {
     { column = 'tags', type = 'jsonb' },
     { column = 'geom', type = 'geometry', projection = srid, not_null = true },
-    { column = 'area', type = 'area' },
 })
 
 tables.routes = osm2pgsql.define_relation_table('routes', {


### PR DESCRIPTION
This columns isn't magically filled any more since we switched from add_row() to insert().