### PR TITLE
Remove comment about hardcoded id

### DIFF
--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -86,7 +86,7 @@ middle_pgsql_t::table_desc::table_desc(options_t const &options,
 {
     m_copy_target->name = build_sql(options, ts.name);
     m_copy_target->schema = options.middle_dbschema;
-    m_copy_target->id = "id"; // XXX hardcoded column name
+    m_copy_target->id = "id";
 
     if (options.with_forward_dependencies) {
         m_prepare_fw_dep_lookups =


### PR DESCRIPTION
We only every use the name "id" for the middle tables, so it's totally fine that this is hardcoded here.