### PR TITLE
Middle: Get dependencies with single queries

### DIFF
--- a/src/dependency-manager.cpp
+++ b/src/dependency-manager.cpp
@@ -20,13 +20,7 @@ void full_dependency_manager_t::node_changed(osmid_t id)
 
 void full_dependency_manager_t::way_changed(osmid_t id)
 {
-    if (m_ways_pending_tracker.get(id)) {
-        return;
-    }
-
-    for (auto const rel_id : m_object_store->get_rels_by_way(id)) {
-        m_rels_pending_tracker.set(rel_id);
-    }
+    m_changed_ways.set(id);
 }
 
 void full_dependency_manager_t::after_nodes()
@@ -38,12 +32,55 @@ void full_dependency_manager_t::after_nodes()
     m_object_store->get_node_parents(m_changed_nodes, &m_ways_pending_tracker,
                                      &m_rels_pending_tracker);
     m_changed_nodes.clear();
+}
 
-    for (auto const way_id : m_ways_pending_tracker) {
-        for (auto const rel_id : m_object_store->get_rels_by_way(way_id)) {
-            m_rels_pending_tracker.set(rel_id);
+static osmium::index::IdSetSmall<osmid_t>
+set_diff(osmium::index::IdSetSmall<osmid_t> const &set,
+         osmium::index::IdSetSmall<osmid_t> const &to_be_removed)
+{
+    osmium::index::IdSetSmall<osmid_t> new_set;
+
+    for (auto const id : set) {
+        if (!to_be_removed.get_binary_search(id)) {
+            new_set.set(id);
         }
     }
+
+    return new_set;
+}
+
+void full_dependency_manager_t::after_ways()
+{
+    if (!m_changed_ways.empty()) {
+        if (!m_ways_pending_tracker.empty()) {
+            // Remove ids from changed ways in the input data from
+            // m_ways_pending_tracker, because they have already been processed.
+            m_ways_pending_tracker =
+                set_diff(m_ways_pending_tracker, m_changed_ways);
+
+            // Add the list of pending way ids to the list of changed ways,
+            // because we need the parents for them, too.
+            m_changed_ways.merge_sorted(m_ways_pending_tracker);
+        }
+
+        m_object_store->get_way_parents(m_changed_ways,
+                                        &m_rels_pending_tracker);
+
+        m_changed_ways.clear();
+        return;
+    }
+
+    if (!m_ways_pending_tracker.empty()) {
+        m_object_store->get_way_parents(m_ways_pending_tracker,
+                                        &m_rels_pending_tracker);
+    }
+}
+
+void full_dependency_manager_t::mark_parent_relations_as_pending(
+    osmium::index::IdSetSmall<osmid_t> const &way_ids)
+{
+    assert(m_rels_pending_tracker.empty());
+    m_object_store->get_way_parents(way_ids, &m_rels_pending_tracker);
 }
 
 bool full_dependency_manager_t::has_pending() const noexcept

--- a/src/dependency-manager.cpp
+++ b/src/dependency-manager.cpp
@@ -23,6 +23,11 @@ void full_dependency_manager_t::way_changed(osmid_t id)
     m_changed_ways.set(id);
 }
 
+void full_dependency_manager_t::relation_changed(osmid_t id)
+{
+    m_changed_relations.set(id);
+}
+
 void full_dependency_manager_t::after_nodes()
 {
     if (m_changed_nodes.empty()) {
@@ -74,6 +79,16 @@ void full_dependency_manager_t::after_ways()
         m_object_store->get_way_parents(m_ways_pending_tracker,
                                         &m_rels_pending_tracker);
     }
+}
+
+void full_dependency_manager_t::after_relations()
+{
+    // Remove ids from changed relations in the input data from
+    // m_rels_pending_tracker, because they have already been processed.
+    m_rels_pending_tracker =
+        set_diff(m_rels_pending_tracker, m_changed_relations);
+
+    m_changed_relations.clear();
 }
 
 void full_dependency_manager_t::mark_parent_relations_as_pending(

--- a/src/dependency-manager.hpp
+++ b/src/dependency-manager.hpp
@@ -52,8 +52,11 @@ public:
      */
     virtual void way_changed(osmid_t) {}
 
+    virtual void relation_changed(osmid_t) {}
+
     virtual void after_nodes() {}
     virtual void after_ways() {}
+    virtual void after_relations() {}
 
     virtual void mark_parent_relations_as_pending(
         osmium::index::IdSetSmall<osmid_t> const & /*way_ids*/)
@@ -102,9 +105,11 @@ public:
 
     void node_changed(osmid_t id) override;
     void way_changed(osmid_t id) override;
+    void relation_changed(osmid_t id) override;
 
     void after_nodes() override;
     void after_ways() override;
+    void after_relations() override;
 
     void mark_parent_relations_as_pending(
         osmium::index::IdSetSmall<osmid_t> const &ids) override;
@@ -144,6 +149,13 @@ private:
      * and so we don't have to find out which ones they are.
      */
     osmium::index::IdSetSmall<osmid_t> m_changed_ways;
+
+    /**
+     * In append mode all new and changed relations will be added to this.
+     * This is then used to remove already processed relations from the
+     * pending list.
+     */
+    osmium::index::IdSetSmall<osmid_t> m_changed_relations;
 
     osmium::index::IdSetSmall<osmid_t> m_ways_pending_tracker;
     osmium::index::IdSetSmall<osmid_t> m_rels_pending_tracker;

--- a/src/dependency-manager.hpp
+++ b/src/dependency-manager.hpp
@@ -53,6 +53,12 @@ public:
     virtual void way_changed(osmid_t) {}
 
     virtual void after_nodes() {}
+    virtual void after_ways() {}
+
+    virtual void mark_parent_relations_as_pending(
+        osmium::index::IdSetSmall<osmid_t> const & /*way_ids*/)
+    {
+    }
 
     /// Are there pending objects that need to be processed?
     virtual bool has_pending() const noexcept { return false; }
@@ -98,6 +104,10 @@ public:
     void way_changed(osmid_t id) override;
 
     void after_nodes() override;
+    void after_ways() override;
+
+    void mark_parent_relations_as_pending(
+        osmium::index::IdSetSmall<osmid_t> const &ids) override;
 
     bool has_pending() const noexcept override;
 
@@ -125,6 +135,15 @@ private:
      * are.
      */
     osmium::index::IdSetSmall<osmid_t> m_changed_nodes;
+
+    /**
+     * In append mode all new and changed ways will be added to this. After
+     * all ways are read this is used to figure out which parent relations
+     * reference these ways. Deleted ways are not stored in here, because all
+     * relations that referenced deleted ways must be in the change file, too,
+     * and so we don't have to find out which ones they are.
+     */
+    osmium::index::IdSetSmall<osmid_t> m_changed_ways;
 
     osmium::index::IdSetSmall<osmid_t> m_ways_pending_tracker;
     osmium::index::IdSetSmall<osmid_t> m_rels_pending_tracker;

--- a/src/dependency-manager.hpp
+++ b/src/dependency-manager.hpp
@@ -52,6 +52,8 @@ public:
      */
     virtual void way_changed(osmid_t) {}
 
+    virtual void after_nodes() {}
+
     /// Are there pending objects that need to be processed?
     virtual bool has_pending() const noexcept { return false; }
 
@@ -95,6 +97,8 @@ public:
     void node_changed(osmid_t id) override;
     void way_changed(osmid_t id) override;
 
+    void after_nodes() override;
+
     bool has_pending() const noexcept override;
 
     idlist_t get_pending_way_ids() override
@@ -111,6 +115,16 @@ private:
     static idlist_t get_ids(osmium::index::IdSetSmall<osmid_t> *tracker);
 
     std::shared_ptr<middle_t> m_object_store;
+
+    /**
+     * In append mode all new and changed nodes will be added to this. After
+     * all nodes are read this is used to figure out which parent ways and
+     * relations reference these nodes. Deleted nodes are not stored in here,
+     * because all ways and relations that referenced deleted nodes must be in
+     * the change file, too, and so we don't have to find out which ones they
+     * are.
+     */
+    osmium::index::IdSetSmall<osmid_t> m_changed_nodes;
 
     osmium::index::IdSetSmall<osmid_t> m_ways_pending_tracker;
     osmium::index::IdSetSmall<osmid_t> m_rels_pending_tracker;

--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -117,8 +117,11 @@ struct middle_pgsql_t : public middle_t
     void after_ways() override;
     void after_relations() override;
 
-    idlist_t get_ways_by_node(osmid_t osm_id) override;
-    idlist_t get_rels_by_node(osmid_t osm_id) override;
+    void get_node_parents(
+        osmium::index::IdSetSmall<osmid_t> const &changed_nodes,
+        osmium::index::IdSetSmall<osmid_t> *parent_ways,
+        osmium::index::IdSetSmall<osmid_t> *parent_relations) const override;
+
     idlist_t get_rels_by_way(osmid_t osm_id) override;
 
     class table_desc

--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -95,7 +95,6 @@ struct table_sql
     std::string name;
     std::string create_table;
     std::string prepare_query;
-    std::string prepare_fw_dep_lookups;
     std::string create_fw_dep_indexes;
 };
 
@@ -122,7 +121,9 @@ struct middle_pgsql_t : public middle_t
         osmium::index::IdSetSmall<osmid_t> *parent_ways,
         osmium::index::IdSetSmall<osmid_t> *parent_relations) const override;
 
-    idlist_t get_rels_by_way(osmid_t osm_id) override;
+    void get_way_parents(
+        osmium::index::IdSetSmall<osmid_t> const &changed_ways,
+        osmium::index::IdSetSmall<osmid_t> *parent_relations) const override;
 
     class table_desc
     {
@@ -150,7 +151,6 @@ struct middle_pgsql_t : public middle_t
 
         std::string m_create_table;
         std::string m_prepare_query;
-        std::string m_prepare_fw_dep_lookups;
         std::string m_create_fw_dep_indexes;
 
         void task_set(std::future<std::chrono::microseconds> &&future)

--- a/src/middle.hpp
+++ b/src/middle.hpp
@@ -10,6 +10,7 @@
  * For a full list of authors see the git log.
  */
 
+#include <osmium/index/id_set.hpp>
 #include <osmium/memory/buffer.hpp>
 #include <osmium/osm/entity_bits.hpp>
 
@@ -148,8 +149,13 @@ public:
 #endif
     }
 
-    virtual idlist_t get_ways_by_node(osmid_t) { return {}; }
-    virtual idlist_t get_rels_by_node(osmid_t) { return {}; }
+    virtual void get_node_parents(
+        osmium::index::IdSetSmall<osmid_t> const & /*changed_nodes*/,
+        osmium::index::IdSetSmall<osmid_t> * /*parent_ways*/,
+        osmium::index::IdSetSmall<osmid_t> * /*parent_relations*/) const
+    {
+    }
+
     virtual idlist_t get_rels_by_way(osmid_t) { return {}; }
 
     virtual std::shared_ptr<middle_query_t> get_query_instance() = 0;

--- a/src/middle.hpp
+++ b/src/middle.hpp
@@ -156,7 +156,11 @@ public:
     {
     }
 
-    virtual idlist_t get_rels_by_way(osmid_t) { return {}; }
+    virtual void get_way_parents(
+        osmium::index::IdSetSmall<osmid_t> const & /*changed_ways*/,
+        osmium::index::IdSetSmall<osmid_t> * /*parent_relations*/) const
+    {
+    }
 
     virtual std::shared_ptr<middle_query_t> get_query_instance() = 0;
 

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -109,6 +109,9 @@ void osmdata_t::after_ways()
 {
     m_mid->after_ways();
     m_output->after_ways();
+    if (m_append) {
+        m_dependency_manager->after_ways();
+    }
 }
 
 void osmdata_t::relation(osmium::Relation const &rel)
@@ -351,9 +354,12 @@ void osmdata_t::process_dependents() const
     }
 
     // stage 1c processing: mark parent relations of marked objects as changed
-    for (auto const id : m_output->get_marked_way_ids()) {
-        m_dependency_manager->way_changed(id);
+    auto marked_ways = m_output->get_marked_way_ids();
+    if (marked_ways.empty()) {
+        return;
     }
+
+    m_dependency_manager->mark_parent_relations_as_pending(marked_ways);
 
     // process parent relations of marked ways
     if (m_dependency_manager->has_pending()) {

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -78,6 +78,9 @@ void osmdata_t::after_nodes()
 {
     m_mid->after_nodes();
     m_output->after_nodes();
+    if (m_append) {
+        m_dependency_manager->after_nodes();
+    }
 }
 
 void osmdata_t::way(osmium::Way &way)

--- a/src/osmdata.cpp
+++ b/src/osmdata.cpp
@@ -141,12 +141,19 @@ void osmdata_t::relation(osmium::Relation const &rel)
         } else {
             m_output->relation_delete(rel.id());
         }
+        m_dependency_manager->relation_changed(rel.id());
     } else if (has_tags_or_attrs) {
         m_output->relation_add(rel);
     }
 }
 
-void osmdata_t::after_relations() { m_mid->after_relations(); }
+void osmdata_t::after_relations()
+{
+    m_mid->after_relations();
+    if (m_append) {
+        m_dependency_manager->after_relations();
+    }
+}
 
 void osmdata_t::start() const
 {

--- a/src/pgsql-helper.cpp
+++ b/src/pgsql-helper.cpp
@@ -25,13 +25,6 @@ idlist_t get_ids_from_result(pg_result_t const &result) {
     return ids;
 }
 
-idlist_t get_ids_from_db(pg_conn_t const *db_connection, char const *stmt,
-                         osmid_t id)
-{
-    auto const res = db_connection->exec_prepared(stmt, id);
-    return get_ids_from_result(res);
-}
-
 void create_geom_check_trigger(pg_conn_t *db_connection,
                                std::string const &schema,
                                std::string const &table,

--- a/src/pgsql-helper.hpp
+++ b/src/pgsql-helper.hpp
@@ -27,9 +27,6 @@ class pg_result_t;
  */
 idlist_t get_ids_from_result(pg_result_t const &result);
 
-idlist_t get_ids_from_db(pg_conn_t const *db_connection, char const *stmt,
-                         osmid_t id);
-
 void create_geom_check_trigger(pg_conn_t *db_connection,
                                std::string const &schema,
                                std::string const &table,

--- a/tests/test-middle.cpp
+++ b/tests/test-middle.cpp
@@ -1107,6 +1107,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
         mid->after_nodes();
         dependency_manager.after_nodes();
         mid->after_ways();
+        dependency_manager.after_ways();
         mid->after_relations();
 
         REQUIRE(dependency_manager.has_pending());
@@ -1141,6 +1142,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
             mid->after_nodes();
             dependency_manager.after_nodes();
             mid->after_ways();
+            dependency_manager.after_ways();
             mid->after_relations();
 
             REQUIRE(dependency_manager.has_pending());
@@ -1181,6 +1183,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
             mid->after_nodes();
             dependency_manager.after_nodes();
             mid->after_ways();
+            dependency_manager.after_ways();
             mid->after_relations();
 
             REQUIRE_FALSE(dependency_manager.has_pending());
@@ -1247,6 +1250,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in relation", "", options_slim_default,
         mid->after_nodes();
         dependency_manager.after_nodes();
         mid->after_ways();
+        dependency_manager.after_ways();
         mid->after_relations();
 
         REQUIRE(dependency_manager.has_pending());
@@ -1268,6 +1272,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in relation", "", options_slim_default,
         mid->after_nodes();
         dependency_manager.after_nodes();
         mid->after_ways();
+        dependency_manager.after_ways();
         mid->after_relations();
 
         REQUIRE(dependency_manager.has_pending());

--- a/tests/test-middle.cpp
+++ b/tests/test-middle.cpp
@@ -1105,6 +1105,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
         mid->node(node10a);
         dependency_manager.node_changed(10);
         mid->after_nodes();
+        dependency_manager.after_nodes();
         mid->after_ways();
         mid->after_relations();
 
@@ -1138,6 +1139,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
             mid->node(node10a);
             dependency_manager.node_changed(10);
             mid->after_nodes();
+            dependency_manager.after_nodes();
             mid->after_ways();
             mid->after_relations();
 
@@ -1177,6 +1179,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
             mid->node(node10a);
             dependency_manager.node_changed(10);
             mid->after_nodes();
+            dependency_manager.after_nodes();
             mid->after_ways();
             mid->after_relations();
 
@@ -1242,6 +1245,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in relation", "", options_slim_default,
         mid->node(node10a);
         dependency_manager.node_changed(10);
         mid->after_nodes();
+        dependency_manager.after_nodes();
         mid->after_ways();
         mid->after_relations();
 
@@ -1262,6 +1266,7 @@ TEMPLATE_TEST_CASE("middle: change nodes in relation", "", options_slim_default,
         mid->node(node11a);
         dependency_manager.node_changed(11);
         mid->after_nodes();
+        dependency_manager.after_nodes();
         mid->after_ways();
         mid->after_relations();
 


### PR DESCRIPTION
In append mode osm2pgsql has to find all parent ways and relations of changed nodes and parent relations of changed ways. This is done by with one query per object read from the input file which is quite wasteful. This changes the code to only do a single query for all dependencies. The list of all changed ids is COPYied into a temporary table. Then parent objects ids are found and written into another temporary table and then retrieved. (We could this without the extra temporary tables, but this could allow us later to use the content of those tables somewhere else, so I chose to do it this way. Should make a big difference perfomance-wise.)

These PR also fixes #423, the longstanding problem that ways and relations that are in the input file AND parents of changed objects were process twice.

The work is split between three commits, one each for nodes, ways, and relations processing.

I did some performance measurements, in every one the new code was more efficient. For smaller (minutely) diffs the difference is small, about 30% performance improvements measured over 2000 something diffs. At the other end of the spectrum the performance gain is huge. Updating a planet file with a diff with about two weeks of data was an order of magnitude faster (from >10h down to an hour).