### PR TITLE
Don't do multi-statement queries

### DIFF
--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -94,8 +94,8 @@ struct table_sql
 {
     std::string name;
     std::string create_table;
-    std::string prepare_query;
-    std::string create_fw_dep_indexes;
+    std::vector<std::string> prepare_queries;
+    std::vector<std::string> create_fw_dep_indexes;
 };
 
 struct middle_pgsql_t : public middle_t
@@ -150,8 +150,8 @@ struct middle_pgsql_t : public middle_t
         void build_index(std::string const &conninfo) const;
 
         std::string m_create_table;
-        std::string m_prepare_query;
-        std::string m_create_fw_dep_indexes;
+        std::vector<std::string> m_prepare_queries;
+        std::vector<std::string> m_create_fw_dep_indexes;
 
         void task_set(std::future<std::chrono::microseconds> &&future)
         {

--- a/tests/test-middle.cpp
+++ b/tests/test-middle.cpp
@@ -1092,6 +1092,9 @@ TEMPLATE_TEST_CASE("middle: change nodes in way", "", options_slim_default,
         check_way_nodes(mid, way21.id(), {&node11, &node12});
 
         REQUIRE_FALSE(dependency_manager.has_pending());
+
+        mid->stop();
+        mid->wait();
     }
 
     // From now on use append mode to not destroy the data we just added.
@@ -1235,6 +1238,9 @@ TEMPLATE_TEST_CASE("middle: change nodes in relation", "", options_slim_default,
         mid->relation(rel30);
         mid->relation(rel31);
         mid->after_relations();
+
+        mid->stop();
+        mid->wait();
     }
 
     // From now on use append mode to not destroy the data we just added.


### PR DESCRIPTION
Only send one SQL command per exec(). This should fix a problem with the Pgpool-II connection pool server which doesn't support multi-statement queries. It also makes it hopefully a bit more obvious that there are several statements sent to the server. To that end I have also removed the semicolons at the end of the queries in all places, because they should never be needed any more.

I tested this with Pgpool-II and, at least in my quick test, everything ran through, which it doesn't without this patch.

Fixes #1994