### PR TITLE
Append mode: Do not try to delete objects that can't exist in middle

### DIFF
--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -160,9 +160,16 @@ struct middle_pgsql_t : public middle_t
 
         std::chrono::microseconds task_wait() { return m_task_result.wait(); }
 
+        void init_max_id(pg_conn_t const &db_connection);
+
+        osmid_t max_id() const noexcept { return m_max_id; }
+
     private:
         std::shared_ptr<db_target_descr_t> m_copy_target;
         task_result_t m_task_result;
+
+        /// The maximum id in the table (used only in append mode)
+        osmid_t m_max_id = 0;
     };
 
     std::shared_ptr<middle_query_t> get_query_instance() override;


### PR DESCRIPTION
When osm2pgsql runs in append mode it deletes all objects for which it gets new versions from the middle tables before then adding the new version. For a typical diff many of these deletes will be unnecessary because the objects are new. With this commit the behaviour changes slightly: We first get the maximum id from the nodes/ways/relations middle tables. This operation is fast, because the PostgreSQL max() function is aware of the btree index on those tables. Later, before we delete an object we check the id against that maximum id, if it is larger the object can't be in the table and we don't do the delete.

(Note that in theory we could use the fact that an object has version number 1 to figure out that it must be new. But this is much less robust than what we are doing here, for instance when the diff overlaps with the original import.)

Performance improvement for small (minutely) diffs is not measurable, for large diffs about 10%.