### PR TITLE
Fix a crash when an exception is thrown in postprocessing

### DIFF
--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -1076,8 +1076,22 @@ void output_flex_t::stop()
 
 void output_flex_t::wait()
 {
+    std::exception_ptr eptr;
+    flex_table_t const *table_with_error = nullptr;
+
     for (auto &table : m_table_connections) {
-        table.task_wait();
+        try {
+            table.task_wait();
+        } catch (...) {
+            eptr = std::current_exception();
+            table_with_error = &table.table();
+        }
+    }
+
+    if (eptr) {
+        log_error("Error while doing postprocessing on table '{}':",
+                  table_with_error->name());
+        std::rethrow_exception(eptr);
     }
 }
 

--- a/src/output-pgsql.cpp
+++ b/src/output-pgsql.cpp
@@ -159,8 +159,16 @@ void output_pgsql_t::stop()
 
 void output_pgsql_t::wait()
 {
+    std::exception_ptr eptr;
     for (auto &t : m_tables) {
-        t->task_wait();
+        try {
+            t->task_wait();
+        } catch (...) {
+            eptr = std::current_exception();
+        }
+    }
+    if (eptr) {
+        std::rethrow_exception(eptr);
     }
 }
 


### PR DESCRIPTION
Postprocessing (like building indexes) on output tables happens in parallel. If there is a problem an exception is thrown which is forwarded to the main thread. Here the normal exception handling will clean up everything including the table datastructures still used by the postprocessing of the other tables which might still be in flight.

We fix this by storing the exception, waiting for all threads to finish and only then passing on the exception.

It is rather unlikely that we'll see this problem in the pgsql output because tables are more or less hardcoded there. It is more likely in the flex output, where users have many options of creating some havoc with unusual table definitions or so. In the flex output we store the table name so that there is at least a chance of narrowing down the problem somewhat.