### PR TITLE
Add support for osm2pgsql_properties table to osm2pgsql-replication

### DIFF
--- a/docs/osm2pgsql-replication.1
+++ b/docs/osm2pgsql-replication.1
@@ -41,34 +41,69 @@ usage: osm2pgsql-replication init [-h] [-q] [-v] [-d DB] [-U NAME] [-H HOST]
                                   [-P PORT] [-p PREFIX]
                                   [--middle-schema MIDDLE_SCHEMA]
                                   [--osm-file FILE | --server URL]
+                                  [--start-at TIME]
 
 Initialise the replication process.
 .br
 
 .br
-There are two ways to initialise the replication process: if you have imported
+This function sets the replication service to use and determines from
 .br
-from a file that contains replication source information, then the
+which date to apply updates. You must call this function at least once
 .br
-initialisation process can use this and set up replication from there.
+to set up the replication process. It can safely be called again later
 .br
-Use the command \(cqosm2pgsql-replication \-\-osm\-file <filename>\(cq for this.
+to change the replication servers or to roll back the update process and
+.br
+reapply updates.
 .br
 
 .br
-If the file has no replication information or you don't have the initial
+There are different methods available for initialisation. When no
 .br
-import file anymore then replication can be set up according to
+additional parameters are given, the data is initialised from the data
 .br
-the data found in the database. It checks the planet_osm_way table for the
+in the database. If the data was imported from a file with replication
 .br
-newest way in the database and then queries the OSM API when the way was
+information and the properties table is available (for osm2pgsql >= 1.9)
 .br
-created. The date is used as the start date for replication. In this mode
+then the replication from the file is used. Otherwise the minutely
 .br
-the minutely diffs from the OSM servers are used as a source. You can change
+update service from openstreetmap.org is used as the default replication
 .br
-this with the \(cq\-\-server\(cq parameter.
+service. The start date is either taken from the database timestamp
+.br
+(for osm2pgsql >= 1.9) or determined from the newest way in the database
+.br
+by querying the OSM API about its creation date.
+.br
+
+.br
+The replication service can be changed with the \(cq\-\-server\(cq parameter.
+.br
+To use a different start date, add \(cq\-\-start\-at\(cq with an absolute
+.br
+ISO timestamp (e.g. 2007\-08\-20T12:21:53Z). When the program determines the
+.br
+start date from the database timestamp or way creation date, then it
+.br
+subtracts another 3 hours by default to ensure that all new changes are
+.br
+available. To change this rollback period, use \(cq\-\-start\-at\(cq with the
+.br
+number of minutes to rollback. This rollback mode can also be used to
+.br
+force initialisation to use the database date and ignore the date
+.br
+from the replication information in the file.
+.br
+
+.br
+The initialisation process can also use replication information from
+.br
+an OSM file directly and ignore all other date information.
+.br
+Use the command \(cqosm2pgsql-replication \-\-osm\-file <filename>\(cq for this.
 
 
 
@@ -110,7 +145,11 @@ Get replication information from the given file.
 
 .TP
 \fB\-\-server\fR URL
-Use replication server at the given URL (default: https://planet.openstreetmap.org/replication/minute)
+Use replication server at the given URL
+
+.TP
+\fB\-\-start\-at\fR TIME
+Time when to start replication. When an absolute timestamp (in ISO format) is given, it will be used. If a number is given, then replication starts the number of minutes before the known date of the database.
 
 .SH OPTIONS 'osm2pgsql-replication update'
 usage: osm2pgsql-replication update update [options] [-- param [param ...]]

--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -62,110 +62,280 @@ def pretty_format_timedelta(seconds):
     output = []
     # If weeks > 1 but hours == 0, we still want to show "0 hours"
     if weeks > 0:
-        output.append("{} week(s)".format(weeks))
+        output.append("{:d} week(s)".format(weeks))
     if days > 0 or weeks > 0:
-        output.append("{} day(s)".format(days))
+        output.append("{:d} day(s)".format(days))
     if hours > 0 or days > 0 or weeks > 0:
-        output.append("{} hour(s)".format(hours))
+        output.append("{:d} hour(s)".format(hours))
     if minutes > 0 or hours > 0 or days > 0 or weeks > 0:
-        output.append("{} minute(s)".format(minutes))
+        output.append("{:d} minute(s)".format(minutes))
 
-    output.append("{} second(s)".format(seconds))
+    output.append("{:d} second(s)".format(seconds))
 
     output = " ".join(output)
     return output
 
-def connect(args):
-    """ Create a connection from the given command line arguments.
-    """
-    # If dbname looks like a conninfo string use it as such
-    if args.database and any(part in args.database for part in ['=', '://']):
-        return psycopg.connect(args.database, fallback_application_name="osm2pgsql-replication")
 
-    return psycopg.connect(dbname=args.database, user=args.username,
-                           host=args.host, port=args.port, fallback_application_name="osm2pgsql-replication")
+def osm_date(date):
+    return date.strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
-def table_exists(conn, table_name, schema_name=None):
-    with conn.cursor() as cur:
-        if schema_name is not None:
-            cur.execute('SELECT * FROM pg_tables where tablename = %s and schemaname = %s ', (table_name, schema_name))
+def from_osm_date(datestr):
+    return dt.datetime.strptime(datestr, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=dt.timezone.utc)
+
+
+def start_point(param):
+    if param.isdigit():
+        return int(param)
+
+    if sys.version_info >= (3, 7):
+        try:
+            date = dt.datetime.fromisoformat(param)
+            if date.tzinfo is None:
+                date = date.replace(tzinfo=dt.timezone.utc)
+            return date
+        except ValueError:
+            pass
+
+    return from_osm_date(param)
+
+
+class DBError(Exception):
+
+    def __init__(self, errno, msg):
+        self.errno = errno
+        self.msg = msg
+
+
+class DBConnection:
+
+    def __init__(self, args):
+        self.schema = args.middle_schema
+
+        # If dbname looks like a conninfo string use it as such
+        if args.database and any(part in args.database for part in ['=', '://']):
+            self.conn = psycopg.connect(args.database,
+                                        fallback_application_name="osm2pgsql-replication")
+
+        self.conn = psycopg.connect(dbname=args.database, user=args.username,
+                                    host=args.host, port=args.port,
+                                    fallback_application_name="osm2pgsql-replication")
+
+        self.name = self.conn.get_dsn_parameters()['dbname']
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.conn is not None:
+            self.conn.close()
+
+    def table_exists(self, table_name):
+        with self.conn.cursor() as cur:
+            cur.execute('SELECT * FROM pg_tables where tablename = %s and schemaname = %s ',
+                        (table_name, self.schema))
+            return cur.rowcount > 0
+
+    def table_id(self, name):
+        return sql.Identifier(self.schema, name)
+
+
+class Osm2pgsqlProperties:
+    PROP_TABLE_NAME = 'osm2pgsql_properties'
+
+    def __init__(self, db):
+        self.db = db
+        self.is_updatable = self._get_prop('updatable') == 'true'
+
+    def _get_prop(self, name):
+        with self.db.conn.cursor() as cur:
+            cur.execute(sql.SQL("SELECT value FROM {} WHERE property = %s")
+                           .format(self.db.table_id(self.PROP_TABLE_NAME)),
+                        (name, ))
+            return cur.fetchone()[0] if cur.rowcount == 1 else None
+
+    def _set_prop(self, name, value):
+        with self.db.conn.cursor() as cur:
+            cur.execute(sql.SQL("""INSERT INTO {} (property, value) VALUES (%s, %s)
+                                   ON CONFLICT (property)
+                                   DO UPDATE SET value = EXCLUDED.value""")
+                           .format(self.db.table_id(self.PROP_TABLE_NAME)),
+                        (name, value))
+
+    def get_replication_base(self, server, start_at):
+        seq, date = None, None
+        if server is None:
+            server = self._get_prop('replication_base_url')
+            if server:
+                seq = self._get_prop('replication_sequence_number')
+                date = self._get_prop('replication_timestamp')
+                if date is not None:
+                    date = from_osm_date(date)
+            else:
+                server = 'https://planet.openstreetmap.org/replication/minute'
+
+        if isinstance(start_at, dt.datetime):
+            return server, None, start_at
+
+        if seq is None or isinstance(start_at, int):
+            date = self._get_prop('current_timestamp')
+            if date is None:
+                LOG.Fatal("Cannot get timestamp from database. "
+                          "Use --start-at to set an explicit date.")
+                return None, None, None
+
+            date = from_osm_date(date)
+            if start_at is not None:
+                date -= dt.timedelta(minutes=start_at)
+                seq = None
         else:
-            cur.execute('SELECT * FROM pg_tables where tablename = %s', (table_name, ))
-        return cur.rowcount > 0
+            seq = int(seq)
+
+        return server, seq, date
+
+    def get_replication_state(self):
+        if not self.db.table_exists(self.PROP_TABLE_NAME):
+            raise DBError(1, "Cannot find replication status table. Run 'osm2pgsql-replication init' first.")
+
+        base_url = self._get_prop('replication_base_url')
+        seq = self._get_prop('replication_sequence_number')
+        date = self._get_prop('replication_timestamp')
+
+        if base_url is None or seq is None or date is None:
+            raise DBError(2, "Updates not set up correctly. Run 'osm2pgsql-updates init' first.")
+
+        return base_url, int(seq), from_osm_date(date)
+
+    def write_replication_state(self, base_url, seq, date):
+        self._set_prop('replication_base_url', base_url)
+        self._set_prop('replication_sequence_number', seq)
+        self._set_prop('replication_timestamp', osm_date(date))
+        self.db.conn.commit()
 
 
-def compute_database_date(conn, schema, prefix):
-    """ Determine the date of the database from the newest object in the
-        database.
-    """
-    # First, find the way with the highest ID in the database
-    # Using nodes would be more reliable but those are not cached by osm2pgsql.
-    with conn.cursor() as cur:
-        table = sql.Identifier(schema, f'{prefix}_ways')
-        cur.execute(sql.SQL("SELECT max(id) FROM {}").format(table))
-        osmid = cur.fetchone()[0] if cur.rowcount == 1 else None
+class LegacyProperties:
 
-        if osmid is None:
-            LOG.fatal("No data found in the database.")
-            return None
+    def __init__(self, db, prefix):
+        self.db = db
+        self.prop_table = f'{prefix}_replication_status'
+        self.way_table = f'{prefix}_ways'
+        self.is_updatable = db.table_exists(self.way_table)
 
-    LOG.debug("Using way id %d for timestamp lookup", osmid)
-    # Get the way from the API to find the timestamp when it was created.
-    url = 'https://www.openstreetmap.org/api/0.6/way/{}/1'.format(osmid)
-    headers = {"User-Agent" : "osm2pgsql-update",
-               "Accept" : "application/json"}
-    with urlrequest.urlopen(urlrequest.Request(url, headers=headers)) as response:
-        data = json.loads(response.read().decode('utf-8'))
+    def get_replication_base(self, server, start_at):
+        """ Determine the date of the database from the newest object in the
+            database.
+        """
+        if server is None:
+            server = 'https://planet.openstreetmap.org/replication/minute'
 
-    if not data.get('elements') or not 'timestamp' in data['elements'][0]:
-        LOG.fatal("The way data downloaded from the API does not contain valid data.\n"
-                  "URL used: %s", url)
-        return None
+        if isinstance(start_at, dt.datetime):
+            return server, None, start_at
 
-    date = data['elements'][0]['timestamp']
-    LOG.debug("Found timestamp %s", date)
+        # First, find the way with the highest ID in the database
+        # Using nodes would be more reliable but those are not cached by osm2pgsql.
+        with self.db.conn.cursor() as cur:
+            cur.execute(sql.SQL("SELECT max(id) FROM {}")
+                           .format(self.db.table_id(self.way_table)))
+            osmid = cur.fetchone()[0] if cur.rowcount == 1 else None
 
-    try:
-        date = dt.datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ')
-    except ValueError:
-        LOG.fatal("Cannot parse timestamp '%s'", date)
-        return None
+            if osmid is None:
+                LOG.fatal("No data found in the database.")
+                return None, None, None
 
-    return date.replace(tzinfo=dt.timezone.utc)
+        LOG.debug("Using way id %d for timestamp lookup", osmid)
+        # Get the way from the API to find the timestamp when it was created.
+        url = 'https://www.openstreetmap.org/api/0.6/way/{}/1'.format(osmid)
+        headers = {"User-Agent" : "osm2pgsql-update",
+                   "Accept" : "application/json"}
+        with urlrequest.urlopen(urlrequest.Request(url, headers=headers)) as response:
+            data = json.loads(response.read().decode('utf-8'))
+
+        if not data.get('elements') or not 'timestamp' in data['elements'][0]:
+            LOG.fatal("The way data downloaded from the API does not contain valid data.\n"
+                      "URL used: %s", url)
+            return None, None, None
+
+        date = data['elements'][0]['timestamp']
+        LOG.debug("Found timestamp %s", date)
+
+        try:
+            date = from_osm_date(date)
+        except ValueError:
+            LOG.fatal("Cannot parse timestamp '%s'", date)
+            return None, None, None
+
+        if isinstance(start_at, int):
+            date -= dt.timedelta(minutes=start_at)
+
+        return server, None, date
+
+    def get_replication_state(self):
+        if not self.db.table_exists(self.prop_table):
+            raise DBError(1, "Cannot find replication status table. Run 'osm2pgsql-replication init' first.")
+
+        with self.db.conn.cursor() as cur:
+            cur.execute(sql.SQL('SELECT * FROM {}').format(self.db.table_id(self.prop_table)))
+            if cur.rowcount != 1:
+                raise DBError(2, "Updates not set up correctly. Run 'osm2pgsql-updates init' first.")
+
+            base_url, seq, date = cur.fetchone()
+
+        if base_url is None or seq is None or date is None:
+            raise DBError(2, "Updates not set up correctly. Run 'osm2pgsql-updates init' first.")
+
+        return base_url, seq, date
+
+    def write_replication_state(self, base_url, seq, date):
+        table = self.db.table_id(self.prop_table)
+        with self.db.conn.cursor() as cur:
+            if not self.db.table_exists(self.prop_table):
+                cur.execute(sql.SQL("""CREATE TABLE {}
+                                       (url TEXT,
+                                        sequence INTEGER,
+                                        importdate TIMESTAMP WITH TIME ZONE)
+                                    """).format(table))
+            cur.execute(sql.SQL('TRUNCATE {}').format(table))
+            if date:
+                cur.execute(sql.SQL('INSERT INTO {} VALUES(%s, %s, %s)').format(table),
+                            (base_url, seq, date))
+            else:
+                cur.execute(sql.SQL('INSERT INTO {} VALUES(%s, %s)').format(table),
+                            (base_url, seq))
+        self.db.conn.commit()
 
 
-def setup_replication_state(conn, table, base_url, seq, date):
-    """ (Re)create the table for the replication state and fill it with
-        the given state.
-    """
-    with conn.cursor() as cur:
-        cur.execute(sql.SQL('DROP TABLE IF EXISTS {}').format(table))
-        cur.execute(sql.SQL("""CREATE TABLE {}
-                               (url TEXT,
-                                sequence INTEGER,
-                                importdate TIMESTAMP WITH TIME ZONE)
-                            """).format(table))
-        cur.execute(sql.SQL('INSERT INTO {} VALUES(%s, %s, %s)').format(table),
-                    (base_url, seq, date))
-    conn.commit()
+def get_status_info(props, args):
+    results = {'status': 0}
+
+    base_url, db_seq, db_ts = props.get_replication_state()
+
+    db_ts = db_ts.astimezone(dt.timezone.utc)
+    results['server'] = {'base_url': base_url}
+    results['local'] = {'sequence': db_seq, 'timestamp': osm_date(db_ts)}
+
+    repl = ReplicationServer(base_url)
+    state_info = repl.get_state_info()
+    if state_info is None:
+        # PyOsmium was unable to download the state information
+        results['status'] = 3
+        results['error'] = "Unable to download the state information from {}".format(base_url)
+    else:
+        results['status'] = 0
+        now = dt.datetime.now(dt.timezone.utc)
+
+        server_seq, server_ts = state_info
+        server_ts = server_ts.astimezone(dt.timezone.utc)
+
+        results['server']['sequence'] = server_seq
+        results['server']['timestamp'] = osm_date(server_ts)
+        results['server']['age_sec'] = int((now-server_ts).total_seconds())
+
+        results['local']['age_sec'] = int((now - db_ts).total_seconds())
+
+    return results
 
 
-def update_replication_state(conn, table, seq, date):
-    """ Update sequence and date in the replication state table.
-        The table is assumed to exist.
-    """
-    with conn.cursor() as cur:
-        if date is not None:
-            cur.execute(sql.SQL('UPDATE {} SET sequence=%s, importdate=%s').format(table),
-                        (seq, date))
-        else:
-            cur.execute(sql.SQL('UPDATE {} SET sequence=%s').format(table),
-                        (seq,))
-
-    conn.commit()
-
-def status(conn, args):
+def status(props, args):
     """\
     Print information about the current replication status, optionally as JSON.
 
@@ -206,47 +376,10 @@ def status(conn, args):
 
     `local` is the status of your server.
     """
-
-    results = {}
-
-    if not table_exists(conn, args.table_name, args.middle_schema):
-        results['status'] = 1
-        results['error'] = "Cannot find replication status table. Run 'osm2pgsql-replication init' first."
-    else:
-        with conn.cursor() as cur:
-            cur.execute(sql.SQL('SELECT * FROM {}').format(args.table))
-            if cur.rowcount != 1:
-                results['status'] = 2
-                results['error'] = "Updates not set up correctly. Run 'osm2pgsql-updates init' first."
-            else:
-
-                base_url, db_seq, db_ts = cur.fetchone()
-                db_ts = db_ts.astimezone(dt.timezone.utc)
-                results['server'] = {}
-                results['local'] = {}
-                results['server']['base_url'] = base_url
-                results['local']['sequence'] = db_seq
-                results['local']['timestamp'] = db_ts.strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-                repl = ReplicationServer(base_url)
-                state_info = repl.get_state_info()
-                if state_info is None:
-                    # PyOsmium was unable to download the state information
-                    results['status'] = 3
-                    results['error'] = "Unable to download the state information from {}".format(base_url)
-                else:
-                    results['status'] = 0
-                    now = dt.datetime.now(dt.timezone.utc)
-
-                    server_seq, server_ts = state_info
-                    server_ts = server_ts.astimezone(dt.timezone.utc)
-
-                    results['server']['sequence'] = server_seq
-                    results['server']['timestamp'] = server_ts.strftime("%Y-%m-%dT%H:%M:%SZ")
-                    results['server']['age_sec'] = int((now-server_ts).total_seconds())
-
-                    results['local']['age_sec'] = int((now - db_ts).total_seconds())
+    try:
+        results = get_status_info(props, args)
+    except DBError as err:
+        results = {'status': err.errno, 'error': err.msg}
 
     if args.json:
         print(json.dumps(results))
@@ -268,11 +401,10 @@ def status(conn, args):
 
             print("Local database's most recent data is {} old".format(pretty_format_timedelta(results['local']['age_sec'])))
 
-
     return results['status']
 
 
-def init(conn, args):
+def init(props, args):
     """\
     Initialise the replication process.
 
@@ -290,17 +422,13 @@ def init(conn, args):
     this with the `--server` parameter.
     """
     if args.osm_file is None:
-        date = compute_database_date(conn, args.middle_schema, args.prefix)
-        if date is None:
+        base_url, seq, date = props.get_replication_base(args.server, args.start_at)
+        if base_url is None:
             return 1
-
-        date = date - dt.timedelta(hours=3)
-        base_url = args.server
-        seq = None
     else:
         base_url, seq, date = get_replication_header(args.osm_file)
         if base_url is None or (seq is None and date is None):
-            LOG.fatal("File '%s' has no usable replication headers. Use '--server' instead.", args.osm_file )
+            LOG.fatal("File '%s' has no usable replication headers. Use '--server' instead.", args.osm_file)
             return 1
 
     repl = ReplicationServer(base_url)
@@ -319,16 +447,17 @@ def init(conn, args):
             LOG.fatal("Cannot reach the configured replication service '%s'.\n"
                       "Does the URL point to a directory containing OSM update data?",
                       base_url)
+        date = from_osm_date(state.timestamp)
 
-    setup_replication_state(conn, args.table, base_url, seq, date)
+    props.write_replication_state(base_url, seq, date)
 
     LOG.info("Initialised updates for service '%s'.", base_url)
-    LOG.info("Starting at sequence %d (%s).", seq,
-            date.astimezone(dt.timezone.utc).strftime('%Y-%m-%dT%H:%MZ'))
+    LOG.info("Starting at sequence %d (%s).", seq, osm_date(date))
 
     return 0
 
-def update(conn, args):
+
+def update(props, args):
     """\
     Download newly available data and apply it to the database.
 
@@ -354,21 +483,15 @@ def update(conn, args):
     may be missing in the rare case that the replication service stops responding
     after the updates have been downloaded.
     """
-    if not table_exists(conn, args.table_name, args.middle_schema):
-        LOG.fatal("Cannot find replication status table. "
-                  "Run 'osm2pgsql-replication init' first.")
+    try:
+        base_url, seq, ts = props.get_replication_state()
+    except DBError as err:
+        LOG.fatal(err.msg)
         return 1
 
-    with conn.cursor() as cur:
-        cur.execute(sql.SQL('SELECT * FROM {}').format(args.table))
-        if cur.rowcount != 1:
-            LOG.fatal("Updates not set up correctly. Run 'osm2pgsql-updates init' first.")
-            return 1
-
-        base_url, seq, ts = cur.fetchone()
-        initial_local_timestamp = ts
-        LOG.info("Using replication service '%s'.", base_url)
-        local_db_age_sec = int((dt.datetime.now(dt.timezone.utc) - ts).total_seconds())
+    initial_local_timestamp = ts
+    LOG.info("Using replication service '%s'.", base_url)
+    local_db_age_sec = int((dt.datetime.now(dt.timezone.utc) - ts).total_seconds())
 
     repl = ReplicationServer(base_url)
     current = repl.get_state_info()
@@ -387,7 +510,8 @@ def update(conn, args):
         current.sequence - seq, current.sequence, seq,
         pretty_format_timedelta(int((current.timestamp - ts).total_seconds())),
         int((current.timestamp - ts).total_seconds()),
-        ts.astimezone(dt.timezone.utc).strftime('%Y-%m-%dT%H:%MZ'), current.timestamp.astimezone(dt.timezone.utc).strftime('%Y-%m-%dT%H:%MZ')
+        osm_date(ts.astimezone(dt.timezone.utc)),
+        osm_date(current.timestamp.astimezone(dt.timezone.utc))
     )
 
     update_started = dt.datetime.now(dt.timezone.utc)
@@ -437,28 +561,23 @@ def update(conn, args):
             LOG.debug('Calling post-processing script: %s', ' '.join(cmd))
             subprocess.run(cmd, check=True)
 
-        update_replication_state(conn, args.table, seq,
-                                 nextstate.timestamp if nextstate else None)
+        props.write_replication_state(base_url, seq, nextstate.timestamp if nextstate else None)
 
         if nextstate is not None:
             LOG.info("Data imported until %s. Backlog remaining: %s",
-                nextstate.timestamp.astimezone(dt.timezone.utc).strftime('%Y-%m-%dT%H:%MZ'),
+                osm_date(nextstate.timestamp.astimezone(dt.timezone.utc)),
                 pretty_format_timedelta((dt.datetime.now(dt.timezone.utc) - nextstate.timestamp).total_seconds()),
             )
-
 
         if args.once:
             break
 
-
     update_duration_sec = (dt.datetime.now(dt.timezone.utc) - update_started).total_seconds()
-    with conn.cursor() as cur:
-        cur.execute(sql.SQL('SELECT * FROM {}').format(args.table))
-        if cur.rowcount != 1:
-            LOG.fatal("Updates not set up correctly. Run 'osm2pgsql-updates init' first.")
-            return 1
-
-        _base_url, _seq, current_local_timestamp = cur.fetchone()
+    try:
+        _base_url, _seq, current_local_timestamp = props.get_replication_state()
+    except DBError as err:
+        LOG.fatal(err.msg)
+        return 1
 
     total_applied_changes_duration_sec = (current_local_timestamp - initial_local_timestamp).total_seconds()
     LOG.debug("It took %s (%d sec) to apply %s (%d sec) of changes. This is a speed of ×%.1f.",
@@ -468,6 +587,7 @@ def update(conn, args):
         )
 
     return 0
+
 
 def get_parser():
     parser = ArgumentParser(description=__doc__,
@@ -514,8 +634,13 @@ def get_parser():
     srcgrp.add_argument('--osm-file', metavar='FILE',
                         help='Get replication information from the given file.')
     srcgrp.add_argument('--server', metavar='URL',
-                        default='https://planet.openstreetmap.org/replication/minute',
                         help='Use replication server at the given URL (default: %(default)s)')
+    grp.add_argument('--start-at', metavar='TIME', type=start_point,
+                     help='Time when to start replication. When an absolute timestamp '
+                          '(in ISO format) is given, it will be used. If a number '
+                          'is given, then replication starts the number of minutes '
+                          'before the known date of the database.')
+
     cmd.set_defaults(handler=init)
 
     # Arguments for update
@@ -549,8 +674,8 @@ def get_parser():
     cmd.add_argument('--json', action="store_true", default=False, help="Output status as json.")
     cmd.set_defaults(handler=status)
 
-
     return parser
+
 
 def main():
     parser = get_parser()
@@ -574,21 +699,18 @@ def main():
                         datefmt='%Y-%m-%d %H:%M:%S',
                         level=max(4 - args.verbose, 1) * 10)
 
-    args.table_name = f'{args.prefix}_replication_status'
-    args.table = sql.Identifier(args.middle_schema, args.table_name)
+    with DBConnection(args) as db:
+        if db.table_exists(Osm2pgsqlProperties.PROP_TABLE_NAME):
+            props = Osm2pgsqlProperties(db)
+        else:
+            props = LegacyProperties(db, args.prefix)
 
-    conn = connect(args)
-
-    try:
-        if not table_exists(conn, f'{args.prefix}_ways'):
-            dbname = conn.get_dsn_parameters()['dbname']         # args.database is None when not specified
-            LOG.fatal(f'osm2pgsql middle table "{args.prefix}_ways" not found in database "{dbname}". '
+        if not props.is_updatable:
+            LOG.fatal(f'osm2pgsql middle table "{args.prefix}_ways" not found in database "{db.name}". '
                        'Database needs to be imported in --slim mode.')
             return 1
 
-        return args.handler(conn, args)
-    finally:
-        conn.close()
+        return args.handler(props, args)
 
 
 if __name__ == '__main__':

--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -54,6 +54,7 @@ LOG = logging.getLogger()
 OSM2PGSQL_PATH = Path(__file__).parent.resolve() / 'osm2pgsql'
 
 def pretty_format_timedelta(seconds):
+    seconds = int(seconds)
     (minutes, seconds) = divmod(seconds, 60)
     (hours, minutes) = divmod(minutes, 60)
     (days, hours) = divmod(hours, 24)
@@ -62,15 +63,15 @@ def pretty_format_timedelta(seconds):
     output = []
     # If weeks > 1 but hours == 0, we still want to show "0 hours"
     if weeks > 0:
-        output.append("{:d} week(s)".format(weeks))
+        output.append("{} week(s)".format(weeks))
     if days > 0 or weeks > 0:
-        output.append("{:d} day(s)".format(days))
+        output.append("{} day(s)".format(days))
     if hours > 0 or days > 0 or weeks > 0:
-        output.append("{:d} hour(s)".format(hours))
+        output.append("{} hour(s)".format(hours))
     if minutes > 0 or hours > 0 or days > 0 or weeks > 0:
-        output.append("{:d} minute(s)".format(minutes))
+        output.append("{} minute(s)".format(minutes))
 
-    output.append("{:d} second(s)".format(seconds))
+    output.append("{} second(s)".format(seconds))
 
     output = " ".join(output)
     return output
@@ -201,7 +202,7 @@ class Osm2pgsqlProperties:
         date = self._get_prop('replication_timestamp')
 
         if base_url is None or seq is None or date is None:
-            raise DBError(2, "Updates not set up correctly. Run 'osm2pgsql-updates init' first.")
+            raise DBError(2, "Updates not set up correctly. Run 'osm2pgsql-replication init' first.")
 
         return base_url, int(seq), from_osm_date(date)
 
@@ -243,7 +244,7 @@ class LegacyProperties:
         LOG.debug("Using way id %d for timestamp lookup", osmid)
         # Get the way from the API to find the timestamp when it was created.
         url = 'https://www.openstreetmap.org/api/0.6/way/{}/1'.format(osmid)
-        headers = {"User-Agent" : "osm2pgsql-update",
+        headers = {"User-Agent" : "osm2pgsql-replication",
                    "Accept" : "application/json"}
         with urlrequest.urlopen(urlrequest.Request(url, headers=headers)) as response:
             data = json.loads(response.read().decode('utf-8'))
@@ -272,12 +273,12 @@ class LegacyProperties:
         with self.db.conn.cursor() as cur:
             cur.execute(sql.SQL('SELECT * FROM {}').format(self.db.table_id(self.prop_table)))
             if cur.rowcount != 1:
-                raise DBError(2, "Updates not set up correctly. Run 'osm2pgsql-updates init' first.")
+                raise DBError(2, "Updates not set up correctly. Run 'osm2pgsql-replication init' first.")
 
             base_url, seq, date = cur.fetchone()
 
         if base_url is None or seq is None or date is None:
-            raise DBError(2, "Updates not set up correctly. Run 'osm2pgsql-updates init' first.")
+            raise DBError(2, "Updates not set up correctly. Run 'osm2pgsql-replication init' first.")
 
         return base_url, seq, date
 
@@ -491,7 +492,7 @@ def update(props, args):
     remote_server_age_sec = int((dt.datetime.now(dt.timezone.utc) - current.timestamp).total_seconds())
     LOG.debug("Applying %d sequence(s) (%d → %d), covering %s (%s sec) of changes (%s → %s)",
         current.sequence - seq, current.sequence, seq,
-        pretty_format_timedelta(int((current.timestamp - ts).total_seconds())),
+        pretty_format_timedelta((current.timestamp - ts).total_seconds()),
         int((current.timestamp - ts).total_seconds()),
         osm_date(ts.astimezone(dt.timezone.utc)),
         osm_date(current.timestamp.astimezone(dt.timezone.utc))

--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -185,9 +185,8 @@ class Osm2pgsqlProperties:
                                  "Use --start-at to set an explicit date.")
 
             date = from_osm_date(date)
-            if start_at is not None:
-                date -= dt.timedelta(minutes=start_at)
-                seq = None
+            date -= dt.timedelta(minutes=start_at or 180)
+            seq = None
         else:
             seq = int(seq)
 
@@ -261,8 +260,7 @@ class LegacyProperties:
         except ValueError:
             raise DBError(1, f"Cannot parse timestamp '{date}'")
 
-        if isinstance(start_at, int):
-            date -= dt.timedelta(minutes=start_at)
+        date -= dt.timedelta(minutes=start_at or 180)
 
         return server, None, date
 

--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -656,9 +656,12 @@ def get_parser():
     return parser
 
 
-def main():
+def main(prog_args=None):
     parser = get_parser()
-    args = parser.parse_args()
+    try:
+        args = parser.parse_args(args=prog_args)
+    except SystemExit:
+        return 1
 
     if missing_modules:
         LOG.fatal("Missing required Python libraries %(mods)s.\n\n"

--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -127,7 +127,7 @@ def compute_database_date(conn, schema, prefix):
     LOG.debug("Found timestamp %s", date)
 
     try:
-        date = dt.datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=dt.timezone.utc)
+        date = dt.datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ')
     except ValueError:
         LOG.fatal("Cannot parse timestamp '%s'", date)
         return None

--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -180,9 +180,8 @@ class Osm2pgsqlProperties:
         if seq is None or isinstance(start_at, int):
             date = self._get_prop('current_timestamp')
             if date is None:
-                LOG.Fatal("Cannot get timestamp from database. "
-                          "Use --start-at to set an explicit date.")
-                return None, None, None
+                raise DBError(1, "Cannot get timestamp from database. "
+                                 "Use --start-at to set an explicit date.")
 
             date = from_osm_date(date)
             if start_at is not None:
@@ -239,8 +238,7 @@ class LegacyProperties:
             osmid = cur.fetchone()[0] if cur.rowcount == 1 else None
 
             if osmid is None:
-                LOG.fatal("No data found in the database.")
-                return None, None, None
+                raise DBError(1, "No data found in the database.")
 
         LOG.debug("Using way id %d for timestamp lookup", osmid)
         # Get the way from the API to find the timestamp when it was created.
@@ -251,9 +249,8 @@ class LegacyProperties:
             data = json.loads(response.read().decode('utf-8'))
 
         if not data.get('elements') or not 'timestamp' in data['elements'][0]:
-            LOG.fatal("The way data downloaded from the API does not contain valid data.\n"
-                      "URL used: %s", url)
-            return None, None, None
+            raise DBError(1, "The way data downloaded from the API does not contain valid data.\n"
+                             f"URL used: {url}")
 
         date = data['elements'][0]['timestamp']
         LOG.debug("Found timestamp %s", date)
@@ -261,8 +258,7 @@ class LegacyProperties:
         try:
             date = from_osm_date(date)
         except ValueError:
-            LOG.fatal("Cannot parse timestamp '%s'", date)
-            return None, None, None
+            raise DBError(1, f"Cannot parse timestamp '{date}'")
 
         if isinstance(start_at, int):
             date -= dt.timedelta(minutes=start_at)
@@ -423,30 +419,23 @@ def init(props, args):
     """
     if args.osm_file is None:
         base_url, seq, date = props.get_replication_base(args.server, args.start_at)
-        if base_url is None:
-            return 1
     else:
         base_url, seq, date = get_replication_header(args.osm_file)
         if base_url is None or (seq is None and date is None):
-            LOG.fatal("File '%s' has no usable replication headers. Use '--server' instead.", args.osm_file)
-            return 1
+            raise DBError(1, f"File '{args.osm_file}' has no usable replication headers. Use '--server' instead.")
 
     repl = ReplicationServer(base_url)
     if seq is None:
         seq = repl.timestamp_to_sequence(date)
-
         if seq is None:
-            LOG.fatal("Cannot reach the configured replication service '%s'.\n"
-                      "Does the URL point to a directory containing OSM update data?",
-                      base_url)
-            return 1
+            raise DBError(1, f"Cannot reach the configured replication service '{base_url}'.\n"
+                             "Does the URL point to a directory containing OSM update data?")
 
     if date is None:
         state = repl.get_state_info(seq)
         if state is None:
-            LOG.fatal("Cannot reach the configured replication service '%s'.\n"
-                      "Does the URL point to a directory containing OSM update data?",
-                      base_url)
+            raise DBError(1, f"Cannot reach the configured replication service '{base_url}'.\n"
+                             "Does the URL point to a directory containing OSM update data?")
         date = from_osm_date(state.timestamp)
 
     props.write_replication_state(base_url, seq, date)
@@ -483,11 +472,7 @@ def update(props, args):
     may be missing in the rare case that the replication service stops responding
     after the updates have been downloaded.
     """
-    try:
-        base_url, seq, ts = props.get_replication_state()
-    except DBError as err:
-        LOG.fatal(err.msg)
-        return 1
+    base_url, seq, ts = props.get_replication_state()
 
     initial_local_timestamp = ts
     LOG.info("Using replication service '%s'.", base_url)
@@ -496,10 +481,8 @@ def update(props, args):
     repl = ReplicationServer(base_url)
     current = repl.get_state_info()
     if current is None:
-        LOG.fatal("Cannot reach the configured replication service '%s'.\n"
-                  "Does the URL point to a directory containing OSM update data?",
-                  base_url)
-        return 1
+        raise DBError(1, f"Cannot reach the configured replication service '{base_url}'.\n"
+                         "Does the URL point to a directory containing OSM update data?")
 
     if seq >= current.sequence:
         LOG.info("Database already up-to-date.")
@@ -573,11 +556,7 @@ def update(props, args):
             break
 
     update_duration_sec = (dt.datetime.now(dt.timezone.utc) - update_started).total_seconds()
-    try:
-        _base_url, _seq, current_local_timestamp = props.get_replication_state()
-    except DBError as err:
-        LOG.fatal(err.msg)
-        return 1
+    _base_url, _seq, current_local_timestamp = props.get_replication_state()
 
     total_applied_changes_duration_sec = (current_local_timestamp - initial_local_timestamp).total_seconds()
     LOG.debug("It took %s (%d sec) to apply %s (%d sec) of changes. This is a speed of ×%.1f.",
@@ -710,7 +689,12 @@ def main():
                        'Database needs to be imported in --slim mode.')
             return 1
 
-        return args.handler(props, args)
+        try:
+            return args.handler(props, args)
+        except DBError as err:
+            LOG.fatal(err.msg)
+
+    return 1
 
 
 if __name__ == '__main__':

--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -405,18 +405,35 @@ def init(props, args):
     """\
     Initialise the replication process.
 
-    There are two ways to initialise the replication process: if you have imported
-    from a file that contains replication source information, then the
-    initialisation process can use this and set up replication from there.
-    Use the command `%(prog)s --osm-file <filename>` for this.
+    This function sets the replication service to use and determines from
+    which date to apply updates. You must call this function at least once
+    to set up the replication process. It can safely be called again later
+    to change the replication servers or to roll back the update process and
+    reapply updates.
 
-    If the file has no replication information or you don't have the initial
-    import file anymore then replication can be set up according to
-    the data found in the database. It checks the planet_osm_way table for the
-    newest way in the database and then queries the OSM API when the way was
-    created. The date is used as the start date for replication. In this mode
-    the minutely diffs from the OSM servers are used as a source. You can change
-    this with the `--server` parameter.
+    There are different methods available for initialisation. When no
+    additional parameters are given, the data is initialised from the data
+    in the database. If the data was imported from a file with replication
+    information and the properties table is available (for osm2pgsql >= 1.9)
+    then the replication from the file is used. Otherwise the minutely
+    update service from openstreetmap.org is used as the default replication
+    service. The start date is either taken from the database timestamp
+    (for osm2pgsql >= 1.9) or determined from the newest way in the database
+    by querying the OSM API about its creation date.
+
+    The replication service can be changed with the `--server` parameter.
+    To use a different start date, add `--start-at` with an absolute
+    ISO timestamp (e.g. 2007-08-20T12:21:53Z). When the program determines the
+    start date from the database timestamp or way creation date, then it
+    subtracts another 3 hours by default to ensure that all new changes are
+    available. To change this rollback period, use `--start-at` with the
+    number of minutes to rollback. This rollback mode can also be used to
+    force initialisation to use the database date and ignore the date
+    from the replication information in the file.
+
+    The initialisation process can also use replication information from
+    an OSM file directly and ignore all other date information.
+    Use the command `%(prog)s --osm-file <filename>` for this.
     """
     if args.osm_file is None:
         base_url, seq, date = props.get_replication_base(args.server, args.start_at)
@@ -614,7 +631,7 @@ def get_parser():
     srcgrp.add_argument('--osm-file', metavar='FILE',
                         help='Get replication information from the given file.')
     srcgrp.add_argument('--server', metavar='URL',
-                        help='Use replication server at the given URL (default: %(default)s)')
+                        help='Use replication server at the given URL')
     grp.add_argument('--start-at', metavar='TIME', type=start_point,
                      help='Time when to start replication. When an absolute timestamp '
                           '(in ISO format) is given, it will be used. If a number '

--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -117,10 +117,10 @@ class DBConnection:
         if args.database and any(part in args.database for part in ['=', '://']):
             self.conn = psycopg.connect(args.database,
                                         fallback_application_name="osm2pgsql-replication")
-
-        self.conn = psycopg.connect(dbname=args.database, user=args.username,
-                                    host=args.host, port=args.port,
-                                    fallback_application_name="osm2pgsql-replication")
+        else:
+            self.conn = psycopg.connect(dbname=args.database, user=args.username,
+                                        host=args.host, port=args.port,
+                                        fallback_application_name="osm2pgsql-replication")
 
         self.name = self.conn.get_dsn_parameters()['dbname']
 
@@ -133,7 +133,7 @@ class DBConnection:
 
     def table_exists(self, table_name):
         with self.conn.cursor() as cur:
-            cur.execute('SELECT * FROM pg_tables where tablename = %s and schemaname = %s ',
+            cur.execute('SELECT * FROM pg_tables WHERE tablename = %s and schemaname = %s ',
                         (table_name, self.schema))
             return cur.rowcount > 0
 

--- a/tests/bdd/command-line/replication.feature
+++ b/tests/bdd/command-line/replication.feature
@@ -1,10 +1,11 @@
 Feature: Tests for the osm2pgsql-replication script with property table
 
-    Scenario: Replication can be initialised with a osm file after import
+    Scenario: Replication can be initialised with an osm file after import
         Given the OSM data
             """
             n34 Tamenity=restaurant x77 y45.3
             """
+        And the replication service at http://example.com/europe/liechtenstein-updates
         When running osm2pgsql pgsql with parameters
             | --slim |
 
@@ -20,6 +21,7 @@ Feature: Tests for the osm2pgsql-replication script with property table
 
     Scenario: Replication will be initialised from the information of the import file
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the replication service at http://example.com/europe/liechtenstein-updates
         When running osm2pgsql pgsql with parameters
             | --slim |
 
@@ -62,6 +64,7 @@ Feature: Tests for the osm2pgsql-replication script with property table
     Scenario: Replication can be initialised for a database in a different schema
         Given the database schema foobar
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the replication service at http://example.com/europe/liechtenstein-updates
         When running osm2pgsql pgsql with parameters
             | --slim | --middle-schema=foobar |
 
@@ -78,6 +81,7 @@ Feature: Tests for the osm2pgsql-replication script with property table
     Scenario: Replication initialiasion will fail for a database in a different schema
         Given the database schema foobar
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the replication service at http://example.com/europe/liechtenstein-updates
         When running osm2pgsql pgsql with parameters
             | --slim |
 
@@ -88,3 +92,223 @@ Feature: Tests for the osm2pgsql-replication script with property table
             Database needs to be imported in --slim mode.
             """
 
+    Scenario: Replication can be initialised with a fixed date (no previous replication info)
+        Given the OSM data
+            """
+            n34 Tamenity=restaurant x77 y45.3
+            """
+        And the replication service at https://planet.openstreetmap.org/replication/minute
+            | sequence | timestamp            |
+            | 345      | 2020-10-04T01:00:00Z |
+            | 346      | 2020-10-04T02:00:00Z |
+            | 347      | 2020-10-04T03:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+
+        And running osm2pgsql-replication
+            | init | --start-at | 2020-10-04T01:30:00Z |
+
+        Then table osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | https://planet.openstreetmap.org/replication/minute |
+            | replication_sequence_number | 345                                             |
+            | replication_timestamp       | 2020-10-04T01:30:00Z                            |
+
+
+    Scenario: Replication can be initialised with a fixed date (with previous replication info)
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the replication service at http://example.com/europe/liechtenstein-updates
+            | sequence | timestamp            |
+            | 345      | 2020-10-04T01:00:00Z |
+            | 346      | 2020-10-04T02:00:00Z |
+            | 347      | 2020-10-04T03:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+
+        And running osm2pgsql-replication
+            | init | --start-at | 2020-10-04T03:30:00Z |
+
+        Then table osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | http://example.com/europe/liechtenstein-updates |
+            | replication_sequence_number | 347                                             |
+            | replication_timestamp       | 2020-10-04T03:30:00Z                            |
+
+
+    Scenario: Replication can be initialised with a rollback (no previous replication info)
+        Given the OSM data
+            """
+            n34 Tamenity=restaurant x77 y45.3 t2020-10-04T02:00:01Z
+            """
+        And the replication service at https://planet.openstreetmap.org/replication/minute
+            | sequence | timestamp            |
+            | 345      | 2020-10-04T01:00:00Z |
+            | 346      | 2020-10-04T02:00:00Z |
+            | 347      | 2020-10-04T03:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+
+        And running osm2pgsql-replication
+            | init | --start-at | 60 |
+
+        Then table osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | https://planet.openstreetmap.org/replication/minute |
+            | replication_sequence_number | 345                                             |
+            | replication_timestamp       | 2020-10-04T01:00:01Z                            |
+
+
+    Scenario: Replication can be initialised with a rollback (with previous replication info)
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the replication service at http://example.com/europe/liechtenstein-updates
+            | sequence | timestamp            |
+            | 345      | 2020-10-04T01:00:00Z |
+            | 346      | 2020-10-04T02:00:00Z |
+            | 347      | 2020-10-04T03:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+
+        And running osm2pgsql-replication
+            | init | --start-at | 60 |
+
+        Then table osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | http://example.com/europe/liechtenstein-updates |
+            | replication_sequence_number | 345                                             |
+            | replication_timestamp       | 2013-08-03T14:55:30Z                            |
+
+
+    Scenario: Replication can be initialised from a different server
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the replication service at https://custom.replication
+            | sequence | timestamp            |
+            | 1345     | 2013-07-01T01:00:00Z |
+            | 1346     | 2013-08-01T01:00:00Z |
+            | 1347     | 2013-09-01T01:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+
+        And running osm2pgsql-replication
+            | init | --server | https://custom.replication |
+
+        Then table osm2pgsql_properties contains
+            | property                    | value                      |
+            | replication_base_url        | https://custom.replication |
+            | replication_sequence_number | 1346                       |
+            | replication_timestamp       | 2013-08-03T15:55:30Z       |
+
+
+    Scenario: Updates need an initialised replication
+        Given the OSM data
+            """
+            n34 Tamenity=restaurant x77 y45.3
+            """
+        And the replication service at https://planet.openstreetmap.org/replication/minute
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+
+        Then running osm2pgsql-replication fails with returncode 1
+            | update |
+        And the error output contains
+            """
+            Updates not set up correctly.
+            """
+
+    Scenario: Updates run until the end (exactly one application)
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the replication service at http://example.com/europe/liechtenstein-updates
+            | sequence | timestamp            |
+            | 9999999  | 2013-08-01T01:00:02Z |
+            | 10000000 | 2013-09-01T01:00:00Z |
+            | 10000001 | 2013-10-01T01:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+        And running osm2pgsql-replication
+            | init |
+        And running osm2pgsql-replication
+            | update |
+
+        Then table osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | http://example.com/europe/liechtenstein-updates |
+            | replication_sequence_number | 10000001                                        |
+            | replication_timestamp       | 2013-10-01T01:00:00Z                            |
+
+
+    Scenario: Updates run until the end (multiple applications)
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the replication service at http://example.com/europe/liechtenstein-updates
+            | sequence | timestamp            |
+            | 9999999  | 2013-08-01T01:00:02Z |
+            | 10000000 | 2013-09-01T01:00:00Z |
+            | 10000001 | 2013-10-01T01:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+        And running osm2pgsql-replication
+            | init |
+        And running osm2pgsql-replication
+            | update | --max-diff-size | 1 |
+
+        Then table osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | http://example.com/europe/liechtenstein-updates |
+            | replication_sequence_number | 10000001                                        |
+            | replication_timestamp       | 2013-10-01T01:00:00Z                            |
+
+
+    Scenario: Updates can run only once
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the replication service at http://example.com/europe/liechtenstein-updates
+            | sequence | timestamp            |
+            | 9999999  | 2013-08-01T01:00:02Z |
+            | 10000000 | 2013-09-01T01:00:00Z |
+            | 10000001 | 2013-10-01T01:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+        And running osm2pgsql-replication
+            | init |
+        And running osm2pgsql-replication
+            | update | --once | --max-diff-size | 1 |
+
+        Then table osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | http://example.com/europe/liechtenstein-updates |
+            | replication_sequence_number | 10000000                                        |
+            | replication_timestamp       | 2013-09-01T01:00:00Z                            |
+
+
+    Scenario: Status of an uninitialised database fails
+        Given the OSM data
+            """
+            n34 Tamenity=restaurant x77 y45.3
+            """
+        And the replication service at https://planet.openstreetmap.org/replication/minute
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+
+        Then running osm2pgsql-replication fails with returncode 2
+            | status | --json |
+        And the standard output contains
+            """
+            "status": 2
+            "error": "Updates not set up correctly.
+            """
+
+    Scenario: Status of a freshly initialised database
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        And the replication service at http://example.com/europe/liechtenstein-updates
+            | sequence | timestamp            |
+            | 9999999  | 2013-08-01T01:00:02Z |
+            | 10000000 | 2013-09-01T01:00:00Z |
+            | 10000001 | 2013-10-01T01:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+
+        And running osm2pgsql-replication
+            | status | --json |
+        Then the standard output contains
+            """
+            "status": 0
+            "server": {"base_url": "http://example.com/europe/liechtenstein-updates", "sequence": 10000001, "timestamp": "2013-10-01T01:00:00Z"
+            "local": {"sequence": 9999999, "timestamp": "2013-08-03T19:00:02Z"
+            """

--- a/tests/bdd/command-line/replication.feature
+++ b/tests/bdd/command-line/replication.feature
@@ -135,6 +135,29 @@ Feature: Tests for the osm2pgsql-replication script with property table
             | replication_timestamp       | 2020-10-04T03:30:00Z                            |
 
 
+    Scenario: Replication can be initialised from database date
+        Given the OSM data
+            """
+            n34 Tamenity=restaurant x77 y45.3 t2020-10-04T04:00:01Z
+            """
+        And the replication service at https://planet.openstreetmap.org/replication/minute
+            | sequence | timestamp            |
+            | 345      | 2020-10-04T01:00:00Z |
+            | 346      | 2020-10-04T02:00:00Z |
+            | 347      | 2020-10-04T03:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+
+        And running osm2pgsql-replication
+            | init |
+
+        Then table osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | https://planet.openstreetmap.org/replication/minute |
+            | replication_sequence_number | 345                                             |
+            | replication_timestamp       | 2020-10-04T01:00:01Z                            |
+
+
     Scenario: Replication can be initialised with a rollback (no previous replication info)
         Given the OSM data
             """
@@ -195,7 +218,7 @@ Feature: Tests for the osm2pgsql-replication script with property table
             | property                    | value                      |
             | replication_base_url        | https://custom.replication |
             | replication_sequence_number | 1346                       |
-            | replication_timestamp       | 2013-08-03T15:55:30Z       |
+            | replication_timestamp       | 2013-08-03T12:55:30Z       |
 
 
     Scenario: Updates need an initialised replication

--- a/tests/bdd/command-line/replication.feature
+++ b/tests/bdd/command-line/replication.feature
@@ -1,7 +1,6 @@
-Feature: Tests for the osm2pgsql-replication script
+Feature: Tests for the osm2pgsql-replication script with property table
 
-    Scenario: Replication can be initialised
-
+    Scenario: Replication can be initialised with a osm file after import
         Given the OSM data
             """
             n34 Tamenity=restaurant x77 y45.3
@@ -12,21 +11,80 @@ Feature: Tests for the osm2pgsql-replication script
         And running osm2pgsql-replication
             | init | --osm-file={TEST_DATA_DIR}/liechtenstein-2013-08-03.osm.pbf |
 
-        Then table planet_osm_replication_status has 1 row
+        Then table osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | http://example.com/europe/liechtenstein-updates |
+            | replication_sequence_number | 9999999                                         |
+            | replication_timestamp       | 2013-08-03T19:00:02Z                            |
 
-    Scenario: Replication can be initialised in different schema
 
-        Given the database schema foobar
-        And the OSM data
+    Scenario: Replication will be initialised from the information of the import file
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+
+        And running osm2pgsql-replication
+            | init |
+
+        Then table osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | http://example.com/europe/liechtenstein-updates |
+            | replication_sequence_number | 9999999                                         |
+            | replication_timestamp       | 2013-08-03T19:00:02Z                            |
+
+
+    Scenario: Replication cannot be initialsed when date information is missing
+        Given the OSM data
             """
             n34 Tamenity=restaurant x77 y45.3
             """
         When running osm2pgsql pgsql with parameters
             | --slim |
 
-        And running osm2pgsql-replication
+        Then running osm2pgsql-replication fails with returncode 1
             | init |
-            | --osm-file={TEST_DATA_DIR}/liechtenstein-2013-08-03.osm.pbf |
-            | --middle-schema=foobar |
+        And the error output contains
+            """
+            Cannot get timestamp from database.
+            """
 
-        Then table foobar.planet_osm_replication_status has 1 row
+    Scenario: Replication cannot initialised on non-updatable database
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        When running osm2pgsql pgsql
+
+        Then running osm2pgsql-replication fails with returncode 1
+            | init |
+        And the error output contains
+            """
+            Database needs to be imported in --slim mode.
+            """
+
+    Scenario: Replication can be initialised for a database in a different schema
+        Given the database schema foobar
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        When running osm2pgsql pgsql with parameters
+            | --slim | --middle-schema=foobar |
+
+        And running osm2pgsql-replication
+            | init | --middle-schema=foobar |
+
+        Then table foobar.osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | http://example.com/europe/liechtenstein-updates |
+            | replication_sequence_number | 9999999                                         |
+            | replication_timestamp       | 2013-08-03T19:00:02Z                            |
+
+
+    Scenario: Replication initialiasion will fail for a database in a different schema
+        Given the database schema foobar
+        Given the input file 'liechtenstein-2013-08-03.osm.pbf'
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+
+        Then running osm2pgsql-replication fails with returncode 1
+            | init | --middle-schema=foobar |
+        And the error output contains
+            """
+            Database needs to be imported in --slim mode.
+            """
+

--- a/tests/bdd/command-line/replication.feature
+++ b/tests/bdd/command-line/replication.feature
@@ -35,7 +35,7 @@ Feature: Tests for the osm2pgsql-replication script with property table
             | replication_timestamp       | 2013-08-03T19:00:02Z                            |
 
 
-    Scenario: Replication cannot be initialsed when date information is missing
+    Scenario: Replication cannot be initialised when date information is missing
         Given the OSM data
             """
             n34 Tamenity=restaurant x77 y45.3
@@ -78,7 +78,7 @@ Feature: Tests for the osm2pgsql-replication script with property table
             | replication_timestamp       | 2013-08-03T19:00:02Z                            |
 
 
-    Scenario: Replication initialiasion will fail for a database in a different schema
+    Scenario: Replication initialisation will fail for a database in a different schema
         Given the database schema foobar
         Given the input file 'liechtenstein-2013-08-03.osm.pbf'
         And the replication service at http://example.com/europe/liechtenstein-updates

--- a/tests/bdd/command-line/replication_legacy.feature
+++ b/tests/bdd/command-line/replication_legacy.feature
@@ -9,6 +9,7 @@ Feature: Tests for the osm2pgsql-replication script without property table
             """
 
     Scenario: Replication can be initialised with a osm file
+        Given the replication service at http://example.com/europe/liechtenstein-updates
         When running osm2pgsql pgsql with parameters
             | --slim |
         And deleting table osm2pgsql_properties
@@ -22,6 +23,7 @@ Feature: Tests for the osm2pgsql-replication script without property table
 
 
     Scenario: Replication cannot be initialised from a osm file without replication info
+        Given the replication service at http://example.com/europe/liechtenstein-updates
         When running osm2pgsql pgsql with parameters
             | --slim |
         And deleting table osm2pgsql_properties
@@ -35,6 +37,7 @@ Feature: Tests for the osm2pgsql-replication script without property table
 
 
     Scenario: Replication can be initialised in different schema
+        Given the replication service at http://example.com/europe/liechtenstein-updates
         Given the database schema foobar
         When running osm2pgsql pgsql with parameters
             | --slim | --middle-schema=foobar |
@@ -52,6 +55,7 @@ Feature: Tests for the osm2pgsql-replication script without property table
 
 
     Scenario: Replication must be initialised in the same schema as rest of middle
+        Given the replication service at http://example.com/europe/liechtenstein-updates
         Given the database schema foobar
         When running osm2pgsql pgsql with parameters
             | --slim | --middle-schema=foobar |
@@ -66,3 +70,173 @@ Feature: Tests for the osm2pgsql-replication script without property table
             Database needs to be imported in --slim mode.
             """
 
+    Scenario: Replication can be initialised with a fixed start date
+        Given the replication service at https://planet.openstreetmap.org/replication/minute
+            | sequence | timestamp            |
+            | 345      | 2020-10-04T01:00:00Z |
+            | 346      | 2020-10-14T02:00:00Z |
+            | 347      | 2020-10-24T03:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+        And deleting table osm2pgsql_properties
+
+        And running osm2pgsql-replication
+            | init | --start-at | 2020-10-22T04:05:06Z |
+
+        Then table planet_osm_replication_status contains exactly
+            | url                                                 | sequence | importdate at time zone 'UTC' |
+            | https://planet.openstreetmap.org/replication/minute | 346  | 2020-10-22 04:05:06               |
+
+
+    Scenario: Replication can be initialised from the data in the database
+        Given the replication service at https://planet.openstreetmap.org/replication/minute
+            | sequence | timestamp            |
+            | 345      | 2020-10-04T01:00:00Z |
+            | 346      | 2020-10-14T02:00:00Z |
+            | 347      | 2020-10-24T03:00:00Z |
+        And the URL https://www.openstreetmap.org/api/0.6/way/4/1 returns
+            """
+            {"version":"0.6","generator":"OpenStreetMap server","copyright":"OpenStreetMap and contributors","attribution":"http://www.openstreetmap.org/copyright","license":"http://opendatacommons.org/licenses/odbl/1-0/","elements":[{"type":"way","id":4,"timestamp":"2020-10-15T12:21:53Z","version":1,"changeset":234165,"user":"ewg2","uid":2,"nodes":[34,35],"tags":{"highway":"residential"}}]}
+            """
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+        And deleting table osm2pgsql_properties
+
+        And running osm2pgsql-replication
+            | init |
+
+        Then table planet_osm_replication_status contains exactly
+            | url                                                 | sequence | importdate at time zone 'UTC' |
+            | https://planet.openstreetmap.org/replication/minute | 346      | 2020-10-15 12:21:53           |
+
+
+    Scenario: Replication can be initialised from the data in the database with rollback
+        Given the replication service at https://planet.openstreetmap.org/replication/minute
+            | sequence | timestamp            |
+            | 345      | 2020-10-04T01:00:00Z |
+            | 346      | 2020-10-14T02:00:00Z |
+            | 347      | 2020-10-24T03:00:00Z |
+        And the URL https://www.openstreetmap.org/api/0.6/way/4/1 returns
+            """
+            {"version":"0.6","generator":"OpenStreetMap server","copyright":"OpenStreetMap and contributors","attribution":"http://www.openstreetmap.org/copyright","license":"http://opendatacommons.org/licenses/odbl/1-0/","elements":[{"type":"way","id":4,"timestamp":"2020-10-15T12:21:53Z","version":1,"changeset":234165,"user":"ewg2","uid":2,"nodes":[34,35],"tags":{"highway":"residential"}}]}
+            """
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+        And deleting table osm2pgsql_properties
+
+        And running osm2pgsql-replication
+            | init | --start-at | 120 |
+
+        Then table planet_osm_replication_status contains exactly
+            | url                                                 | sequence | importdate at time zone 'UTC' |
+            | https://planet.openstreetmap.org/replication/minute | 346      | 2020-10-15 10:21:53           |
+
+
+    Scenario: Updates need an initialised replication
+        Given the replication service at https://planet.openstreetmap.org/replication/minute
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+
+        Then running osm2pgsql-replication fails with returncode 1
+            | update |
+        And the error output contains
+            """
+            Updates not set up correctly.
+            """
+
+    Scenario: Updates run until the end (exactly one application)
+        Given the replication service at https://planet.openstreetmap.org/replication/minute
+            | sequence | timestamp            |
+            | 345      | 2020-10-04T01:00:00Z |
+            | 346      | 2020-10-14T02:00:00Z |
+            | 347      | 2020-10-24T03:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+        And running osm2pgsql-replication
+            | init | --start-at | 2020-10-04T01:05:06Z |
+        And running osm2pgsql-replication
+            | update |
+
+        Then table osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | https://planet.openstreetmap.org/replication/minute |
+            | replication_sequence_number | 347                                                 |
+            | replication_timestamp       | 2020-10-24T03:00:00Z                                |
+
+
+    Scenario: Updates run until the end (multiple applications)
+        Given the replication service at https://planet.openstreetmap.org/replication/minute
+            | sequence | timestamp            |
+            | 345      | 2020-10-04T01:00:00Z |
+            | 346      | 2020-10-14T02:00:00Z |
+            | 347      | 2020-10-24T03:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+        And running osm2pgsql-replication
+            | init | --start-at | 2020-10-04T01:05:06Z |
+        And running osm2pgsql-replication
+            | update | --max-diff-size | 1 |
+
+        Then table osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | https://planet.openstreetmap.org/replication/minute |
+            | replication_sequence_number | 347                                                 |
+            | replication_timestamp       | 2020-10-24T03:00:00Z                                |
+
+
+    Scenario: Updates can run only once
+        Given the replication service at https://planet.openstreetmap.org/replication/minute
+            | sequence | timestamp            |
+            | 345      | 2020-10-04T01:00:00Z |
+            | 346      | 2020-10-14T02:00:00Z |
+            | 347      | 2020-10-24T03:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+        And running osm2pgsql-replication
+            | init | --start-at | 2020-10-04T01:05:06Z |
+        And running osm2pgsql-replication
+            | update | --max-diff-size | 1 | --once |
+
+        Then table osm2pgsql_properties contains
+            | property                    | value                                           |
+            | replication_base_url        | https://planet.openstreetmap.org/replication/minute |
+            | replication_sequence_number | 346                                                 |
+            | replication_timestamp       | 2020-10-14T02:00:00Z                                |
+
+
+
+    Scenario: Status of an uninitialised database fails
+        Given the replication service at https://planet.openstreetmap.org/replication/minute
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+        And deleting table osm2pgsql_properties
+
+        Then running osm2pgsql-replication fails with returncode 1
+            | status | --json |
+        And the standard output contains
+            """
+            "status": 1
+            "error": "Cannot find replication status table
+            """
+
+    Scenario: Status of a freshly initialised database
+        Given the replication service at https://planet.openstreetmap.org/replication/minute
+            | sequence | timestamp            |
+            | 345      | 2020-10-04T01:00:00Z |
+            | 346      | 2020-10-14T02:00:00Z |
+            | 347      | 2020-10-24T03:00:00Z |
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+        And deleting table osm2pgsql_properties
+
+        And running osm2pgsql-replication
+            | init | --start-at | 2020-10-22T04:05:06Z |
+
+        And running osm2pgsql-replication
+            | status | --json |
+        Then the standard output contains
+            """
+            "status": 0
+            "server": {"base_url": "https://planet.openstreetmap.org/replication/minute", "sequence": 347, "timestamp": "2020-10-24T03:00:00Z"
+            "local": {"sequence": 346, "timestamp": "2020-10-22T04:05:06Z"
+            """

--- a/tests/bdd/command-line/replication_legacy.feature
+++ b/tests/bdd/command-line/replication_legacy.feature
@@ -1,0 +1,68 @@
+Feature: Tests for the osm2pgsql-replication script without property table
+
+    Background:
+        Given the OSM data
+            """
+            n34 Tamenity=restaurant x77 y45.3
+            n35 x77 y45.31
+            w4 Thighway=residential Nn34,n35
+            """
+
+    Scenario: Replication can be initialised with a osm file
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+        And deleting table osm2pgsql_properties
+
+        And running osm2pgsql-replication
+            | init | --osm-file={TEST_DATA_DIR}/liechtenstein-2013-08-03.osm.pbf |
+
+        Then table planet_osm_replication_status contains exactly
+            | url                                             | sequence | importdate at time zone 'UTC' |
+            | http://example.com/europe/liechtenstein-updates | 9999999  | 2013-08-03 19:00:02           |
+
+
+    Scenario: Replication cannot be initialised from a osm file without replication info
+        When running osm2pgsql pgsql with parameters
+            | --slim |
+        And deleting table osm2pgsql_properties
+
+        Then running osm2pgsql-replication fails with returncode 1
+            | init | --osm-file={TEST_DATA_DIR}/008-ch.osc.gz |
+        And the error output contains
+            """
+            has no usable replication headers
+            """
+
+
+    Scenario: Replication can be initialised in different schema
+        Given the database schema foobar
+        When running osm2pgsql pgsql with parameters
+            | --slim | --middle-schema=foobar |
+
+        And deleting table foobar.osm2pgsql_properties
+
+        And running osm2pgsql-replication
+            | init |
+            | --osm-file={TEST_DATA_DIR}/liechtenstein-2013-08-03.osm.pbf |
+            | --middle-schema=foobar |
+
+        Then table foobar.planet_osm_replication_status contains exactly
+            | url                                             | sequence | importdate at time zone 'UTC' |
+            | http://example.com/europe/liechtenstein-updates | 9999999  | 2013-08-03 19:00:02           |
+
+
+    Scenario: Replication must be initialised in the same schema as rest of middle
+        Given the database schema foobar
+        When running osm2pgsql pgsql with parameters
+            | --slim | --middle-schema=foobar |
+
+        And deleting table foobar.osm2pgsql_properties
+
+        Then running osm2pgsql-replication fails with returncode 1
+            | init |
+            | --osm-file={TEST_DATA_DIR}/liechtenstein-2013-08-03.osm.pbf |
+         And the error output contains
+            """
+            Database needs to be imported in --slim mode.
+            """
+

--- a/tests/bdd/command-line/replication_legacy.feature
+++ b/tests/bdd/command-line/replication_legacy.feature
@@ -107,7 +107,7 @@ Feature: Tests for the osm2pgsql-replication script without property table
 
         Then table planet_osm_replication_status contains exactly
             | url                                                 | sequence | importdate at time zone 'UTC' |
-            | https://planet.openstreetmap.org/replication/minute | 346      | 2020-10-15 12:21:53           |
+            | https://planet.openstreetmap.org/replication/minute | 346      | 2020-10-15 09:21:53           |
 
 
     Scenario: Replication can be initialised from the data in the database with rollback

--- a/tests/bdd/environment.py
+++ b/tests/bdd/environment.py
@@ -130,6 +130,7 @@ def working_directory(context, **kwargs):
     with tempfile.TemporaryDirectory() as tmpdir:
         yield Path(tmpdir)
 
+
 def before_tag(context, tag):
     if tag == 'needs-pg-index-includes':
         if context.config.userdata['PG_VERSION'] < 110000:

--- a/tests/bdd/environment.py
+++ b/tests/bdd/environment.py
@@ -96,7 +96,8 @@ def before_all(context):
     # Set up replication script.
     replicationfile = str(Path(context.config.userdata['REPLICATION_SCRIPT']).resolve())
     spec = importlib.util.spec_from_loader('osm2pgsql_replication',
-                                           SourceFileLoader( 'osm2pgsql_replication',replicationfile))
+                                           SourceFileLoader('osm2pgsql_replication',
+                                                            replicationfile))
     assert spec, f"File not found: {replicationfile}"
     context.osm2pgsql_replication = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(context.osm2pgsql_replication)

--- a/tests/bdd/steps/replication_server_mock.py
+++ b/tests/bdd/steps/replication_server_mock.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of osm2pgsql (https://osm2pgsql.org/).
+#
+# Copyright (C) 2023 by the osm2pgsql developer community.
+# For a full list of authors see the git log.
+
+
+class ReplicationServerMock:
+
+    def __init__(self):
+        self.expected_base_url = None
+        self.state_infos = []
+
+
+    def __call__(self, base_url):
+        assert self.expected_base_url is not None and base_url == self.expected_base_url,\
+               f"Wrong replication service called. Expected '{self.expected_base_url}', got '{base_url}'"
+        return self
+
+
+    def get_state_info(self, seq=None, retries=2):
+        assert self.state_infos, 'Replication mock not propoerly set up'
+        if seq is None:
+            return self.state_infos[-1]
+
+        for info in self.state_infos:
+            if info.sequence == seq:
+                return info
+
+        assert False, f"No sequence information for sequence ID {seq}."
+
+    def timestamp_to_sequence(self, timestamp, balanced_search=False):
+        assert self.state_infos, 'Replication mock not propoerly set up'
+
+        if timestamp < self.state_infos[0].timestamp:
+            return self.state_infos[0].sequence
+
+        prev = self.state_infos[0]
+        for info in self.state_infos:
+            if timestamp >= prev.timestamp and timestamp < info.timestamp:
+                return prev.sequence
+            prev = info
+
+        return prev.sequence
+
+    def apply_diffs(self, handler, start_id, max_size=1024, idx="", simplify=True):
+        if start_id > self.state_infos[-1].sequence:
+            return None
+
+        numdiffs = int((max_size + 1023)/1024)
+        return min(self.state_infos[-1].sequence, start_id + numdiffs - 1)
+

--- a/tests/bdd/steps/replication_server_mock.py
+++ b/tests/bdd/steps/replication_server_mock.py
@@ -20,7 +20,7 @@ class ReplicationServerMock:
 
 
     def get_state_info(self, seq=None, retries=2):
-        assert self.state_infos, 'Replication mock not propoerly set up'
+        assert self.state_infos, 'Replication mock not properly set up'
         if seq is None:
             return self.state_infos[-1]
 
@@ -31,7 +31,7 @@ class ReplicationServerMock:
         assert False, f"No sequence information for sequence ID {seq}."
 
     def timestamp_to_sequence(self, timestamp, balanced_search=False):
-        assert self.state_infos, 'Replication mock not propoerly set up'
+        assert self.state_infos, 'Replication mock not properly set up'
 
         if timestamp < self.state_infos[0].timestamp:
             return self.state_infos[0].sequence


### PR DESCRIPTION
osm2pgsql-replication will now use the property table if available to store the replication state. If it is not available, it keeps using its own table.

Also adds a new option `--start-at` which allows to set an explicit start date and ignore the information in the database or to change the rollback timespan used when guessing the date from the data in the database.

All functions are now properly tested through BDD tests. This required changing how osm2pgsql-replication is called. It is now loaded as a module instead of run as a separate process. This way it is possible to monkeypatch the replication functions and simulate a fake replication service for the tests.