### PR TITLE
Refactor db_target_descr_t: Always need schema on construction and make it a real class

### DIFF
--- a/src/db-copy.cpp
+++ b/src/db-copy.cpp
@@ -188,7 +188,7 @@ void db_copy_thread_t::thread_t::write_to_db(db_cmd_copy_t *buffer)
         start_copy(buffer->target);
     }
 
-    m_conn->copy_send(buffer->buffer, buffer->target->name);
+    m_conn->copy_send(buffer->buffer, buffer->target->name());
 }
 
 void db_copy_thread_t::thread_t::start_copy(
@@ -196,16 +196,16 @@ void db_copy_thread_t::thread_t::start_copy(
 {
     assert(!m_inflight);
 
-    auto const qname = qualified_name(target->schema, target->name);
+    auto const qname = qualified_name(target->schema(), target->name());
     fmt::memory_buffer sql;
-    sql.reserve(qname.size() + target->rows.size() + 20);
-    if (target->rows.empty()) {
+    sql.reserve(qname.size() + target->rows().size() + 20);
+    if (target->rows().empty()) {
         fmt::format_to(std::back_inserter(sql),
                        FMT_STRING("COPY {} FROM STDIN"), qname);
     } else {
         fmt::format_to(std::back_inserter(sql),
                        FMT_STRING("COPY {} ({}) FROM STDIN"), qname,
-                       target->rows);
+                       target->rows());
     }
 
     sql.push_back('\0');
@@ -217,7 +217,7 @@ void db_copy_thread_t::thread_t::start_copy(
 void db_copy_thread_t::thread_t::finish_copy()
 {
     if (m_inflight) {
-        m_conn->copy_end(m_inflight->name);
+        m_conn->copy_end(m_inflight->name());
         m_inflight.reset();
     }
 }

--- a/src/db-copy.hpp
+++ b/src/db-copy.hpp
@@ -10,6 +10,7 @@
  * For a full list of authors see the git log.
  */
 
+#include <cassert>
 #include <condition_variable>
 #include <deque>
 #include <future>
@@ -29,7 +30,7 @@
 struct db_target_descr_t
 {
     /// Schema of the target table.
-    std::string schema{"public"};
+    std::string schema;
     /// Name of the target table for the copy operation.
     std::string name;
     /// Name of id column used when deleting objects.
@@ -46,11 +47,15 @@ struct db_target_descr_t
                                     name == other.name && rows == other.rows);
     }
 
-    db_target_descr_t() = default;
+    db_target_descr_t() = delete;
 
-    db_target_descr_t(std::string n, std::string i, std::string r = {})
-    : name(std::move(n)), id(std::move(i)), rows(std::move(r))
-    {}
+    db_target_descr_t(std::string s, std::string n, std::string i,
+                      std::string r = {})
+    : schema(std::move(s)), name(std::move(n)), id(std::move(i)),
+      rows(std::move(r))
+    {
+        assert(!schema.empty());
+    }
 };
 
 /**

--- a/src/db-copy.hpp
+++ b/src/db-copy.hpp
@@ -27,35 +27,45 @@
 /**
  * Table information necessary for building SQL queries.
  */
-struct db_target_descr_t
+class db_target_descr_t
 {
-    /// Schema of the target table.
-    std::string schema;
-    /// Name of the target table for the copy operation.
-    std::string name;
-    /// Name of id column used when deleting objects.
-    std::string id;
-    /// Comma-separated list of rows for copy operation (when empty: all rows)
-    std::string rows;
+public:
+    db_target_descr_t(std::string schema, std::string name, std::string id,
+                      std::string rows = {})
+    : m_schema(std::move(schema)), m_name(std::move(name)), m_id(std::move(id)),
+      m_rows(std::move(rows))
+    {
+        assert(!m_schema.empty());
+        assert(!m_name.empty());
+        assert(!m_id.empty());
+    }
+
+    std::string const &schema() const noexcept { return m_schema; }
+    std::string const &name() const noexcept { return m_name; }
+    std::string const &id() const noexcept { return m_id; }
+    std::string const &rows() const noexcept { return m_rows; }
+
+    void set_rows(std::string rows) { m_rows = std::move(rows); }
 
     /**
      * Check if the buffer would use exactly the same copy operation.
      */
     bool same_copy_target(db_target_descr_t const &other) const noexcept
     {
-        return (this == &other) || (schema == other.schema &&
-                                    name == other.name && rows == other.rows);
+        return (this == &other) ||
+               (m_schema == other.m_schema && m_name == other.m_name &&
+                m_id == other.m_id && m_rows == other.m_rows);
     }
 
-    db_target_descr_t() = delete;
-
-    db_target_descr_t(std::string s, std::string n, std::string i,
-                      std::string r = {})
-    : schema(std::move(s)), name(std::move(n)), id(std::move(i)),
-      rows(std::move(r))
-    {
-        assert(!schema.empty());
-    }
+private:
+    /// Schema of the target table.
+    std::string m_schema;
+    /// Name of the target table for the copy operation.
+    std::string m_name;
+    /// Name of id column used when deleting objects.
+    std::string m_id;
+    /// Comma-separated list of rows for copy operation (when empty: all rows)
+    std::string m_rows;
 };
 
 /**
@@ -203,8 +213,9 @@ public:
     void delete_data(pg_conn_t *conn) override
     {
         if (m_deleter.has_data()) {
-            m_deleter.delete_rows(qualified_name(target->schema, target->name),
-                                  target->id, conn);
+            m_deleter.delete_rows(
+                qualified_name(target->schema(), target->name()), target->id(),
+                conn);
         }
     }
 

--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -250,11 +250,10 @@ public:
                        std::shared_ptr<db_copy_thread_t> const &copy_thread)
     : m_proj(reprojection::create_projection(table->srid())), m_table(table),
       m_target(std::make_shared<db_target_descr_t>(
-          table->name(), table->id_column_names(),
+          table->schema(), table->name(), table->id_column_names(),
           table->build_sql_column_list())),
       m_copy_mgr(copy_thread), m_db_connection(nullptr)
     {
-        m_target->schema = table->schema();
     }
 
     void connect(std::string const &conninfo);

--- a/src/gazetteer-style.hpp
+++ b/src/gazetteer-style.hpp
@@ -86,8 +86,10 @@ public:
     explicit gazetteer_copy_mgr_t(
         std::shared_ptr<db_copy_thread_t> const &processor)
     : db_copy_mgr_t<db_deleter_place_t>(processor),
-      m_table(std::make_shared<db_target_descr_t>("place", "place_id"))
-    {}
+      m_table(
+          std::make_shared<db_target_descr_t>("public", "place", "place_id"))
+    {
+    }
 
     void prepare() { new_line(m_table); }
 

--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -132,12 +132,9 @@ middle_pgsql_t::table_desc::table_desc(options_t const &options,
                                        table_sql const &ts)
 : m_create_table(build_sql(options, ts.create_table)),
   m_prepare_queries(build_sql(options, ts.prepare_queries)),
-  m_copy_target(std::make_shared<db_target_descr_t>())
+  m_copy_target(std::make_shared<db_target_descr_t>(
+      options.middle_dbschema, build_sql(options, ts.name), "id"))
 {
-    m_copy_target->name = build_sql(options, ts.name);
-    m_copy_target->schema = options.middle_dbschema;
-    m_copy_target->id = "id";
-
     if (options.with_forward_dependencies) {
         m_create_fw_dep_indexes = build_sql(options, ts.create_fw_dep_indexes);
     }
@@ -1324,9 +1321,8 @@ void middle_pgsql_t::write_users_table()
 {
     log_info("Writing {} entries to table '{}'...", m_users.size(),
              m_users_table.name());
-    auto const users_table =
-        std::make_shared<db_target_descr_t>(m_users_table.name(), "id");
-    users_table->schema = m_users_table.schema();
+    auto const users_table = std::make_shared<db_target_descr_t>(
+        m_users_table.schema(), m_users_table.name(), "id");
 
     for (auto const &[id, name] : m_users) {
         m_db_copy.new_line(users_table);

--- a/src/middle-pgsql.hpp
+++ b/src/middle-pgsql.hpp
@@ -133,10 +133,13 @@ struct middle_pgsql_t : public middle_t
 
         std::string const &schema() const noexcept
         {
-            return m_copy_target->schema;
+            return m_copy_target->schema();
         }
 
-        std::string const &name() const noexcept { return m_copy_target->name; }
+        std::string const &name() const noexcept
+        {
+            return m_copy_target->name();
+        }
 
         std::shared_ptr<db_target_descr_t> const &copy_target() const noexcept
         {

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -75,17 +75,17 @@ void table_t::start(std::string const &conninfo, std::string const &table_space)
 {
     if (m_sql_conn) {
         throw fmt_error("{} cannot start, its already started.",
-                        m_target->name);
+                        m_target->name());
     }
 
     m_conninfo = conninfo;
     m_table_space = tablespace_clause(table_space);
 
     connect();
-    log_info("Setting up table '{}'", m_target->name);
-    auto const qual_name = qualified_name(m_target->schema, m_target->name);
-    auto const qual_tmp_name = qualified_name(
-        m_target->schema, m_target->name + "_tmp");
+    log_info("Setting up table '{}'", m_target->name());
+    auto const qual_name = qualified_name(m_target->schema(), m_target->name());
+    auto const qual_tmp_name =
+        qualified_name(m_target->schema(), m_target->name() + "_tmp");
 
     // we are making a new table
     if (!m_append) {
@@ -132,8 +132,8 @@ void table_t::start(std::string const &conninfo, std::string const &table_space)
         m_sql_conn->exec(sql);
 
         if (m_srid != "4326") {
-            create_geom_check_trigger(m_sql_conn.get(), m_target->schema,
-                                      m_target->name, "ST_IsValid(NEW.way)");
+            create_geom_check_trigger(m_sql_conn.get(), m_target->schema(),
+                                      m_target->name(), "ST_IsValid(NEW.way)");
         }
     }
 
@@ -143,7 +143,7 @@ void table_t::start(std::string const &conninfo, std::string const &table_space)
 void table_t::prepare()
 {
     //let postgres cache this query as it will presumably happen a lot
-    auto const qual_name = qualified_name(m_target->schema, m_target->name);
+    auto const qual_name = qualified_name(m_target->schema(), m_target->name());
     m_sql_conn->exec("PREPARE get_wkb(int8) AS"
                      " SELECT way FROM {} WHERE osm_id = $1",
                      qual_name);
@@ -173,7 +173,7 @@ void table_t::generate_copy_column_list()
     // add geom column
     joiner.add("way");
 
-    m_target->rows = joiner();
+    m_target->set_rows(joiner());
 }
 
 void table_t::stop(bool updateable, bool enable_hstore_index,
@@ -182,17 +182,17 @@ void table_t::stop(bool updateable, bool enable_hstore_index,
     // make sure that all data is written to the DB before continuing
     m_copy.sync();
 
-    auto const qual_name = qualified_name(m_target->schema, m_target->name);
-    auto const qual_tmp_name = qualified_name(
-        m_target->schema, m_target->name + "_tmp");
+    auto const qual_name = qualified_name(m_target->schema(), m_target->name());
+    auto const qual_tmp_name =
+        qualified_name(m_target->schema(), m_target->name() + "_tmp");
 
     if (!m_append) {
         if (m_srid != "4326") {
-            drop_geom_check_trigger(m_sql_conn.get(), m_target->schema,
-                                    m_target->name);
+            drop_geom_check_trigger(m_sql_conn.get(), m_target->schema(),
+                                    m_target->name());
         }
 
-        log_info("Clustering table '{}' by geometry...", m_target->name);
+        log_info("Clustering table '{}' by geometry...", m_target->name());
 
         std::string sql = fmt::format("CREATE TABLE {} {} AS SELECT * FROM {}",
                                       qual_tmp_name, m_table_space, qual_name);
@@ -202,7 +202,7 @@ void table_t::stop(bool updateable, bool enable_hstore_index,
         sql += " ORDER BY ";
         if (postgis_version.major == 2 && postgis_version.minor < 4) {
             log_debug("Using GeoHash for clustering table '{}'",
-                      m_target->name);
+                      m_target->name());
             if (m_srid == "4326") {
                 sql += "ST_GeoHash(way,10)";
             } else {
@@ -211,7 +211,7 @@ void table_t::stop(bool updateable, bool enable_hstore_index,
             sql += " COLLATE \"C\"";
         } else {
             log_debug("Using native order for clustering table '{}'",
-                      m_target->name);
+                      m_target->name());
             // Since Postgis 2.4 the order function for geometries gives
             // useful results.
             sql += "way";
@@ -221,9 +221,9 @@ void table_t::stop(bool updateable, bool enable_hstore_index,
 
         m_sql_conn->exec("DROP TABLE {}", qual_name);
         m_sql_conn->exec(R"(ALTER TABLE {} RENAME TO "{}")", qual_tmp_name,
-                         m_target->name);
+                         m_target->name());
 
-        log_info("Creating geometry index on table '{}'...", m_target->name);
+        log_info("Creating geometry index on table '{}'...", m_target->name());
 
         // Use fillfactor 100 for un-updatable imports
         m_sql_conn->exec("CREATE INDEX ON {} USING GIST (way) {} {}", qual_name,
@@ -232,12 +232,13 @@ void table_t::stop(bool updateable, bool enable_hstore_index,
 
         /* slim mode needs this to be able to apply diffs */
         if (updateable) {
-            log_info("Creating osm_id index on table '{}'...", m_target->name);
+            log_info("Creating osm_id index on table '{}'...",
+                     m_target->name());
             m_sql_conn->exec("CREATE INDEX ON {} USING BTREE (osm_id) {}",
                              qual_name, tablespace_clause(table_space_index));
             if (m_srid != "4326") {
-                create_geom_check_trigger(m_sql_conn.get(), m_target->schema,
-                                          m_target->name,
+                create_geom_check_trigger(m_sql_conn.get(), m_target->schema(),
+                                          m_target->name(),
                                           "ST_IsValid(NEW.way)");
             }
         }
@@ -245,7 +246,7 @@ void table_t::stop(bool updateable, bool enable_hstore_index,
         /* Create hstore index if selected */
         if (enable_hstore_index) {
             log_info("Creating hstore indexes on table '{}'...",
-                     m_target->name);
+                     m_target->name());
             if (m_hstore_mode != hstore_column::none) {
                 m_sql_conn->exec("CREATE INDEX ON {} USING GIN (tags) {}",
                                  qual_name,
@@ -257,8 +258,8 @@ void table_t::stop(bool updateable, bool enable_hstore_index,
                                  tablespace_clause(table_space_index));
             }
         }
-        log_info("Analyzing table '{}'...", m_target->name);
-        analyze_table(*m_sql_conn, m_target->schema, m_target->name);
+        log_info("Analyzing table '{}'...", m_target->name());
+        analyze_table(*m_sql_conn, m_target->schema(), m_target->name());
     }
     teardown();
 }
@@ -369,7 +370,7 @@ void table_t::write_hstore_columns(taglist_t const &tags)
 void table_t::task_wait()
 {
     auto const run_time = m_task_result.wait();
-    log_info("All postprocessing on table '{}' done in {}.", m_target->name,
+    log_info("All postprocessing on table '{}' done in {}.", m_target->name(),
              util::human_readable_duration(run_time));
 }
 

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -30,14 +30,11 @@ table_t::table_t(std::string const &name, std::string type, columns_t columns,
                  hstore_column hstore_mode,
                  std::shared_ptr<db_copy_thread_t> const &copy_thread,
                  std::string const &schema)
-: m_target(std::make_shared<db_target_descr_t>(name.c_str(), "osm_id")),
+: m_target(std::make_shared<db_target_descr_t>(schema, name, "osm_id")),
   m_type(std::move(type)), m_srid(fmt::to_string(srid)), m_append(append),
   m_hstore_mode(hstore_mode), m_columns(std::move(columns)),
   m_hstore_columns(std::move(hstore_columns)), m_copy(copy_thread)
 {
-    assert(!schema.empty());
-    m_target->schema = schema;
-
     // if we dont have any columns
     if (m_columns.empty() && m_hstore_mode != hstore_column::all) {
         throw fmt_error("No columns provided for table {}.", name);

--- a/tests/test-db-copy-mgr.cpp
+++ b/tests/test-db-copy-mgr.cpp
@@ -27,9 +27,8 @@ static std::shared_ptr<db_target_descr_t> setup_table(std::string const &cols)
     conn.exec("CREATE TABLE test_copy_mgr (id int8{}{})",
               cols.empty() ? "" : ",", cols);
 
-    auto table = std::make_shared<db_target_descr_t>();
-    table->name = "test_copy_mgr";
-    table->id = "id";
+    auto table =
+        std::make_shared<db_target_descr_t>("public", "test_copy_mgr", "id");
 
     return table;
 }

--- a/tests/test-db-copy-thread.cpp
+++ b/tests/test-db-copy-thread.cpp
@@ -27,9 +27,8 @@ TEST_CASE("db_copy_thread_t with db_deleter_by_id_t")
     conn.exec("DROP TABLE IF EXISTS test_copy_thread");
     conn.exec("CREATE TABLE test_copy_thread (id int8)");
 
-    auto const table = std::make_shared<db_target_descr_t>();
-    table->name = "test_copy_thread";
-    table->id = "id";
+    auto const table =
+        std::make_shared<db_target_descr_t>("public", "test_copy_thread", "id");
 
     db_copy_thread_t t(db.conninfo());
     using cmd_copy_t = db_cmd_copy_delete_t<db_deleter_by_id_t>;
@@ -157,9 +156,8 @@ TEST_CASE("db_copy_thread_t with db_deleter_place_t")
               "osm_id bigint,"
               "class text)");
 
-    auto table = std::make_shared<db_target_descr_t>();
-    table->name = "test_copy_thread";
-    table->id = "place_id";
+    auto table = std::make_shared<db_target_descr_t>(
+        "public", "test_copy_thread", "place_id");
 
     db_copy_thread_t t(db.conninfo());
     using cmd_copy_t = db_cmd_copy_delete_t<db_deleter_place_t>;


### PR DESCRIPTION
We now always construct this fully with schema, name, and id column. This way we make sure all data is there and there is no magic default for the schema.

This is also now a real class.