### PR TITLE
Fix: Remove assert for the id column

### DIFF
--- a/src/db-copy.hpp
+++ b/src/db-copy.hpp
@@ -37,7 +37,6 @@ public:
     {
         assert(!m_schema.empty());
         assert(!m_name.empty());
-        assert(!m_id.empty());
     }
 
     std::string const &schema() const noexcept { return m_schema; }


### PR DESCRIPTION
This is actually not required for COPY operation, only for DELETEs. The flex output can create tables without id.