### PR TITLE
Add new command line parameter --schema that sets the default schema

### DIFF
--- a/src/expire-output.hpp
+++ b/src/expire-output.hpp
@@ -81,7 +81,7 @@ private:
     std::string m_filename;
 
     /// The schema for output
-    std::string m_schema{"public"};
+    std::string m_schema;
 
     /// The table (if any) for output
     std::string m_table;

--- a/src/flex-lua-expire-output.cpp
+++ b/src/flex-lua-expire-output.cpp
@@ -18,7 +18,7 @@
 #include <lua.hpp>
 
 static expire_output_t &
-create_expire_output(lua_State *lua_state,
+create_expire_output(lua_State *lua_state, std::string const &default_schema,
                      std::vector<expire_output_t> *expire_outputs)
 {
     auto &new_expire_output = expire_outputs->emplace_back();
@@ -30,8 +30,8 @@ create_expire_output(lua_State *lua_state,
     lua_pop(lua_state, 1); // "filename"
 
     // optional "schema" and "table" fields
-    auto const *schema = luaX_get_table_string(lua_state, "schema", -1,
-                                               "The expire output", "public");
+    auto const *schema = luaX_get_table_string(
+        lua_state, "schema", -1, "The expire output", default_schema.c_str());
     check_identifier(schema, "schema field");
     auto const *table =
         luaX_get_table_string(lua_state, "table", -2, "The expire output", "");
@@ -72,6 +72,7 @@ create_expire_output(lua_State *lua_state,
 }
 
 int setup_flex_expire_output(lua_State *lua_state,
+                             std::string const &default_schema,
                              std::vector<expire_output_t> *expire_outputs)
 {
     if (lua_type(lua_state, 1) != LUA_TTABLE) {
@@ -79,7 +80,7 @@ int setup_flex_expire_output(lua_State *lua_state,
             "Argument #1 to 'define_expire_output' must be a Lua table."};
     }
 
-    create_expire_output(lua_state, expire_outputs);
+    create_expire_output(lua_state, default_schema, expire_outputs);
 
     void *ptr = lua_newuserdata(lua_state, sizeof(std::size_t));
     auto *num = new (ptr) std::size_t{};

--- a/src/flex-lua-expire-output.hpp
+++ b/src/flex-lua-expire-output.hpp
@@ -20,6 +20,7 @@ static char const *const osm2pgsql_expire_output_name =
     "osm2pgsql.ExpireOutput";
 
 int setup_flex_expire_output(lua_State *lua_state,
+                             std::string const &default_schema,
                              std::vector<expire_output_t> *expire_outputs);
 
 #endif // OSM2PGSQL_FLEX_LUA_EXPIRE_OUTPUT_HPP

--- a/src/flex-lua-table.cpp
+++ b/src/flex-lua-table.cpp
@@ -29,6 +29,7 @@ static void check_tablespace(std::string const &tablespace)
 }
 
 static flex_table_t &create_flex_table(lua_State *lua_state,
+                                       std::string const &default_schema,
                                        std::vector<flex_table_t> *tables)
 {
     std::string const table_name =
@@ -40,7 +41,7 @@ static flex_table_t &create_flex_table(lua_State *lua_state,
         throw fmt_error("Table with name '{}' already exists.", table_name);
     }
 
-    auto &new_table = tables->emplace_back(table_name);
+    auto &new_table = tables->emplace_back(default_schema, table_name);
 
     lua_pop(lua_state, 1); // "name"
 
@@ -411,14 +412,15 @@ static void setup_flex_table_indexes(lua_State *lua_state, flex_table_t *table,
 
 int setup_flex_table(lua_State *lua_state, std::vector<flex_table_t> *tables,
                      std::vector<expire_output_t> *expire_outputs,
-                     bool updatable, bool append_mode)
+                     std::string const &default_schema, bool updatable,
+                     bool append_mode)
 {
     if (lua_type(lua_state, 1) != LUA_TTABLE) {
         throw std::runtime_error{
             "Argument #1 to 'define_table' must be a table."};
     }
 
-    auto &new_table = create_flex_table(lua_state, tables);
+    auto &new_table = create_flex_table(lua_state, default_schema, tables);
     setup_flex_table_id_columns(lua_state, &new_table);
     setup_flex_table_columns(lua_state, &new_table, expire_outputs,
                              append_mode);

--- a/src/flex-lua-table.hpp
+++ b/src/flex-lua-table.hpp
@@ -10,6 +10,7 @@
  * For a full list of authors see the git log.
  */
 
+#include <string>
 #include <vector>
 
 class expire_output_t;
@@ -20,6 +21,7 @@ static char const *const osm2pgsql_table_name = "osm2pgsql.Table";
 
 int setup_flex_table(lua_State *lua_state, std::vector<flex_table_t> *tables,
                      std::vector<expire_output_t> *expire_outputs,
-                     bool updatable, bool append_mode);
+                     std::string const &default_schema, bool updatable,
+                     bool append_mode);
 
 #endif // OSM2PGSQL_FLEX_LUA_TABLE_HPP

--- a/src/flex-table.hpp
+++ b/src/flex-table.hpp
@@ -59,7 +59,10 @@ public:
         permanent
     };
 
-    explicit flex_table_t(std::string name) : m_name(std::move(name)) {}
+    flex_table_t(std::string schema, std::string name)
+    : m_schema(std::move(schema)), m_name(std::move(name))
+    {
+    }
 
     std::string const &name() const noexcept { return m_name; }
 
@@ -195,11 +198,11 @@ public:
     bool has_columns_with_expire() const noexcept;
 
 private:
+    /// The schema this table is in
+    std::string m_schema;
+
     /// The name of the table
     std::string m_name;
-
-    /// The schema this table is in
-    std::string m_schema{"public"};
 
     /// The table space used for this table (empty for default tablespace)
     std::string m_data_tablespace;

--- a/src/gen/gen-base.cpp
+++ b/src/gen/gen-base.cpp
@@ -20,7 +20,7 @@ gen_base_t::gen_base_t(pg_conn_t *connection, params_t *params)
     assert(connection);
     assert(params);
 
-    params->check_identifier_with_default("schema", "public");
+    params->check_identifier_with_default("schema", "");
     auto const schema = params->get_identifier("schema");
 
     if (params->has("src_table")) {

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -98,11 +98,14 @@ struct options_t
     /// Pg Tablespace to store slim tables (no default TABLESPACE)
     std::string tblsslim_data{};
 
+    /// Default Pg schema.
+    std::string dbschema{"public"};
+
     /// Pg schema to store middle tables in.
-    std::string middle_dbschema{"public"};
+    std::string middle_dbschema{};
 
     /// Pg schema to store output tables in.
-    std::string output_dbschema{"public"};
+    std::string output_dbschema{};
 
     std::string style{}; ///< style file to use
 

--- a/src/osm2pgsql.cpp
+++ b/src/osm2pgsql.cpp
@@ -90,6 +90,7 @@ static void check_db(options_t const &options)
 
     init_database_capabilities(db_connection);
 
+    check_schema(options.dbschema);
     check_schema(options.middle_dbschema);
     check_schema(options.output_dbschema);
 }

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -402,6 +402,7 @@ int output_flex_t::app_define_table()
     }
 
     return setup_flex_table(lua_state(), m_tables.get(), m_expire_outputs.get(),
+                            get_options()->dbschema,
                             get_options()->slim && !get_options()->droptemp,
                             get_options()->append);
 }
@@ -414,7 +415,8 @@ int output_flex_t::app_define_expire_output()
             " main Lua code, not in any of the callbacks."};
     }
 
-    return setup_flex_expire_output(lua_state(), m_expire_outputs.get());
+    return setup_flex_expire_output(lua_state(), get_options()->dbschema,
+                                    m_expire_outputs.get());
 }
 
 // Check that the first element on the Lua stack is a "type_name"

--- a/tests/common-options.hpp
+++ b/tests/common-options.hpp
@@ -28,6 +28,8 @@ public:
         m_opt.cache = 2;
         m_opt.append = false;
         m_opt.projection = reprojection::create_projection(PROJ_SPHERE_MERC);
+        m_opt.middle_dbschema = "public";
+        m_opt.output_dbschema = "public";
     }
 
     operator options_t() const { return m_opt; }

--- a/tests/test-flex-indexes.cpp
+++ b/tests/test-flex-indexes.cpp
@@ -48,7 +48,7 @@ TEST_CASE("check index with single column", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"test_table"};
+    flex_table_t table{"public", "test_table"};
     table.add_column("geom", "geometry", "");
 
     REQUIRE(table.indexes().empty());
@@ -71,7 +71,7 @@ TEST_CASE("check index with multiple columns", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"test_table"};
+    flex_table_t table{"public", "test_table"};
     table.add_column("a", "int", "");
     table.add_column("b", "int", "");
 
@@ -93,7 +93,7 @@ TEST_CASE("check unique index", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"test_table"};
+    flex_table_t table{"public", "test_table"};
     table.add_column("col", "int", "");
 
     REQUIRE(tf.run_lua(
@@ -115,7 +115,7 @@ TEST_CASE("check index with tablespace from table", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"test_table"};
+    flex_table_t table{"public", "test_table"};
     table.set_index_tablespace("foo");
     table.add_column("col", "int", "");
 
@@ -137,7 +137,7 @@ TEST_CASE("check index with tablespace", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"test_table"};
+    flex_table_t table{"public", "test_table"};
     table.add_column("col", "int", "");
 
     REQUIRE(tf.run_lua("return { method = 'btree', column = 'col', tablespace "
@@ -159,7 +159,7 @@ TEST_CASE("check index with expression and where clause", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"test_table"};
+    flex_table_t table{"public", "test_table"};
     table.add_column("col", "text", "");
 
     REQUIRE(tf.run_lua("return { method = 'btree', expression = 'lower(col)',"
@@ -181,7 +181,7 @@ TEST_CASE("check index with include", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"test_table"};
+    flex_table_t table{"public", "test_table"};
     table.add_column("col", "int", "");
     table.add_column("extra", "int", "");
 
@@ -204,7 +204,7 @@ TEST_CASE("check index with include as array", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"test_table"};
+    flex_table_t table{"public", "test_table"};
     table.add_column("col", "int", "");
     table.add_column("extra", "int", "");
 
@@ -227,7 +227,7 @@ TEST_CASE("check index with empty include array", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"test_table"};
+    flex_table_t table{"public", "test_table"};
     table.add_column("col", "int", "");
     table.add_column("extra", "int", "");
 
@@ -250,7 +250,7 @@ TEST_CASE("check multiple indexes", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"test_table"};
+    flex_table_t table{"public", "test_table"};
     table.add_column("a", "int", "");
     table.add_column("b", "int", "");
 
@@ -273,7 +273,7 @@ TEST_CASE("check various broken index configs", "[NoDB]")
 {
     test_framework const tf;
 
-    flex_table_t table{"test_table"};
+    flex_table_t table{"public", "test_table"};
     table.add_column("col", "text", "");
 
     SECTION("empty index description") { REQUIRE(tf.run_lua("return {}")); }


### PR DESCRIPTION
This will be used as default for --middle-schema, --output-pgsql-schema, and for the different ways of setting a schema in the flex output and generalizer code.

This removes the last places where the schema was hardcoded to "public" (except as a default for this command line parameter and in some legacy gazetteer code).