### PR TITLE
Fix invalid escape sequence warnings

### DIFF
--- a/tests/bdd/steps/steps_db.py
+++ b/tests/bdd/steps/steps_db.py
@@ -25,7 +25,7 @@ def delete_table(context, table):
         cur.execute("DROP TABLE " + table)
 
 
-@then("table (?P<table>.+) has (?P<row_num>\d+) rows?(?P<has_where> with condition)?")
+@then("table (?P<table>.+) has (?P<row_num>\\d+) rows?(?P<has_where> with condition)?")
 def db_table_row_count(context, table, row_num, has_where):
     assert table_exists(context.db, table)
 
@@ -40,7 +40,7 @@ def db_table_row_count(context, table, row_num, has_where):
            f"Table {table}: expected {row_num} rows, got {actual}"
 
 
-@then("the sum of '(?P<formula>.+)' in table (?P<table>.+) is (?P<result>\d+)(?P<has_where> with condition)?")
+@then("the sum of '(?P<formula>.+)' in table (?P<table>.+) is (?P<result>\\d+)(?P<has_where> with condition)?")
 def db_table_sum_up(context, table, formula, result, has_where):
     assert table_exists(context.db, table)
 

--- a/tests/bdd/steps/steps_execute.py
+++ b/tests/bdd/steps/steps_execute.py
@@ -148,7 +148,7 @@ def setup_style_file(context, style):
     context.osm2pgsql_params.extend(('-S', str(context.test_data_dir / style)))
 
 
-@when("running osm2pgsql (?P<output>\w+)(?: with parameters)?")
+@when("running osm2pgsql (?P<output>\\w+)(?: with parameters)?")
 def execute_osm2pgsql_successfully(context, output):
     returncode = run_osm2pgsql(context, output)
 
@@ -160,7 +160,7 @@ def execute_osm2pgsql_successfully(context, output):
            f"Output:\n{context.osm2pgsql_outdata[0]}\n{context.osm2pgsql_outdata[1]}\n"
 
 
-@then("running osm2pgsql (?P<output>\w+)(?: with parameters)? fails")
+@then("running osm2pgsql (?P<output>\\w+)(?: with parameters)? fails")
 def execute_osm2pgsql_with_failure(context, output):
     returncode = run_osm2pgsql(context, output)
 
@@ -179,7 +179,7 @@ def execute_osm2pgsql_replication_successfully(context):
            f"Output:\n{context.osm2pgsql_outdata[0]}\n{context.osm2pgsql_outdata[1]}\n"
 
 
-@then("running osm2pgsql-replication fails(?: with returncode (?P<expected>\d+))?")
+@then("running osm2pgsql-replication fails(?: with returncode (?P<expected>\\d+))?")
 def execute_osm2pgsql_replication_successfully(context, expected):
     returncode = run_osm2pgsql_replication(context)
 
@@ -190,7 +190,7 @@ def execute_osm2pgsql_replication_successfully(context, expected):
                f"Output:\n{context.osm2pgsql_outdata[0]}\n{context.osm2pgsql_outdata[1]}\n"
 
 
-@then("the (?P<kind>\w+) output contains")
+@then("the (?P<kind>\\w+) output contains")
 def check_program_output(context, kind):
     if kind == 'error':
         s = context.osm2pgsql_outdata[1]


### PR DESCRIPTION
These warnings are normally hidden but when a bdd test fails you see them in the output:

```
steps/steps_db.py:28: SyntaxWarning: invalid escape sequence '\d'
  @then("table (?P<table>.+) has (?P<row_num>\d+) rows?(?P<has_where> with condition)?")
steps/steps_db.py:43: SyntaxWarning: invalid escape sequence '\d'
  @then("the sum of '(?P<formula>.+)' in table (?P<table>.+) is (?P<result>\d+)(?P<has_where> with condition)?")
steps/steps_execute.py:151: SyntaxWarning: invalid escape sequence '\w'
  @when("running osm2pgsql (?P<output>\w+)(?: with parameters)?")
steps/steps_execute.py:163: SyntaxWarning: invalid escape sequence '\w'
  @then("running osm2pgsql (?P<output>\w+)(?: with parameters)? fails")
steps/steps_execute.py:182: SyntaxWarning: invalid escape sequence '\d'
  @then("running osm2pgsql-replication fails(?: with returncode (?P<expected>\d+))?")
steps/steps_execute.py:193: SyntaxWarning: invalid escape sequence '\w'
  @then("the (?P<kind>\w+) output contains")
```