### PR TITLE
Fix running osm2pgsql-replication with psycopg3

### DIFF
--- a/.github/actions/ubuntu-prerequisites/action.yml
+++ b/.github/actions/ubuntu-prerequisites/action.yml
@@ -30,11 +30,15 @@ runs:
           postgresql-${POSTGRESQL_VERSION}-postgis-${POSTGIS_VERSION} \
           postgresql-${POSTGRESQL_VERSION}-postgis-${POSTGIS_VERSION}-scripts \
           postgresql-client postgresql-contrib-${POSTGRESQL_VERSION} \
-          python3-psycopg2 \
           python3-setuptools \
           zlib1g-dev
         pip3 install behave osmium
         if [ "$CC" = clang-8 ]; then sudo apt-get install -yq --no-install-suggests --no-install-recommends clang-8; fi
+        if [ "$PSYCOPG" = "2"]; then
+            sudo apt-get install -yq --no-install-suggests --no-install-recommends python3-psycopg2
+        else
+            pip3 install psycopg
+        fi
       shell: bash
 
     - name: Install Lua

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       POSTGRESQL_VERSION: 9.6
       POSTGIS_VERSION: 2.5
       BUILD_TYPE: Release
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -75,6 +76,7 @@ jobs:
       POSTGRESQL_VERSION: 9.6
       POSTGIS_VERSION: 2.5
       BUILD_TYPE: Release
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -93,6 +95,7 @@ jobs:
       POSTGRESQL_VERSION: 10
       POSTGIS_VERSION: 3
       BUILD_TYPE: Debug
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -111,6 +114,7 @@ jobs:
       POSTGRESQL_VERSION: 11
       POSTGIS_VERSION: 2.5
       BUILD_TYPE: Debug
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -128,6 +132,7 @@ jobs:
       POSTGRESQL_VERSION: 12
       POSTGIS_VERSION: 2.5
       BUILD_TYPE: Debug
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -146,6 +151,7 @@ jobs:
       POSTGRESQL_VERSION: 13
       POSTGIS_VERSION: 3
       BUILD_TYPE: Debug
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -164,6 +170,7 @@ jobs:
       POSTGIS_VERSION: 3
       USE_PROJ_LIB: 6
       BUILD_TYPE: Debug
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -182,6 +189,7 @@ jobs:
       POSTGIS_VERSION: 3
       USE_PROJ_LIB: off
       BUILD_TYPE: Debug
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -200,6 +208,7 @@ jobs:
       POSTGIS_VERSION: 3
       USE_PROJ_LIB: 6
       BUILD_TYPE: Debug
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -217,6 +226,7 @@ jobs:
       POSTGRESQL_VERSION: 13
       POSTGIS_VERSION: 2.5
       BUILD_TYPE: Release
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -232,6 +242,7 @@ jobs:
       POSTGRESQL_VERSION: 13
       POSTGIS_VERSION: 2.5
       BUILD_TYPE: Release
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -249,6 +260,7 @@ jobs:
       POSTGRESQL_VERSION: 14
       POSTGIS_VERSION: 3
       BUILD_TYPE: Debug
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -267,6 +279,7 @@ jobs:
       POSTGIS_VERSION: 3
       USE_PROJ_LIB: 6
       BUILD_TYPE: Debug
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -285,6 +298,7 @@ jobs:
       POSTGIS_VERSION: 3
       USE_PROJ_LIB: off
       BUILD_TYPE: Debug
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -303,6 +317,7 @@ jobs:
       POSTGIS_VERSION: 3
       USE_PROJ_LIB: 6
       BUILD_TYPE: Debug
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -321,6 +336,7 @@ jobs:
       POSTGRESQL_VERSION: 14
       POSTGIS_VERSION: 3
       BUILD_TYPE: Release
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -337,6 +353,7 @@ jobs:
       POSTGRESQL_VERSION: 14
       POSTGIS_VERSION: 3
       BUILD_TYPE: Release
+      PSYCOPG: 2
 
     steps:
       - uses: actions/checkout@v3
@@ -355,6 +372,7 @@ jobs:
       POSTGIS_VERSION: 3
       CPP_VERSION: 20
       BUILD_TYPE: Debug
+      PSYCOPG: 3
 
     steps:
       - uses: actions/checkout@v3
@@ -373,6 +391,7 @@ jobs:
       POSTGIS_VERSION: 3
       CPP_VERSION: 20
       BUILD_TYPE: Debug
+      PSYCOPG: 3
 
     steps:
       - uses: actions/checkout@v3

--- a/scripts/osm2pgsql-replication
+++ b/scripts/osm2pgsql-replication
@@ -122,7 +122,7 @@ class DBConnection:
                                         host=args.host, port=args.port,
                                         fallback_application_name="osm2pgsql-replication")
 
-        self.name = self.conn.get_dsn_parameters()['dbname']
+        self.name = self.conn.info.dbname
 
     def __enter__(self):
         return self

--- a/tests/bdd/steps/steps_db.py
+++ b/tests/bdd/steps/steps_db.py
@@ -11,7 +11,11 @@ import math
 import re
 from typing import Iterable
 
-from psycopg2 import sql
+try:
+    from psycopg2 import sql
+except ImportError:
+    from psycopg import sql
+
 
 @given("the database schema (?P<schema>.+)")
 def create_db_schema(context, schema):


### PR DESCRIPTION
Avoids use of get_dsn_parameter() which is outdated anyway.

Also makes sure that the psycopg3 version is run in the CI. This in turn required to make the BDD tests work with psycopg3.

Fixes #2040.