### PR TITLE
Pass points as values, other geoms as reference to add_geometry()

### DIFF
--- a/src/geom.hpp
+++ b/src/geom.hpp
@@ -22,6 +22,7 @@
 #include <cassert>
 #include <cmath>
 #include <initializer_list>
+#include <type_traits>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -197,12 +198,15 @@ public:
     using iterator = typename std::vector<GEOM>::iterator;
     using value_type = GEOM;
 
+    static constexpr bool const for_point = std::is_same_v<GEOM, point_t>;
+
     [[nodiscard]] std::size_t num_geometries() const noexcept
     {
         return m_geometry.size();
     }
 
-    GEOM &add_geometry(GEOM &&geom)
+    GEOM &
+    add_geometry(typename std::conditional_t<for_point, point_t, GEOM &&> geom)
     {
         m_geometry.push_back(std::forward<GEOM>(geom));
         return m_geometry.back();

--- a/tests/test-expire-from-geometry.cpp
+++ b/tests/test-expire-from-geometry.cpp
@@ -332,22 +332,22 @@ TEST_CASE("expire multipoint geometry", "[NoDB]")
     expire_config_t const expire_config;
     expire_tiles et{zoom, defproj};
 
-    geom::point_t p1{0.0, 0.0};
-    geom::point_t p2{15000.0, 15000.0};
+    geom::point_t const p1{0.0, 0.0};
+    geom::point_t const p2{15000.0, 15000.0};
 
     SECTION("multipoint")
     {
         geom::multipoint_t mpt;
-        mpt.add_geometry(std::move(p1));
-        mpt.add_geometry(std::move(p2));
+        mpt.add_geometry(p1);
+        mpt.add_geometry(p2);
         et.from_geometry(mpt, expire_config);
     }
 
     SECTION("geom")
     {
         geom::multipoint_t mpt;
-        mpt.add_geometry(std::move(p1));
-        mpt.add_geometry(std::move(p2));
+        mpt.add_geometry(p1);
+        mpt.add_geometry(p2);
         geom::geometry_t const geom{std::move(mpt)};
         et.from_geometry(geom, expire_config);
     }
@@ -355,8 +355,8 @@ TEST_CASE("expire multipoint geometry", "[NoDB]")
     SECTION("geom with check")
     {
         geom::multipoint_t mpt;
-        mpt.add_geometry(std::move(p1));
-        mpt.add_geometry(std::move(p2));
+        mpt.add_geometry(p1);
+        mpt.add_geometry(p2);
         geom::geometry_t geom{std::move(mpt)};
         geom.set_srid(3857);
         et.from_geometry_if_3857(geom, expire_config);


### PR DESCRIPTION
Points are small and not movable. Removes a complaint from clang-tidy about pessimizing std::move.