### PR TITLE
docs/readme: Add link to Github for docs and example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,6 @@ the [compiled version](osm2pgsql.1) and the files necessary to create it.
 Call `make man` to re-build the man page.
 
 The documentation that used to be in this directory has been moved to
-the [osm2pgsql manual](https://osm2pgsql.org/doc/manual.html) or to the
-[examples](https://osm2pgsql.org/examples) on the website.
+the [osm2pgsql manual](https://osm2pgsql.org/doc/manual.html) ([Github](https://github.com/openstreetmap/osm2pgsql-website/tree/master/doc)) or to the
+[examples](https://osm2pgsql.org/examples) ([Github](https://github.com/openstreetmap/osm2pgsql-website/tree/master/examples)) on the website.
 


### PR DESCRIPTION
I was looking for the docs source code. This makes it a bit easier to find.