### PR TITLE
Fix regression in select_relation_members()

### DIFF
--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -48,6 +48,9 @@
 #include <stdexcept>
 #include <string>
 
+// Mutex used to coordinate access to Lua code
+static std::mutex lua_mutex;
+
 // Lua can't call functions on C++ objects directly. This macro defines simple
 // C "trampoline" functions which are called from Lua which get the current
 // context (the output_flex_t object) and call the respective function on the
@@ -895,9 +898,6 @@ int output_flex_t::expire_output_table()
 void output_flex_t::call_lua_function(prepared_lua_function_t func,
                                       osmium::OSMObject const &object)
 {
-    static std::mutex lua_mutex;
-    std::lock_guard<std::mutex> const guard{lua_mutex};
-
     m_calling_context = func.context();
 
     lua_pushvalue(lua_state(), func.index()); // the function to call
@@ -914,6 +914,13 @@ void output_flex_t::call_lua_function(prepared_lua_function_t func,
     m_calling_context = calling_context::main;
 }
 
+void output_flex_t::get_mutex_and_call_lua_function(
+    prepared_lua_function_t func, osmium::OSMObject const &object)
+{
+    std::lock_guard<std::mutex> const guard{lua_mutex};
+    call_lua_function(func, object);
+}
+
 void output_flex_t::pending_way(osmid_t id)
 {
     if (!m_process_way) {
@@ -926,7 +933,7 @@ void output_flex_t::pending_way(osmid_t id)
 
     way_delete(id);
 
-    call_lua_function(m_process_way, m_way_cache.get());
+    get_mutex_and_call_lua_function(m_process_way, m_way_cache.get());
 }
 
 void output_flex_t::select_relation_members()
@@ -935,6 +942,7 @@ void output_flex_t::select_relation_members()
         return;
     }
 
+    std::lock_guard<std::mutex> const guard{lua_mutex};
     call_lua_function(m_select_relation_members, m_relation_cache.get());
 
     // If the function returned nil there is nothing to be marked.
@@ -1014,7 +1022,8 @@ void output_flex_t::pending_relation(osmid_t id)
     delete_from_tables(osmium::item_type::relation, id);
 
     if (m_process_relation) {
-        call_lua_function(m_process_relation, m_relation_cache.get());
+        get_mutex_and_call_lua_function(m_process_relation,
+                                        m_relation_cache.get());
     }
 }
 
@@ -1029,7 +1038,7 @@ void output_flex_t::pending_relation_stage1c(osmid_t id)
     }
 
     m_disable_add_row = true;
-    call_lua_function(m_process_relation, m_relation_cache.get());
+    get_mutex_and_call_lua_function(m_process_relation, m_relation_cache.get());
     m_disable_add_row = false;
 }
 
@@ -1104,7 +1113,7 @@ void output_flex_t::node_add(osmium::Node const &node)
     }
 
     m_context_node = &node;
-    call_lua_function(m_process_node, node);
+    get_mutex_and_call_lua_function(m_process_node, node);
     m_context_node = nullptr;
 }
 
@@ -1117,7 +1126,7 @@ void output_flex_t::way_add(osmium::Way *way)
     }
 
     m_way_cache.init(way);
-    call_lua_function(m_process_way, m_way_cache.get());
+    get_mutex_and_call_lua_function(m_process_way, m_way_cache.get());
 }
 
 void output_flex_t::relation_add(osmium::Relation const &relation)
@@ -1128,7 +1137,7 @@ void output_flex_t::relation_add(osmium::Relation const &relation)
 
     m_relation_cache.init(relation);
     select_relation_members();
-    call_lua_function(m_process_relation, relation);
+    get_mutex_and_call_lua_function(m_process_relation, relation);
 }
 
 void output_flex_t::delete_from_table(table_connection_t *table_connection,
@@ -1518,7 +1527,7 @@ void output_flex_t::reprocess_marked()
         }
         way_delete(id);
         if (m_process_way) {
-            call_lua_function(m_process_way, m_way_cache.get());
+            get_mutex_and_call_lua_function(m_process_way, m_way_cache.get());
         }
     }
 

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -942,6 +942,8 @@ void output_flex_t::select_relation_members()
         return;
     }
 
+    // We can not use get_mutex_and_call_lua_function() here, because we need
+    // the mutex to stick around as long as we are looking at the Lua stack.
     std::lock_guard<std::mutex> const guard{lua_mutex};
     call_lua_function(m_select_relation_members, m_relation_cache.get());
 

--- a/src/output-flex.hpp
+++ b/src/output-flex.hpp
@@ -185,11 +185,14 @@ private:
 
     /**
      * Call a Lua function that was "prepared" earlier with the OSMObject
-     * as its only parameter. Uses a mutex internally to make access to the
-     * Lua environment thread safe.
+     * as its only parameter.
      */
     void call_lua_function(prepared_lua_function_t func,
                            osmium::OSMObject const &object);
+
+    /// Aquire the lua_mutex and the call `call_lua_function()`.
+    void get_mutex_and_call_lua_function(prepared_lua_function_t func,
+                                         osmium::OSMObject const &object);
 
     void init_lua(std::string const &filename);
 


### PR DESCRIPTION
This reverts a commit we recently did. Turns out we need the mutex to be around after the call to the function, because we are using the Lua stack after the function returns to get the results.