### PR TITLE
Disable the warning that cache is disabled in append mode

### DIFF
--- a/src/command-line-parser.cpp
+++ b/src/command-line-parser.cpp
@@ -486,7 +486,7 @@ static void check_options(options_t *options)
             throw std::runtime_error{
                 "RAM node cache can only be disabled in slim mode."};
         }
-        if (options->flat_node_file.empty()) {
+        if (options->flat_node_file.empty() && !options->append) {
             log_warn("RAM cache is disabled. This will likely slow down "
                      "processing a lot.");
         }


### PR DESCRIPTION
In append mode we don't necessarily have the flat node setting from the command line, because it is read from the properties file. So this would give us an unnecessary and wrong warning.

This is just a band aid though, a better fix would be to check after we have read the properties file. But that needs some larger changes I'll leave for when we refactor the command line parsing code.