### PR TITLE
Check in CMake config that we are building for 64bit architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ else()
     set(ENABLE_INSTALL OFF)
 endif()
 
+if (NOT ${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+    message(FATAL_ERROR "osm2pgsql needs a 64 bit architecture")
+endif()
+
 if (WIN32)
     set(DEFAULT_STYLE "default.style" CACHE STRING "Default style used unless one is given on the command line")
 else()


### PR DESCRIPTION
For a long time we haven't officially supported 32bit architectures but not really disabled them. But this is giving us more problems lately and we can't test on 32 bit systems anyway, so this now gives us an up front check.