### PR TITLE
Fail on 32bit architectures.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ if (PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
     message(FATAL_ERROR "In-source builds are not allowed, please use a separate build directory like `mkdir build && cd build && cmake ..`")
 endif()
 
+if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+    message(FATAL_ERROR "32bit is not supported")
+endif()
+
 message(STATUS "Building osm2pgsql ${PROJECT_VERSION}")
 
 if (NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
From https://github.com/openstreetmap/osm2pgsql/issues/2065#issuecomment-1705401937:
> Officially we are not supporting 32bit architectures and have for a while now. Its not that you can do much with a 32bit system with OSM data. So maybe it is time to take these architectures out?

Let's make this explicit then, and fail early at configure time on 32bit architectures.