### PR TITLE
Generalization: Wrap upload of data in transaction

### DIFF
--- a/src/gen/gen-tile-builtup.cpp
+++ b/src/gen/gen-tile-builtup.cpp
@@ -253,6 +253,7 @@ void gen_tile_builtup_t::process(tile_t const &tile)
 
     log_gen("Write geometries to destination table...");
     timer(m_timer_write).start();
+    connection().exec("BEGIN");
     for (auto const &geom : geometries) {
         auto const wkb = to_hex(geom_to_ewkb(geom));
         if (m_has_area_column) {
@@ -262,6 +263,7 @@ void gen_tile_builtup_t::process(tile_t const &tile)
             connection().exec_prepared("insert_geoms", wkb, tile.x(), tile.y());
         }
     }
+    connection().exec("COMMIT");
     timer(m_timer_write).stop();
     log_gen("Inserted {} generalized polygons", geometries.size());
 }

--- a/src/gen/gen-tile-raster.cpp
+++ b/src/gen/gen-tile-raster.cpp
@@ -236,11 +236,13 @@ void gen_tile_raster_union_t::process(tile_t const &tile)
 
         log_gen("Write geometries to destination table...");
         timer(m_timer_write).start();
+        connection().exec("BEGIN");
         for (auto const &geom : geometries) {
             auto const wkb = geom_to_ewkb(geom);
             connection().exec_prepared("insert_geoms", binary_param{wkb},
                                        tile.x(), tile.y(), param);
         }
+        connection().exec("COMMIT");
         timer(m_timer_write).stop();
         log_gen("Inserted {} generalized polygons", geometries.size());
     }


### PR DESCRIPTION
So we don't use so many transaction ids.