### PR TITLE
Generalization: Wrap delete/upload of data in transaction

### DIFF
--- a/src/gen/gen-tile-builtup.cpp
+++ b/src/gen/gen-tile-builtup.cpp
@@ -181,6 +181,7 @@ static void draw_from_db(double margin, canvas_list_t *canvas_list,
 
 void gen_tile_builtup_t::process(tile_t const &tile)
 {
+    connection().exec("BEGIN");
     delete_existing(tile);
 
     canvas_list_t canvas_list;
@@ -262,6 +263,7 @@ void gen_tile_builtup_t::process(tile_t const &tile)
             connection().exec_prepared("insert_geoms", wkb, tile.x(), tile.y());
         }
     }
+    connection().exec("COMMIT");
     timer(m_timer_write).stop();
     log_gen("Inserted {} generalized polygons", geometries.size());
 }

--- a/src/gen/gen-tile-raster.cpp
+++ b/src/gen/gen-tile-raster.cpp
@@ -174,6 +174,7 @@ static void draw_from_db(double margin, unsigned int image_extent,
 
 void gen_tile_raster_union_t::process(tile_t const &tile)
 {
+    connection().exec("BEGIN");
     delete_existing(tile);
 
     canvas_list_t canvas_list;
@@ -244,6 +245,7 @@ void gen_tile_raster_union_t::process(tile_t const &tile)
         timer(m_timer_write).stop();
         log_gen("Inserted {} generalized polygons", geometries.size());
     }
+    connection().exec("COMMIT");
 }
 
 void gen_tile_raster_union_t::post()

--- a/src/gen/gen-tile-vector.cpp
+++ b/src/gen/gen-tile-vector.cpp
@@ -83,12 +83,14 @@ PREPARE gen_geoms (int, int, int) AS
 
 void gen_tile_vector_union_t::process(tile_t const &tile)
 {
+    connection().exec("BEGIN");
     delete_existing(tile);
 
     log_gen("Generalize...");
     timer(m_timer_simplify).start();
     auto const result = connection().exec_prepared("gen_geoms", tile.zoom(),
                                                    tile.x(), tile.y());
+    connection().exec("COMMIT");
     timer(m_timer_simplify).stop();
     log_gen("Inserted {} generalized polygons", result.affected_rows());
 }


### PR DESCRIPTION
So we either see the old or the new data. And we are saving transaction ids.