### PR TITLE
Generalizer: Log tile being processed also in multithreaded mode

### DIFF
--- a/src/gen/osm2pgsql-gen.cpp
+++ b/src/gen/osm2pgsql-gen.cpp
@@ -262,7 +262,10 @@ void run_tile_gen(std::string const &conninfo, gen_base_t *master_generalizer,
             queue->pop_back();
         }
 
-        generalizer->process({zoom, p.first, p.second});
+        tile_t tile{zoom, p.first, p.second};
+        log_debug("Processing tile {}/{}/{}...", tile.zoom(), tile.x(),
+                  tile.y());
+        generalizer->process(tile);
     }
     log_debug("Shutting down generalizer thread.");
 }


### PR DESCRIPTION
Not only in singlethreaded more.