### PR TITLE
Simplify and fix code getting relation members

### DIFF
--- a/src/middle-pgsql.cpp
+++ b/src/middle-pgsql.cpp
@@ -839,9 +839,9 @@ middle_query_pgsql_t::rel_members_get(osmium::Relation const &rel,
     for (auto const &member : rel.members()) {
         if (member.type() == osmium::item_type::node &&
             (types & osmium::osm_entity_bits::node)) {
-            osmium::builder::NodeBuilder builder{*buffer};
-            builder.set_id(member.ref());
-            ++members_found;
+            if (node_get(member.ref(), buffer)) {
+                ++members_found;
+            }
         } else if (member.type() == osmium::item_type::way &&
                    (types & osmium::osm_entity_bits::way) && res) {
             // Match the list of ways coming from postgres in a different order

--- a/src/middle-ram.cpp
+++ b/src/middle-ram.cpp
@@ -334,26 +334,14 @@ middle_ram_t::rel_members_get(osmium::Relation const &rel,
     for (auto const &member : rel.members()) {
         auto const member_entity_type =
             osmium::osm_entity_bits::from_item_type(member.type());
+
         if ((member_entity_type & types) == 0) {
             continue;
         }
 
         switch (member.type()) {
         case osmium::item_type::node:
-            if (m_store_options.nodes) {
-                auto const offset =
-                    m_object_index.nodes().get(member.ref());
-                if (offset != ordered_index_t::not_found_value()) {
-                    buffer->add_item(m_object_buffer.get<osmium::Node>(offset));
-                    buffer->commit();
-                    ++count;
-                }
-            } else {
-                {
-                    osmium::builder::NodeBuilder builder{*buffer};
-                    builder.set_id(member.ref());
-                }
-                buffer->commit();
+            if (node_get(member.ref(), buffer)) {
                 ++count;
             }
             break;
@@ -379,15 +367,8 @@ middle_ram_t::rel_members_get(osmium::Relation const &rel,
             }
             break;
         default: // osmium::item_type::relation
-            if (m_store_options.relations) {
-                auto const offset =
-                    m_object_index.relations().get(member.ref());
-                if (offset != ordered_index_t::not_found_value()) {
-                    buffer->add_item(
-                        m_object_buffer.get<osmium::Relation>(offset));
-                    buffer->commit();
-                    ++count;
-                }
+            if (relation_get(member.ref(), buffer)) {
+                ++count;
             }
         }
     }

--- a/src/output-flex.cpp
+++ b/src/output-flex.cpp
@@ -687,12 +687,6 @@ bool output_flex_t::relation_cache_t::add_members(middle_query_t const &middle)
             return false;
         }
 
-        for (auto &node : m_members_buffer.select<osmium::Node>()) {
-            if (!node.location().valid()) {
-                node.set_location(middle.get_node_location(node.id()));
-            }
-        }
-
         for (auto &way : m_members_buffer.select<osmium::Way>()) {
             get_nodes(middle, &way);
         }


### PR DESCRIPTION
This changes the way we are getting node members of relations. We now always get the locations of those nodes directly in the middle code instead of only getting the nodes themselves and adding the locations through an extra call from the output.

This also fixes a problem where node locations for untagged nodes were not retrieved from the RAM middle. The node_get() code does that correctly, while the old code didn't.