### PR TITLE
Implement expire of points in its own code

### DIFF
--- a/src/expire-tiles.cpp
+++ b/src/expire-tiles.cpp
@@ -71,8 +71,22 @@ void expire_tiles_t::from_point_list(geom::point_list_t const &list,
 void expire_tiles_t::from_geometry(geom::point_t const &geom,
                                    expire_config_t const &expire_config)
 {
-    geom::box_t const box = geom::envelope(geom);
-    from_bbox(box, expire_config);
+    auto const tilec = coords_to_tile(geom);
+
+    auto const ymin =
+        std::max(0U, static_cast<uint32_t>(tilec.y() - expire_config.buffer));
+
+    auto const ymax =
+        std::min(m_map_width - 1U,
+                 static_cast<uint32_t>(tilec.y() + expire_config.buffer));
+
+    for (int x = static_cast<int>(tilec.x() - expire_config.buffer);
+         x <= static_cast<int>(tilec.x() + expire_config.buffer); ++x) {
+        uint32_t const norm_x = normalise_tile_x_coord(x);
+        for (uint32_t y = ymin; y <= ymax; ++y) {
+            expire_tile(norm_x, y);
+        }
+    }
 }
 
 void expire_tiles_t::from_geometry(geom::linestring_t const &geom,

--- a/tests/test-expire-tiles.cpp
+++ b/tests/test-expire-tiles.cpp
@@ -189,9 +189,10 @@ TEST_CASE("simple expire z10 bounds 1023, 0", "[NoDB]")
                      expire_config_t{});
 
     auto const tiles = get_tiles_ordered(&et, minzoom, maxzoom);
-    CHECK(tiles.size() == 1);
+    CHECK(tiles.size() == 2);
 
     auto itr = tiles.cbegin();
+    CHECK(*(itr++) == tile_t(10, 0, 0));
     CHECK(*(itr++) == tile_t(10, 1023, 0));
 }
 
@@ -205,9 +206,10 @@ TEST_CASE("simple expire z10 bounds 1023, 1023", "[NoDB]")
                      expire_config_t{});
 
     auto const tiles = get_tiles_ordered(&et, minzoom, maxzoom);
-    CHECK(tiles.size() == 1);
+    CHECK(tiles.size() == 2);
 
     auto itr = tiles.cbegin();
+    CHECK(*(itr++) == tile_t(10, 0, 1023));
     CHECK(*(itr++) == tile_t(10, 1023, 1023));
 }
 


### PR DESCRIPTION
Instead of generating a bounding box and using the general bbox expire code.

This takes the expire buffer into account, so neighboring tiles are expired if the point is near the tile boundary.

Other than before tiles affected wrap around at the 180° line.