### PR TITLE
Fix: Always disable expiry if maxzoom==0

### DIFF
--- a/src/expire-tiles.cpp
+++ b/src/expire-tiles.cpp
@@ -147,6 +147,10 @@ void expire_tiles_t::from_geometry(geom::multipolygon_t const &geom,
 void expire_tiles_t::from_geometry(geom::geometry_t const &geom,
                                    expire_config_t const &expire_config)
 {
+    if (!enabled()) {
+        return;
+    }
+
     geom.visit([&](auto const &g) { from_geometry(g, expire_config); });
 }
 
@@ -224,10 +228,6 @@ void expire_tiles_t::from_line_segment(geom::point_t const &a,
 int expire_tiles_t::from_bbox(geom::box_t const &box,
                               expire_config_t const &expire_config)
 {
-    if (!enabled()) {
-        return 0;
-    }
-
     double const width = box.width();
     double const height = box.height();
     if (width > tile_t::HALF_EARTH_CIRCUMFERENCE + 1) {

--- a/tests/bdd/flex/expire.feature
+++ b/tests/bdd/flex/expire.feature
@@ -1,4 +1,4 @@
-Feature: Changes on way with expire on zoom 0
+Feature: Changes on way with expire on zoom 1
 
     Background:
         Given the style file 'test_expire.lua'
@@ -71,7 +71,7 @@ Feature: Changes on way with expire on zoom 0
             | 11     |
         Then table osm2pgsql_test_expire contains exactly
             | zoom | x | y |
-            | 0    | 0 | 0 |
+            | 1    | 1 | 0 |
 
 
     Scenario: change in t1
@@ -88,7 +88,7 @@ Feature: Changes on way with expire on zoom 0
             | way_id |
         Then table osm2pgsql_test_expire contains exactly
             | zoom | x | y |
-            | 0    | 0 | 0 |
+            | 1    | 1 | 0 |
 
 
     Scenario: remove from t1
@@ -105,4 +105,4 @@ Feature: Changes on way with expire on zoom 0
             | way_id |
         Then table osm2pgsql_test_expire contains exactly
             | zoom | x | y |
-            | 0    | 0 | 0 |
+            | 1    | 1 | 0 |

--- a/tests/data/test_expire.lua
+++ b/tests/data/test_expire.lua
@@ -1,7 +1,7 @@
 
--- No maxzoom sets it to 0
 local eo = osm2pgsql.define_expire_output({
     table = 'osm2pgsql_test_expire',
+    maxzoom = 1,
 })
 
 local the_table = osm2pgsql.define_way_table('osm2pgsql_test_t1', {


### PR DESCRIPTION
maxzoom==0 is the default setting and it is documented to means that there is no expire. That's what the enabled() function checks.

But disabling this in from_bbox() only disabled the expire for that case, not for linestrings. Better to do this check in the function that's called from outside the expire code:  from_geometry().

We also need to fix some tests that were using maxzoom==0 by changing their setting to use maxzoom==1.