### PR TITLE
BDD tests: change handling of untagged nodes

### DIFF
--- a/tests/bdd/flex/expire.feature
+++ b/tests/bdd/flex/expire.feature
@@ -26,7 +26,6 @@ Feature: Changes on way with expire on zoom 0
             """
             w10 v1 dV Ta=b Nn10,n11
             """
-        And an empty grid
 
         When running osm2pgsql flex with parameters
             | --slim | -a |
@@ -43,7 +42,6 @@ Feature: Changes on way with expire on zoom 0
             """
             n1 v2 dV x1 y2
             """
-        And an empty grid
 
         When running osm2pgsql flex with parameters
             | --slim | -a |
@@ -60,7 +58,6 @@ Feature: Changes on way with expire on zoom 0
             """
             w10 v1 dV Tt1=yes Nn10,n11
             """
-        And an empty grid
 
         When running osm2pgsql flex with parameters
             | --slim | -a |
@@ -79,7 +76,6 @@ Feature: Changes on way with expire on zoom 0
             """
             w11 v2 dV Ta=b Nn10,n11
             """
-        And an empty grid
 
         When running osm2pgsql flex with parameters
             | --slim | -a |
@@ -96,7 +92,6 @@ Feature: Changes on way with expire on zoom 0
             """
             w11 v2 dD
             """
-        And an empty grid
 
         When running osm2pgsql flex with parameters
             | --slim | -a |

--- a/tests/bdd/flex/locator.feature
+++ b/tests/bdd/flex/locator.feature
@@ -199,8 +199,7 @@ Feature: Locators
             | way_id | region | ST_AsText(geom)         |
             | 20     | P1     | (10 0,20 10,10 10,10 0) |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             n10 v1 dV Tamenity=post_box x15.0 y8.0
             n11 v1 dV Tamenity=post_box x15.0 y2.0

--- a/tests/bdd/flex/node-add.feature
+++ b/tests/bdd/flex/node-add.feature
@@ -27,8 +27,7 @@ Feature: Adding nodes to a flex database
 
 
     Scenario: node is not relevant
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             n10 v1 dV Tt=ag x0 y0
             r30 v2 dV Tt=ag Mn10@,n11@,n12@mark,n13@,n14@mark
@@ -49,8 +48,7 @@ Feature: Adding nodes to a flex database
 
 
     Scenario: add to t1
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             n10 v1 dV Tt1=yes x0 y0
             r30 v2 dV Tt=ag Mn10@,n11@,n12@mark,n13@,n14@mark
@@ -72,8 +70,7 @@ Feature: Adding nodes to a flex database
 
 
     Scenario: add to t2
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             n10 v1 dV Tt2=yes x0 y0
             r30 v2 dV Tt=ag Mn10@mark,n11@,n12@mark,n13@,n14@mark
@@ -95,8 +92,7 @@ Feature: Adding nodes to a flex database
 
 
     Scenario: add to t1 and t2
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             n10 v1 dV Tt1=yes,t2=yes x0 y0
             r30 v2 dV Tt=ag Mn10@mark,n11@,n12@mark,n13@,n14@mark
@@ -119,8 +115,7 @@ Feature: Adding nodes to a flex database
 
 
     Scenario: add to tboth (only stage1)
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             n10 v1 dV Ttboth=yes x0 y0
             r30 v2 dV Tt=ag Mn10@,n11@,n12@mark,n13@,n14@mark
@@ -142,8 +137,7 @@ Feature: Adding nodes to a flex database
 
 
     Scenario: add to tboth (stage1 and stage2)
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             n10 v1 dV Ttboth=yes x0 y0
             r30 v2 dV Tt=ag Mn10@mark,n11@,n12@mark,n13@,n14@mark

--- a/tests/bdd/flex/relation-changes.feature
+++ b/tests/bdd/flex/relation-changes.feature
@@ -32,8 +32,7 @@ Feature: Handling changes to relations
             | --slim |
         Then table osm2pgsql_test_relations has 0 rows
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r30 v2 dV Ttype=multipolygon Mw20@,w21@
             """
@@ -56,8 +55,7 @@ Feature: Handling changes to relations
             | --slim |
         Then table osm2pgsql_test_relations has 0 rows
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w21 v2 dV Nn12,n13,n10
             """
@@ -79,8 +77,7 @@ Feature: Handling changes to relations
             | --slim |
         Then table osm2pgsql_test_relations has 0 rows
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             n12 v2 dV x10.1 y10.1
             """
@@ -103,8 +100,7 @@ Feature: Handling changes to relations
             | --slim |
         Then table osm2pgsql_test_relations has 0 rows
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r30 v2 dV Ttype=multipolygon Mw20@,w21@
             """
@@ -127,8 +123,7 @@ Feature: Handling changes to relations
             | --slim |
         Then table osm2pgsql_test_relations has 1 row
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r30 v2 dV Mw20@,w21@
             """
@@ -151,8 +146,7 @@ Feature: Handling changes to relations
             | --slim |
         Then table osm2pgsql_test_relations has 1 row
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w21 v2 dV <new nodelist>
             """
@@ -180,8 +174,7 @@ Feature: Handling changes to relations
             | --slim |
         Then table osm2pgsql_test_relations has 1 row
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             n12 v2 dV <new coordinates>
             """
@@ -209,8 +202,7 @@ Feature: Handling changes to relations
             | --slim |
         Then table osm2pgsql_test_relations has 1 row
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r30 v2 dV Ttype=multipolygon <new memberlist>
             """
@@ -240,8 +232,7 @@ Feature: Handling changes to relations
             | area_id | tags->'natural' | tags->'landuse' |
             | -30     | wood            | NULL            |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r30 v2 dV Ttype=multipolygon,landuse=forest Mw20@,w21@
             """

--- a/tests/bdd/flex/way-add.feature
+++ b/tests/bdd/flex/way-add.feature
@@ -31,8 +31,7 @@ Feature: Adding ways to a flex database
 
 
     Scenario: way is not relevant
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v1 dV Tt=ag Nn10,n11
             r30 v2 dV Tt=ag Mw10@,w11@,w12@mark,w13@,w14@mark
@@ -53,8 +52,7 @@ Feature: Adding ways to a flex database
 
 
     Scenario: add to t1
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v1 dV Tt1=yes Nn10,n11
             r30 v2 dV Tt=ag Mw10@,w11@,w12@mark,w13@,w14@mark
@@ -76,8 +74,7 @@ Feature: Adding ways to a flex database
 
 
     Scenario: add to t2
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v1 dV Tt2=yes Nn10,n11
             r30 v2 dV Tt=ag Mw10@mark,w11@,w12@mark,w13@,w14@mark
@@ -99,8 +96,7 @@ Feature: Adding ways to a flex database
 
 
     Scenario: add to t1 and t2
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v1 dV Tt1=yes,t2=yes Nn10,n11
             r30 v2 dV Tt=ag Mw10@mark,w11@,w12@mark,w13@,w14@mark
@@ -123,8 +119,7 @@ Feature: Adding ways to a flex database
 
 
     Scenario: add to tboth (only stage1)
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v1 dV Ttboth=yes Nn10,n11
             r30 v2 dV Tt=ag Mw10@,w11@,w12@mark,w13@,w14@mark
@@ -146,8 +141,7 @@ Feature: Adding ways to a flex database
 
 
     Scenario: add to tboth (stage1 and stage2)
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v1 dV Ttboth=yes Nn10,n11
             r30 v2 dV Tt=ag Mw10@mark,w11@,w12@mark,w13@,w14@mark

--- a/tests/bdd/flex/way-change.feature
+++ b/tests/bdd/flex/way-change.feature
@@ -31,8 +31,7 @@ Feature: Changing ways in a flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             <input>
             """
@@ -84,8 +83,7 @@ Feature: Changing ways in a flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             <input>
             """
@@ -138,8 +136,7 @@ Feature: Changing ways in a flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             <input>
             """
@@ -196,8 +193,7 @@ Feature: Changing ways in a flex database
             | 13     | NULL    |
             | 14     | {30}    |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             <input>
             """
@@ -243,8 +239,7 @@ Feature: Changing ways in a flex database
             | 13     | NULL    |
             | 14     | {30}    |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v2 dV Tt1=yes,t2=yes,tboth=yes Nn10,n11
             """

--- a/tests/bdd/flex/way-del.feature
+++ b/tests/bdd/flex/way-del.feature
@@ -31,8 +31,7 @@ Feature: Deleting ways in a 2-stage flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v2 dD
             """
@@ -74,8 +73,7 @@ Feature: Deleting ways in a 2-stage flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v2 dD
             """
@@ -117,8 +115,7 @@ Feature: Deleting ways in a 2-stage flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v2 dD
             """
@@ -159,8 +156,7 @@ Feature: Deleting ways in a 2-stage flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v2 dD
             """
@@ -202,8 +198,7 @@ Feature: Deleting ways in a 2-stage flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v2 dD
             """
@@ -245,8 +240,7 @@ Feature: Deleting ways in a 2-stage flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v2 dD
             """
@@ -289,8 +283,7 @@ Feature: Deleting ways in a 2-stage flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v2 dD
             """
@@ -332,8 +325,7 @@ Feature: Deleting ways in a 2-stage flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             w10 v2 dD
             """

--- a/tests/bdd/flex/way-relation-add.feature
+++ b/tests/bdd/flex/way-relation-add.feature
@@ -34,8 +34,7 @@ Feature: Adding relations to a 2-stage flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r32 v2 dV Tt=ag Mw10@mark,w11@,w12@,w13@,w14@,w15@
             """
@@ -86,8 +85,7 @@ Feature: Adding relations to a 2-stage flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r32 v2 dV Tt=ag Mw10@mark,w11@,w12@,w13@,w14@,w15@
             """
@@ -133,8 +131,7 @@ Feature: Adding relations to a 2-stage flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r32 v2 dV Tt=ag Mw10@mark,w11@,w12@,w13@,w14@,w15@
             """
@@ -180,8 +177,7 @@ Feature: Adding relations to a 2-stage flex database
             | 13     | NULL    |
             | 14     | {30}    |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r32 v2 dV Tt=ag Mw10@mark,w11@,w12@,w13@,w14@,w15@
             """
@@ -231,8 +227,7 @@ Feature: Adding relations to a 2-stage flex database
             | 13     | NULL    |
             | 14     | {30}    |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r32 v2 dV Tt=ag Mw10@mark,w11@,w12@,w13@,w14@,w15@
             """
@@ -277,8 +272,7 @@ Feature: Adding relations to a 2-stage flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r32 v2 dV Tt=ag Mw10@,w11@,w12@,w13@,w14@,w15@
             """
@@ -328,8 +322,7 @@ Feature: Adding relations to a 2-stage flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r32 v2 dV Tt=ag Mw10@mark,w11@,w12@,w13@,w14@,w15@
             """
@@ -375,8 +368,7 @@ Feature: Adding relations to a 2-stage flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r32 v2 dV Tt=ag Mw10@,w11@,w12@,w13@,w14@,w15@
             """
@@ -422,8 +414,7 @@ Feature: Adding relations to a 2-stage flex database
             | 13     | NULL    |
             | 14     | {30}    |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r32 v2 dV Tt=ag Mw10@,w11@,w12@,w13@,w14@,w15@
             """
@@ -468,8 +459,7 @@ Feature: Adding relations to a 2-stage flex database
             | 13     | NULL    |
             | 14     | {30}    |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r32 v2 dV Tt=ag Mw10@,w11@,w12@,w13@,w14@,w15@
             """

--- a/tests/bdd/flex/way-relation-del.feature
+++ b/tests/bdd/flex/way-relation-del.feature
@@ -33,8 +33,7 @@ Feature: Deleting relations in a stage-2 flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r32 v2 dD
             """
@@ -78,8 +77,7 @@ Feature: Deleting relations in a stage-2 flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             r32 v2 dD
             """
@@ -125,8 +123,7 @@ Feature: Deleting relations in a stage-2 flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             <input>
             """
@@ -176,8 +173,7 @@ Feature: Deleting relations in a stage-2 flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             <input>
             """
@@ -228,8 +224,7 @@ Feature: Deleting relations in a stage-2 flex database
             | 13     |
             | 14     |
 
-        Given an empty grid
-        And the OSM data
+        Given the OSM data
             """
             <input>
             """

--- a/tests/bdd/steps/steps_execute.py
+++ b/tests/bdd/steps/steps_execute.py
@@ -21,8 +21,6 @@ def get_import_file(context):
     if context.import_file is not None:
         return str(context.import_file), None
 
-    context.geometry_factory.complete_node_list(context.import_data['n'])
-
     # sort by OSM id
     for obj in context.import_data.values():
         obj.sort(key=lambda l: int(l.split(' ')[0][1:]))

--- a/tests/bdd/steps/steps_osm_data.py
+++ b/tests/bdd/steps/steps_osm_data.py
@@ -8,17 +8,26 @@
 Steps for creating the OSM import file.
 """
 
+def add_opl_lines(context, lines):
+    for line in lines:
+        if (oplobj := line.strip()):
+            assert oplobj[0] in ('n', 'w', 'r')
+            oplobj = context.geometry_factory.complete_opl(oplobj)
+            data = context.import_data[oplobj[0]]
+            objid = oplobj.split(' ', 1)[0] + ' '
+            for i, existing in enumerate(data):
+                if existing.startswith(objid):
+                    data[i] = oplobj
+                    break
+            else:
+                data.append(oplobj)
+
 
 @given("the input file '(?P<osm_file>.+)'")
 def osm_set_import_file(context, osm_file):
     """ Use an OSM file from the test directory for the import.
     """
     context.import_file = context.test_data_dir / osm_file
-
-
-@given("an empty grid")
-def osm_define_node_grid(context):
-    context.geometry_factory.remove_grid()
 
 
 @given("the (?P<step>[0-9.]+ )?grid(?: with origin (?P<origin_x>[0-9.-]+) (?P<origin_y>[0-9.-]+))?")
@@ -32,6 +41,7 @@ def osm_define_node_grid(context, step, origin_x, origin_y):
 
     context.geometry_factory.set_grid([context.table.headings] + [list(h) for h in context.table],
                                       step, x, y)
+    add_opl_lines(context, context.geometry_factory.as_opl_lines())
 
 
 @given("the (?P<formatted>python-formatted )?OSM data")
@@ -41,8 +51,4 @@ def osm_define_data(context, formatted):
     if formatted:
         data = eval('f"""' + data + '"""')
 
-    for line in data.split('\n'):
-        line = line.strip()
-        if line:
-            assert line[0] in ('n', 'w', 'r')
-            context.import_data[line[0]].append(line)
+    add_opl_lines(context, data.split('\n'))


### PR DESCRIPTION
The BDD tests have the hidden feature that they implicitly add any nodes defined in the grid to the import data. This leads to a bit off odd behaviour for tests that have an update phase: you have to unset the grid in order to avoid untagged nodes being added during update.

This PR changes the behaviour: nodes defined in the grid are now added to the import data only when the grid is defined, not when the final OPL is generated. So, nodes from the grid will still appear in the import data but only once.