### PR TITLE
BDD: remove "has rows with condition" steps

### DIFF
--- a/tests/bdd/flex/way-change.feature
+++ b/tests/bdd/flex/way-change.feature
@@ -40,10 +40,9 @@ Feature: Changing ways in a flex database
         Then table osm2pgsql_test_t1 contains
             | way_id |
             | 11     |
-        And table osm2pgsql_test_t1 has <num_w10> rows with condition
-            """
-            way_id = 10
-            """
+        And table osm2pgsql_test_t1 <exist_w10>
+            | way_id |
+            | 10     |
         Then table osm2pgsql_test_t2 contains exactly
             | way_id |
             | 10     |
@@ -54,9 +53,9 @@ Feature: Changing ways in a flex database
             | 14     |
 
         Examples:
-            | input                             | num_w10 |
-            | w10 v2 dV Tt2=yes Nn10,n11        | 0       |
-            | w10 v2 dV Tt1=yes,t2=yes Nn10,n11 | 1       |
+            | input                             | exist_w10       |
+            | w10 v2 dV Tt2=yes Nn10,n11        | doesn't contain |
+            | w10 v2 dV Tt1=yes,t2=yes Nn10,n11 | contains        |
 
 
     Scenario Outline: change way from t2
@@ -96,19 +95,18 @@ Feature: Changing ways in a flex database
         Then table osm2pgsql_test_t2 contains
             | way_id |
             | 12     |
-        And table osm2pgsql_test_t2 has <num_w10> rows with condition
-            """
-            way_id = 10
-            """
+        And table osm2pgsql_test_t2 <exist_w10>
+            | way_id |
+            | 10     |
         Then table osm2pgsql_test_tboth contains exactly
             | way_id |
             | 13     |
             | 14     |
 
         Examples:
-            | input                             | num_w10 |
-            | w10 v2 dV Tt1=yes Nn10,n11        | 0       |
-            | w10 v2 dV Tt1=yes,t2=yes Nn10,n11 | 1       |
+            | input                             | exist_w10       |
+            | w10 v2 dV Tt1=yes Nn10,n11        | doesn't contain |
+            | w10 v2 dV Tt1=yes,t2=yes Nn10,n11 | contains        |
 
 
     Scenario Outline: change way from t1 and t2
@@ -145,26 +143,24 @@ Feature: Changing ways in a flex database
         Then table osm2pgsql_test_t1 contains
             | way_id |
             | 11     |
-        And table osm2pgsql_test_t1 has <num_t1> rows with condition
-            """
-            way_id = 10
-            """
+        And table osm2pgsql_test_t1 <exist_t1>
+            | way_id |
+            | 10     |
         Then table osm2pgsql_test_t2 contains
             | way_id |
             | 12     |
-        And table osm2pgsql_test_t2 has <num_t2> rows with condition
-            """
-            way_id = 10
-            """
+        And table osm2pgsql_test_t2 <exist_t2>
+            | way_id |
+            | 10     |
         Then table osm2pgsql_test_tboth contains exactly
             | way_id |
             | 13     |
             | 14     |
 
         Examples:
-            | input                      | num_t1 | num_t2 |
-            | w10 v2 dV Tt1=yes Nn10,n11 | 1      | 0      |
-            | w10 v2 dV Tt2=yes Nn10,n11 | 0      | 1      |
+            | input                      | exist_t1        | exist_t2 |
+            | w10 v2 dV Tt1=yes Nn10,n11 | contains        | doesn't contain |
+            | w10 v2 dV Tt2=yes Nn10,n11 | doesn't contain | contains        |
 
 
     Scenario Outline: change valid geom to invalid geom

--- a/tests/bdd/regression/forward_dependencies.feature
+++ b/tests/bdd/regression/forward_dependencies.feature
@@ -29,16 +29,15 @@ Feature: Test forward propagation of changes
         When running osm2pgsql pgsql with parameters
             | --slim | -a | --latlong |
 
-        Then table planet_osm_point has 1 row
-        Then table planet_osm_line has 1 row
-        Then table planet_osm_line has 0 rows with condition
-            """
-            abs(ST_X(ST_StartPoint(way)) - 3.0) < 0.0001
-            """
-        Then table planet_osm_line has 1 row with condition
-            """
-            abs(ST_X(ST_StartPoint(way)) - 3.1) < 0.0001
-            """
-        Then table planet_osm_roads has 1 row
-        Then table planet_osm_polygon has 1 row
-
+        Then table planet_osm_point contains exactly
+            | osm_id |
+            | 12     |
+        Then table planet_osm_line contains exactly
+            | osm_id | round(ST_X(ST_StartPoint(way))::numeric, 1) |
+            | 21     | 3.1                                         |
+        Then table planet_osm_roads contains exactly
+            | osm_id |
+            | 21     |
+        Then table planet_osm_polygon contains exactly
+            | osm_id |
+            | 20     |

--- a/tests/bdd/regression/import.feature
+++ b/tests/bdd/regression/import.feature
@@ -162,32 +162,15 @@ Feature: Imports of the test database
             | -j |
             | -x |
 
-        Then table planet_osm_point has 1360 rows with condition
-            """
-            tags ? 'osm_user' AND
-            tags ? 'osm_version' AND
-            tags ? 'osm_uid' AND
-            tags ? 'osm_changeset'
-            """
-        And table planet_osm_line has 3254 rows with condition
-            """
-            tags ? 'osm_user' AND
-            tags ? 'osm_version' AND
-            tags ? 'osm_uid' AND
-            tags ? 'osm_changeset'
-            """
-        And table planet_osm_roads has 375 rows with condition
-            """
-            tags ? 'osm_user' AND
-            tags ? 'osm_version' AND
-            tags ? 'osm_uid' AND
-            tags ? 'osm_changeset'
-            """
-        And table planet_osm_polygon has 4131 rows with condition
-            """
-            tags ? 'osm_user' AND
-            tags ? 'osm_version' AND
-            tags ? 'osm_uid' AND
-            tags ? 'osm_changeset'
-            """
-
+        Then table planet_osm_point contains
+            | count(*) | every(tags ?& ARRAY['osm_user', 'osm_version', 'osm_uid', 'osm_changeset']) |
+            | 1360     | True |
+        Then table planet_osm_line contains
+            | count(*) | every(tags ?& ARRAY['osm_user', 'osm_version', 'osm_uid', 'osm_changeset']) |
+            | 3254     | True |
+        Then table planet_osm_roads contains
+            | count(*) | every(tags ?& ARRAY['osm_user', 'osm_version', 'osm_uid', 'osm_changeset']) |
+            | 375      | True |
+        Then table planet_osm_polygon contains
+            | count(*) | every(tags ?& ARRAY['osm_user', 'osm_version', 'osm_uid', 'osm_changeset']) |
+            | 4131     | True |

--- a/tests/bdd/regression/multipolygon.feature
+++ b/tests/bdd/regression/multipolygon.feature
@@ -54,15 +54,14 @@ Feature: Import and update of multipolygon areas
             | 138    | 1     |
             | 140    | 1     |
 
-        Then table planet_osm_polygon has 0 rows with condition
-            """
-            osm_id IN (109, 104)
-            """
+        Then table planet_osm_polygon doesn't contain
+            | osm_id |
+            | 109    |
+            | 104    |
 
-        Then table planet_osm_polygon has 0 rows with condition
-            """
-            osm_id = -33 and "natural" = 'water'
-            """
+        Then table planet_osm_polygon doesn't contain
+            | osm_id | "natural" |
+            | -33    | water     |
 
         Then SELECT osm_id, CASE WHEN '<param1>' = '-G' THEN min(ST_NumGeometries(way)) ELSE count(*) END FROM planet_osm_polygon GROUP BY osm_id
            | osm_id | count |
@@ -118,15 +117,15 @@ Feature: Import and update of multipolygon areas
             | 138    | 1     |
             | 140    | 1     |
 
-        Then table planet_osm_polygon has 0 rows with condition
-            """
-            osm_id IN (-25, 109, 104)
-            """
+        Then table planet_osm_polygon doesn't contain
+            | osm_id |
+            | -25    |
+            | 109    |
+            | 104    |
 
-        Then table planet_osm_polygon has 0 rows with condition
-            """
-            osm_id = -33 and "natural" = 'water'
-            """
+        Then table planet_osm_polygon doesn't contain
+            | osm_id | "natural" |
+            | -33    | water     |
 
         Examples:
             | param1 | lua         |


### PR DESCRIPTION
The special "table has N rows with condition" step would count rows with a given WHERE condition. Most of the uses where actual workarounds for a "table doesn't contain" expression. This PR adds the latter, so that the intention can be expressed more explicitly. This new step should be used sparingly because any typo in the expression will make the test happily pass.